### PR TITLE
Stable Codegen Ordering

### DIFF
--- a/src/SharpMetal.Generator/Instances/ClassInstance.cs
+++ b/src/SharpMetal.Generator/Instances/ClassInstance.cs
@@ -77,6 +77,9 @@ namespace SharpMetal.Generator.Instances
                 _selectorInstances.AddRange(parent.SelectorInstances);
             }
 
+            _propertyInstances.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.InvariantCultureIgnoreCase));
+            _methodInstances.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.InvariantCultureIgnoreCase));
+
             var objectiveCInstances = new List<ObjectiveCInstance>();
 
             context.WriteLine("[SupportedOSPlatform(\"macos\")]");
@@ -130,6 +133,8 @@ namespace SharpMetal.Generator.Instances
             }
 
             var selectorInstances = new List<SelectorInstance>(_selectorInstances);
+            // These have to be sorted after making the copy, otherwise it might resolve to wrong selector due to the Find-based mechanism when generating the calls
+            _selectorInstances.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.InvariantCultureIgnoreCase));
 
             for (var j = 0; j < _propertyInstances.Count; j++)
             {

--- a/src/SharpMetal.Generator/Program.cs
+++ b/src/SharpMetal.Generator/Program.cs
@@ -85,7 +85,11 @@ namespace SharpMetal.Generator
             context.WriteLine($"namespace SharpMetal.{fullNamespace}");
             context.EnterScope();
 
-            foreach (var instance in headerInfo.EnumInstances)
+            headerInfo.EnumInstances.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.InvariantCultureIgnoreCase));
+            headerInfo.StructInstances.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.InvariantCultureIgnoreCase));
+            headerInfo.ClassInstances.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.InvariantCultureIgnoreCase));
+
+            foreach (var instance in headerInfo.EnumInstances.OrderBy(x => x.Name))
             {
                 instance.Generate(context);
             }
@@ -205,7 +209,7 @@ namespace SharpMetal.Generator
             context.EnterScope();
 
             var list = objectiveCInstances.ToList();
-            list.Sort();
+            list.Sort(ObjectiveCEmitOrderComparer);
 
             for (var i = 0; i < list.Count; i++)
             {
@@ -218,6 +222,25 @@ namespace SharpMetal.Generator
 
             context.LeaveScope();
             context.LeaveScope();
+
+            static int ObjectiveCEmitOrderComparer(ObjectiveCInstance x, ObjectiveCInstance y)
+            {
+                int typeComparison = string.Compare(x.Type, y.Type, StringComparison.InvariantCultureIgnoreCase);
+                if (typeComparison != 0)
+                {
+                    return typeComparison;
+                }
+
+                int lengthComparison = x.Inputs.Count.CompareTo(y.Inputs.Count);
+                if (lengthComparison != 0)
+                {
+                    return lengthComparison;
+                }
+
+                string xInputs = string.Join(" ", x.Inputs);
+                string yInputs = string.Join(" ", y.Inputs);
+                return string.Compare(xInputs, yInputs, StringComparison.InvariantCultureIgnoreCase);
+            }
         }
     }
 }

--- a/src/SharpMetal/Foundation/NSArray.cs
+++ b/src/SharpMetal/Foundation/NSArray.cs
@@ -51,9 +51,9 @@ namespace SharpMetal.Foundation
         private static readonly Selector sel_array = "array";
         private static readonly Selector sel_arrayWithObject = "arrayWithObject:";
         private static readonly Selector sel_arrayWithObjectscount = "arrayWithObjects:count:";
-        private static readonly Selector sel_initWithObjectscount = "initWithObjects:count:";
-        private static readonly Selector sel_initWithCoder = "initWithCoder:";
         private static readonly Selector sel_count = "count";
+        private static readonly Selector sel_initWithCoder = "initWithCoder:";
+        private static readonly Selector sel_initWithObjectscount = "initWithObjects:count:";
         private static readonly Selector sel_objectAtIndex = "objectAtIndex:";
         private static readonly Selector sel_release = "release";
     }

--- a/src/SharpMetal/Foundation/NSAutoreleasePool.cs
+++ b/src/SharpMetal/Foundation/NSAutoreleasePool.cs
@@ -21,14 +21,14 @@ namespace SharpMetal.Foundation
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public void Drain()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drain);
-        }
-
         public void AddObject(NSObject pObject)
         {
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_addObject, pObject);
+        }
+
+        public void Drain()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drain);
         }
 
         public static void ShowPools()
@@ -36,8 +36,8 @@ namespace SharpMetal.Foundation
             throw new NotSupportedException();
         }
 
-        private static readonly Selector sel_drain = "drain";
         private static readonly Selector sel_addObject = "addObject:";
+        private static readonly Selector sel_drain = "drain";
         private static readonly Selector sel_showPools = "showPools";
         private static readonly Selector sel_release = "release";
     }

--- a/src/SharpMetal/Foundation/NSBundle.cs
+++ b/src/SharpMetal/Foundation/NSBundle.cs
@@ -25,52 +25,47 @@ namespace SharpMetal.Foundation
 
         public NSArray AllFrameworks => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_allFrameworks));
 
-        public bool Load => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_load);
-
-        public bool Unload => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_unload);
-
-        public bool IsLoaded => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isLoaded);
-
-        public NSURL BundleURL => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_bundleURL));
-
-        public NSURL ResourceURL => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_resourceURL));
-
-        public NSURL ExecutableURL => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_executableURL));
-
-        public NSURL PrivateFrameworksURL => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_privateFrameworksURL));
-
-        public NSURL SharedFrameworksURL => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_sharedFrameworksURL));
-
-        public NSURL SharedSupportURL => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_sharedSupportURL));
-
-        public NSURL BuiltInPlugInsURL => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_builtInPlugInsURL));
-
         public NSURL AppStoreReceiptURL => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_appStoreReceiptURL));
-
-        public NSString BundlePath => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_bundlePath));
-
-        public NSString ResourcePath => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_resourcePath));
-
-        public NSString ExecutablePath => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_executablePath));
-
-        public NSString PrivateFrameworksPath => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_privateFrameworksPath));
-
-        public NSString SharedFrameworksPath => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_sharedFrameworksPath));
-
-        public NSString SharedSupportPath => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_sharedSupportPath));
 
         public NSString BuiltInPlugInsPath => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_builtInPlugInsPath));
 
+        public NSURL BuiltInPlugInsURL => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_builtInPlugInsURL));
+
         public NSString BundleIdentifier => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_bundleIdentifier));
+
+        public NSString BundlePath => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_bundlePath));
+
+        public NSURL BundleURL => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_bundleURL));
+
+        public NSString ExecutablePath => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_executablePath));
+
+        public NSURL ExecutableURL => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_executableURL));
 
         public NSDictionary InfoDictionary => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_infoDictionary));
 
+        public bool IsLoaded => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isLoaded);
+
+        public bool Load => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_load);
+
         public NSDictionary LocalizedInfoDictionary => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_localizedInfoDictionary));
 
-        public static NSBundle MainBundle()
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(new ObjectiveCClass("NSBundle"), sel_mainBundle));
-        }
+        public NSString PrivateFrameworksPath => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_privateFrameworksPath));
+
+        public NSURL PrivateFrameworksURL => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_privateFrameworksURL));
+
+        public NSString ResourcePath => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_resourcePath));
+
+        public NSURL ResourceURL => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_resourceURL));
+
+        public NSString SharedFrameworksPath => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_sharedFrameworksPath));
+
+        public NSURL SharedFrameworksURL => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_sharedFrameworksURL));
+
+        public NSString SharedSupportPath => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_sharedSupportPath));
+
+        public NSURL SharedSupportURL => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_sharedSupportURL));
+
+        public bool Unload => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_unload);
 
         public static NSBundle Bundle(NSString pPath)
         {
@@ -92,24 +87,14 @@ namespace SharpMetal.Foundation
             return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithURL, pURL));
         }
 
-        public bool PreflightAndReturnError(ref NSError pError)
-        {
-            return ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_preflightAndReturnError, ref pError.NativePtr);
-        }
-
         public bool LoadAndReturnError(ref NSError pError)
         {
             return ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_loadAndReturnError, ref pError.NativePtr);
         }
 
-        public NSURL URLForAuxiliaryExecutable(NSString pExecutableName)
+        public static NSBundle MainBundle()
         {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_URLForAuxiliaryExecutable, pExecutableName));
-        }
-
-        public NSString PathForAuxiliaryExecutable(NSString pExecutableName)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_pathForAuxiliaryExecutable, pExecutableName));
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(new ObjectiveCClass("NSBundle"), sel_mainBundle));
         }
 
         public NSObject ObjectForInfoDictionaryKey(NSString pKey)
@@ -117,41 +102,56 @@ namespace SharpMetal.Foundation
             return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_objectForInfoDictionaryKey, pKey));
         }
 
-        private static readonly Selector sel_mainBundle = "mainBundle";
-        private static readonly Selector sel_bundleWithPath = "bundleWithPath:";
-        private static readonly Selector sel_bundleWithURL = "bundleWithURL:";
-        private static readonly Selector sel_alloc = "alloc";
-        private static readonly Selector sel_initWithPath = "initWithPath:";
-        private static readonly Selector sel_initWithURL = "initWithURL:";
+        public NSString PathForAuxiliaryExecutable(NSString pExecutableName)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_pathForAuxiliaryExecutable, pExecutableName));
+        }
+
+        public bool PreflightAndReturnError(ref NSError pError)
+        {
+            return ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_preflightAndReturnError, ref pError.NativePtr);
+        }
+
+        public NSURL URLForAuxiliaryExecutable(NSString pExecutableName)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_URLForAuxiliaryExecutable, pExecutableName));
+        }
+
         private static readonly Selector sel_allBundles = "allBundles";
         private static readonly Selector sel_allFrameworks = "allFrameworks";
-        private static readonly Selector sel_load = "load";
-        private static readonly Selector sel_unload = "unload";
-        private static readonly Selector sel_isLoaded = "isLoaded";
-        private static readonly Selector sel_preflightAndReturnError = "preflightAndReturnError:";
-        private static readonly Selector sel_loadAndReturnError = "loadAndReturnError:";
-        private static readonly Selector sel_bundleURL = "bundleURL";
-        private static readonly Selector sel_resourceURL = "resourceURL";
-        private static readonly Selector sel_executableURL = "executableURL";
-        private static readonly Selector sel_URLForAuxiliaryExecutable = "URLForAuxiliaryExecutable:";
-        private static readonly Selector sel_privateFrameworksURL = "privateFrameworksURL";
-        private static readonly Selector sel_sharedFrameworksURL = "sharedFrameworksURL";
-        private static readonly Selector sel_sharedSupportURL = "sharedSupportURL";
-        private static readonly Selector sel_builtInPlugInsURL = "builtInPlugInsURL";
+        private static readonly Selector sel_alloc = "alloc";
         private static readonly Selector sel_appStoreReceiptURL = "appStoreReceiptURL";
-        private static readonly Selector sel_bundlePath = "bundlePath";
-        private static readonly Selector sel_resourcePath = "resourcePath";
-        private static readonly Selector sel_executablePath = "executablePath";
-        private static readonly Selector sel_pathForAuxiliaryExecutable = "pathForAuxiliaryExecutable:";
-        private static readonly Selector sel_privateFrameworksPath = "privateFrameworksPath";
-        private static readonly Selector sel_sharedFrameworksPath = "sharedFrameworksPath";
-        private static readonly Selector sel_sharedSupportPath = "sharedSupportPath";
         private static readonly Selector sel_builtInPlugInsPath = "builtInPlugInsPath";
+        private static readonly Selector sel_builtInPlugInsURL = "builtInPlugInsURL";
         private static readonly Selector sel_bundleIdentifier = "bundleIdentifier";
+        private static readonly Selector sel_bundlePath = "bundlePath";
+        private static readonly Selector sel_bundleURL = "bundleURL";
+        private static readonly Selector sel_bundleWithPath = "bundleWithPath:";
+        private static readonly Selector sel_bundleWithURL = "bundleWithURL:";
+        private static readonly Selector sel_executablePath = "executablePath";
+        private static readonly Selector sel_executableURL = "executableURL";
         private static readonly Selector sel_infoDictionary = "infoDictionary";
+        private static readonly Selector sel_initWithPath = "initWithPath:";
+        private static readonly Selector sel_initWithURL = "initWithURL:";
+        private static readonly Selector sel_isLoaded = "isLoaded";
+        private static readonly Selector sel_load = "load";
+        private static readonly Selector sel_loadAndReturnError = "loadAndReturnError:";
         private static readonly Selector sel_localizedInfoDictionary = "localizedInfoDictionary";
-        private static readonly Selector sel_objectForInfoDictionaryKey = "objectForInfoDictionaryKey:";
         private static readonly Selector sel_localizedStringForKeyvaluetable = "localizedStringForKey:value:table:";
+        private static readonly Selector sel_mainBundle = "mainBundle";
+        private static readonly Selector sel_objectForInfoDictionaryKey = "objectForInfoDictionaryKey:";
+        private static readonly Selector sel_pathForAuxiliaryExecutable = "pathForAuxiliaryExecutable:";
+        private static readonly Selector sel_preflightAndReturnError = "preflightAndReturnError:";
+        private static readonly Selector sel_privateFrameworksPath = "privateFrameworksPath";
+        private static readonly Selector sel_privateFrameworksURL = "privateFrameworksURL";
+        private static readonly Selector sel_resourcePath = "resourcePath";
+        private static readonly Selector sel_resourceURL = "resourceURL";
+        private static readonly Selector sel_sharedFrameworksPath = "sharedFrameworksPath";
+        private static readonly Selector sel_sharedFrameworksURL = "sharedFrameworksURL";
+        private static readonly Selector sel_sharedSupportPath = "sharedSupportPath";
+        private static readonly Selector sel_sharedSupportURL = "sharedSupportURL";
+        private static readonly Selector sel_unload = "unload";
+        private static readonly Selector sel_URLForAuxiliaryExecutable = "URLForAuxiliaryExecutable:";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Foundation/NSData.cs
+++ b/src/SharpMetal/Foundation/NSData.cs
@@ -15,12 +15,12 @@ namespace SharpMetal.Foundation
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public IntPtr MutableBytes => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_mutableBytes));
-
         public ulong Length => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_length);
 
-        private static readonly Selector sel_mutableBytes = "mutableBytes";
+        public IntPtr MutableBytes => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_mutableBytes));
+
         private static readonly Selector sel_length = "length";
+        private static readonly Selector sel_mutableBytes = "mutableBytes";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Foundation/NSDictionary.cs
+++ b/src/SharpMetal/Foundation/NSDictionary.cs
@@ -21,9 +21,9 @@ namespace SharpMetal.Foundation
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public NSEnumerator KeyEnumerator => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_keyEnumerator));
-
         public ulong Count => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_count);
+
+        public NSEnumerator KeyEnumerator => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_keyEnumerator));
 
         public static NSDictionary Dictionary(NSObject pObject, NSObject pKey)
         {
@@ -50,14 +50,14 @@ namespace SharpMetal.Foundation
             return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_objectForKey, pKey));
         }
 
+        private static readonly Selector sel_count = "count";
         private static readonly Selector sel_dictionary = "dictionary";
         private static readonly Selector sel_dictionaryWithObjectforKey = "dictionaryWithObject:forKey:";
         private static readonly Selector sel_dictionaryWithObjectsforKeyscount = "dictionaryWithObjects:forKeys:count:";
-        private static readonly Selector sel_initWithObjectsforKeyscount = "initWithObjects:forKeys:count:";
         private static readonly Selector sel_initWithCoder = "initWithCoder:";
+        private static readonly Selector sel_initWithObjectsforKeyscount = "initWithObjects:forKeys:count:";
         private static readonly Selector sel_keyEnumerator = "keyEnumerator";
         private static readonly Selector sel_objectForKey = "objectForKey:";
-        private static readonly Selector sel_count = "count";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Foundation/NSEnumerator.cs
+++ b/src/SharpMetal/Foundation/NSEnumerator.cs
@@ -12,27 +12,6 @@ namespace SharpMetal.Foundation
     }
 
     [SupportedOSPlatform("macos")]
-    public struct NSFastEnumeration : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(NSFastEnumeration obj) => obj.NativePtr;
-        public NSFastEnumeration(IntPtr ptr) => NativePtr = ptr;
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public ulong CountByEnumerating(NSFastEnumerationState pState, NSObject pBuffer, ulong len)
-        {
-            return ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_countByEnumeratingWithStateobjectscount, pState, pBuffer, len);
-        }
-
-        private static readonly Selector sel_countByEnumeratingWithStateobjectscount = "countByEnumeratingWithState:objects:count:";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
     public struct NSEnumerator : IDisposable
     {
         public IntPtr NativePtr;
@@ -46,6 +25,27 @@ namespace SharpMetal.Foundation
         }
 
 
+
+        public ulong CountByEnumerating(NSFastEnumerationState pState, NSObject pBuffer, ulong len)
+        {
+            return ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_countByEnumeratingWithStateobjectscount, pState, pBuffer, len);
+        }
+
+        private static readonly Selector sel_countByEnumeratingWithStateobjectscount = "countByEnumeratingWithState:objects:count:";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
+    public struct NSFastEnumeration : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(NSFastEnumeration obj) => obj.NativePtr;
+        public NSFastEnumeration(IntPtr ptr) => NativePtr = ptr;
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
 
         public ulong CountByEnumerating(NSFastEnumerationState pState, NSObject pBuffer, ulong len)
         {

--- a/src/SharpMetal/Foundation/NSError.cs
+++ b/src/SharpMetal/Foundation/NSError.cs
@@ -25,15 +25,15 @@ namespace SharpMetal.Foundation
 
         public IntPtr Domain => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_domain));
 
-        public NSDictionary UserInfo => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_userInfo));
-
         public NSString LocalizedDescription => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_localizedDescription));
+
+        public NSString LocalizedFailureReason => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_localizedFailureReason));
 
         public NSArray LocalizedRecoveryOptions => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_localizedRecoveryOptions));
 
         public NSString LocalizedRecoverySuggestion => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_localizedRecoverySuggestion));
 
-        public NSString LocalizedFailureReason => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_localizedFailureReason));
+        public NSDictionary UserInfo => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_userInfo));
 
         public static NSError Error(IntPtr domain, long code, NSDictionary pDictionary)
         {
@@ -45,15 +45,15 @@ namespace SharpMetal.Foundation
             return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithDomaincodeuserInfo, domain, code, pDictionary));
         }
 
-        private static readonly Selector sel_errorWithDomaincodeuserInfo = "errorWithDomain:code:userInfo:";
-        private static readonly Selector sel_initWithDomaincodeuserInfo = "initWithDomain:code:userInfo:";
         private static readonly Selector sel_code = "code";
         private static readonly Selector sel_domain = "domain";
-        private static readonly Selector sel_userInfo = "userInfo";
+        private static readonly Selector sel_errorWithDomaincodeuserInfo = "errorWithDomain:code:userInfo:";
+        private static readonly Selector sel_initWithDomaincodeuserInfo = "initWithDomain:code:userInfo:";
         private static readonly Selector sel_localizedDescription = "localizedDescription";
+        private static readonly Selector sel_localizedFailureReason = "localizedFailureReason";
         private static readonly Selector sel_localizedRecoveryOptions = "localizedRecoveryOptions";
         private static readonly Selector sel_localizedRecoverySuggestion = "localizedRecoverySuggestion";
-        private static readonly Selector sel_localizedFailureReason = "localizedFailureReason";
+        private static readonly Selector sel_userInfo = "userInfo";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Foundation/NSLock.cs
+++ b/src/SharpMetal/Foundation/NSLock.cs
@@ -4,20 +4,6 @@ using SharpMetal.ObjectiveCCore;
 namespace SharpMetal.Foundation
 {
     [SupportedOSPlatform("macos")]
-    public struct NSLocking : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(NSLocking obj) => obj.NativePtr;
-        public NSLocking(IntPtr ptr) => NativePtr = ptr;
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
     public struct NSCondition : IDisposable
     {
         public IntPtr NativePtr;
@@ -35,6 +21,16 @@ namespace SharpMetal.Foundation
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
+        public void Broadcast()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_broadcast);
+        }
+
+        public void Signal()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_signal);
+        }
+
         public void Wait()
         {
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_wait);
@@ -45,20 +41,24 @@ namespace SharpMetal.Foundation
             return ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_waitUntilDate, pLimit);
         }
 
-        public void Signal()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_signal);
-        }
-
-        public void Broadcast()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_broadcast);
-        }
-
+        private static readonly Selector sel_broadcast = "broadcast";
+        private static readonly Selector sel_signal = "signal";
         private static readonly Selector sel_wait = "wait";
         private static readonly Selector sel_waitUntilDate = "waitUntilDate:";
-        private static readonly Selector sel_signal = "signal";
-        private static readonly Selector sel_broadcast = "broadcast";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
+    public struct NSLocking : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(NSLocking obj) => obj.NativePtr;
+        public NSLocking(IntPtr ptr) => NativePtr = ptr;
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Foundation/NSNumber.cs
+++ b/src/SharpMetal/Foundation/NSNumber.cs
@@ -4,6 +4,225 @@ using SharpMetal.ObjectiveCCore;
 namespace SharpMetal.Foundation
 {
     [SupportedOSPlatform("macos")]
+    public struct NSNumber : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(NSNumber obj) => obj.NativePtr;
+        public NSNumber(IntPtr ptr) => NativePtr = ptr;
+
+        public NSNumber()
+        {
+            var cls = new ObjectiveCClass("NSNumber");
+            NativePtr = cls.Alloc();
+        }
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public bool BoolValue => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_boolValue);
+
+        public ushort CharValue => ObjectiveCRuntime.ushort_objc_msgSend(NativePtr, sel_charValue);
+
+        public double DoubleValue => ObjectiveCRuntime.double_objc_msgSend(NativePtr, sel_doubleValue);
+
+        public float FloatValue => ObjectiveCRuntime.float_objc_msgSend(NativePtr, sel_floatValue);
+
+        public long IntegerValue => ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_integerValue);
+
+        public int IntValue => ObjectiveCRuntime.int_objc_msgSend(NativePtr, sel_intValue);
+
+        public long LongLongValue => ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_longLongValue);
+
+        public long LongValue => ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_longValue);
+
+        public short ShortValue => ObjectiveCRuntime.short_objc_msgSend(NativePtr, sel_shortValue);
+
+        public NSString StringValue => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_stringValue));
+
+        public byte UnsignedCharValue => ObjectiveCRuntime.byte_objc_msgSend(NativePtr, sel_unsignedCharValue);
+
+        public ulong UnsignedIntegerValue => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_unsignedIntegerValue);
+
+        public uint UnsignedIntValue => ObjectiveCRuntime.uint_objc_msgSend(NativePtr, sel_unsignedIntValue);
+
+        public ulong UnsignedLongLongValue => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_unsignedLongLongValue);
+
+        public ulong UnsignedLongValue => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_unsignedLongValue);
+
+        public ushort UnsignedShortValue => ObjectiveCRuntime.ushort_objc_msgSend(NativePtr, sel_unsignedShortValue);
+
+        public NSComparisonResult Compare(NSNumber pOtherNumber)
+        {
+            return (NSComparisonResult)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_compare, pOtherNumber);
+        }
+
+        public NSString DescriptionWithLocale(NSObject pLocale)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_descriptionWithLocale, pLocale));
+        }
+
+        public NSNumber Init(bool value)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithBool, value));
+        }
+
+        public NSNumber Init(double value)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithDouble, value));
+        }
+
+        public NSNumber Init(float value)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithFloat, value));
+        }
+
+        public NSNumber Init(ulong value)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithUnsignedLong, value));
+        }
+
+        public NSNumber Init(long value)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithLong, value));
+        }
+
+        public NSNumber Init(uint value)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithUnsignedInt, value));
+        }
+
+        public NSNumber Init(int value)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithInt, value));
+        }
+
+        public NSNumber Init(short value)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithShort, value));
+        }
+
+        public NSNumber Init(byte value)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithUnsignedChar, value));
+        }
+
+        public NSNumber Init(ushort value)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithChar, value));
+        }
+
+        public NSNumber Init(IntPtr pCoder)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithCoder, pCoder));
+        }
+
+        public bool IsEqualToNumber(NSNumber pNumber)
+        {
+            return ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isEqualToNumber, pNumber);
+        }
+
+        public static NSNumber Number(bool value)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(new ObjectiveCClass("NSNumber"), sel_numberWithBool, value));
+        }
+
+        public static NSNumber Number(double value)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(new ObjectiveCClass("NSNumber"), sel_numberWithDouble, value));
+        }
+
+        public static NSNumber Number(float value)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(new ObjectiveCClass("NSNumber"), sel_numberWithFloat, value));
+        }
+
+        public static NSNumber Number(ulong value)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(new ObjectiveCClass("NSNumber"), sel_numberWithUnsignedLong, value));
+        }
+
+        public static NSNumber Number(long value)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(new ObjectiveCClass("NSNumber"), sel_numberWithLong, value));
+        }
+
+        public static NSNumber Number(uint value)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(new ObjectiveCClass("NSNumber"), sel_numberWithUnsignedInt, value));
+        }
+
+        public static NSNumber Number(int value)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(new ObjectiveCClass("NSNumber"), sel_numberWithInt, value));
+        }
+
+        public static NSNumber Number(short value)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(new ObjectiveCClass("NSNumber"), sel_numberWithShort, value));
+        }
+
+        public static NSNumber Number(byte value)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(new ObjectiveCClass("NSNumber"), sel_numberWithUnsignedChar, value));
+        }
+
+        public static NSNumber Number(ushort value)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(new ObjectiveCClass("NSNumber"), sel_numberWithChar, value));
+        }
+
+        private static readonly Selector sel_boolValue = "boolValue";
+        private static readonly Selector sel_charValue = "charValue";
+        private static readonly Selector sel_compare = "compare:";
+        private static readonly Selector sel_descriptionWithLocale = "descriptionWithLocale:";
+        private static readonly Selector sel_doubleValue = "doubleValue";
+        private static readonly Selector sel_floatValue = "floatValue";
+        private static readonly Selector sel_initWithBool = "initWithBool:";
+        private static readonly Selector sel_initWithChar = "initWithChar:";
+        private static readonly Selector sel_initWithCoder = "initWithCoder:";
+        private static readonly Selector sel_initWithDouble = "initWithDouble:";
+        private static readonly Selector sel_initWithFloat = "initWithFloat:";
+        private static readonly Selector sel_initWithInt = "initWithInt:";
+        private static readonly Selector sel_initWithLong = "initWithLong:";
+        private static readonly Selector sel_initWithLongLong = "initWithLongLong:";
+        private static readonly Selector sel_initWithShort = "initWithShort:";
+        private static readonly Selector sel_initWithUnsignedChar = "initWithUnsignedChar:";
+        private static readonly Selector sel_initWithUnsignedInt = "initWithUnsignedInt:";
+        private static readonly Selector sel_initWithUnsignedLong = "initWithUnsignedLong:";
+        private static readonly Selector sel_initWithUnsignedLongLong = "initWithUnsignedLongLong:";
+        private static readonly Selector sel_initWithUnsignedShort = "initWithUnsignedShort:";
+        private static readonly Selector sel_integerValue = "integerValue";
+        private static readonly Selector sel_intValue = "intValue";
+        private static readonly Selector sel_isEqualToNumber = "isEqualToNumber:";
+        private static readonly Selector sel_longLongValue = "longLongValue";
+        private static readonly Selector sel_longValue = "longValue";
+        private static readonly Selector sel_numberWithBool = "numberWithBool:";
+        private static readonly Selector sel_numberWithChar = "numberWithChar:";
+        private static readonly Selector sel_numberWithDouble = "numberWithDouble:";
+        private static readonly Selector sel_numberWithFloat = "numberWithFloat:";
+        private static readonly Selector sel_numberWithInt = "numberWithInt:";
+        private static readonly Selector sel_numberWithLong = "numberWithLong:";
+        private static readonly Selector sel_numberWithLongLong = "numberWithLongLong:";
+        private static readonly Selector sel_numberWithShort = "numberWithShort:";
+        private static readonly Selector sel_numberWithUnsignedChar = "numberWithUnsignedChar:";
+        private static readonly Selector sel_numberWithUnsignedInt = "numberWithUnsignedInt:";
+        private static readonly Selector sel_numberWithUnsignedLong = "numberWithUnsignedLong:";
+        private static readonly Selector sel_numberWithUnsignedLongLong = "numberWithUnsignedLongLong:";
+        private static readonly Selector sel_numberWithUnsignedShort = "numberWithUnsignedShort:";
+        private static readonly Selector sel_shortValue = "shortValue";
+        private static readonly Selector sel_stringValue = "stringValue";
+        private static readonly Selector sel_unsignedCharValue = "unsignedCharValue";
+        private static readonly Selector sel_unsignedIntegerValue = "unsignedIntegerValue";
+        private static readonly Selector sel_unsignedIntValue = "unsignedIntValue";
+        private static readonly Selector sel_unsignedLongLongValue = "unsignedLongLongValue";
+        private static readonly Selector sel_unsignedLongValue = "unsignedLongValue";
+        private static readonly Selector sel_unsignedShortValue = "unsignedShortValue";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
     public struct NSValue : IDisposable
     {
         public IntPtr NativePtr;
@@ -25,14 +244,9 @@ namespace SharpMetal.Foundation
 
         public IntPtr PointerValue => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_pointerValue));
 
-        public static NSValue Value(IntPtr pValue, ushort pType)
+        public void GetValue(IntPtr pValue, ulong size)
         {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(new ObjectiveCClass("NSValue"), sel_valueWithBytesobjCType, pValue, pType));
-        }
-
-        public static NSValue Value(IntPtr pPointer)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(new ObjectiveCClass("NSValue"), sel_valueWithPointer, pPointer));
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_getValuesize, pValue, size);
         }
 
         public NSValue Init(IntPtr pValue, ushort pType)
@@ -45,243 +259,29 @@ namespace SharpMetal.Foundation
             return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithCoder, pCoder));
         }
 
-        public void GetValue(IntPtr pValue, ulong size)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_getValuesize, pValue, size);
-        }
-
         public bool IsEqualToValue(NSValue pValue)
         {
             return ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isEqualToValue, pValue);
         }
 
-        private static readonly Selector sel_valueWithBytesobjCType = "valueWithBytes:objCType:";
-        private static readonly Selector sel_valueWithPointer = "valueWithPointer:";
+        public static NSValue Value(IntPtr pValue, ushort pType)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(new ObjectiveCClass("NSValue"), sel_valueWithBytesobjCType, pValue, pType));
+        }
+
+        public static NSValue Value(IntPtr pPointer)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(new ObjectiveCClass("NSValue"), sel_valueWithPointer, pPointer));
+        }
+
+        private static readonly Selector sel_getValuesize = "getValue:size:";
         private static readonly Selector sel_initWithBytesobjCType = "initWithBytes:objCType:";
         private static readonly Selector sel_initWithCoder = "initWithCoder:";
-        private static readonly Selector sel_getValuesize = "getValue:size:";
-        private static readonly Selector sel_objCType = "objCType";
         private static readonly Selector sel_isEqualToValue = "isEqualToValue:";
+        private static readonly Selector sel_objCType = "objCType";
         private static readonly Selector sel_pointerValue = "pointerValue";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct NSNumber : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(NSNumber obj) => obj.NativePtr;
-        public NSNumber(IntPtr ptr) => NativePtr = ptr;
-
-        public NSNumber()
-        {
-            var cls = new ObjectiveCClass("NSNumber");
-            NativePtr = cls.Alloc();
-        }
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public ushort CharValue => ObjectiveCRuntime.ushort_objc_msgSend(NativePtr, sel_charValue);
-
-        public byte UnsignedCharValue => ObjectiveCRuntime.byte_objc_msgSend(NativePtr, sel_unsignedCharValue);
-
-        public short ShortValue => ObjectiveCRuntime.short_objc_msgSend(NativePtr, sel_shortValue);
-
-        public ushort UnsignedShortValue => ObjectiveCRuntime.ushort_objc_msgSend(NativePtr, sel_unsignedShortValue);
-
-        public int IntValue => ObjectiveCRuntime.int_objc_msgSend(NativePtr, sel_intValue);
-
-        public uint UnsignedIntValue => ObjectiveCRuntime.uint_objc_msgSend(NativePtr, sel_unsignedIntValue);
-
-        public long LongValue => ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_longValue);
-
-        public ulong UnsignedLongValue => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_unsignedLongValue);
-
-        public long LongLongValue => ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_longLongValue);
-
-        public ulong UnsignedLongLongValue => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_unsignedLongLongValue);
-
-        public float FloatValue => ObjectiveCRuntime.float_objc_msgSend(NativePtr, sel_floatValue);
-
-        public double DoubleValue => ObjectiveCRuntime.double_objc_msgSend(NativePtr, sel_doubleValue);
-
-        public bool BoolValue => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_boolValue);
-
-        public long IntegerValue => ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_integerValue);
-
-        public ulong UnsignedIntegerValue => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_unsignedIntegerValue);
-
-        public NSString StringValue => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_stringValue));
-
-        public static NSNumber Number(ushort value)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(new ObjectiveCClass("NSNumber"), sel_numberWithChar, value));
-        }
-
-        public static NSNumber Number(byte value)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(new ObjectiveCClass("NSNumber"), sel_numberWithUnsignedChar, value));
-        }
-
-        public static NSNumber Number(short value)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(new ObjectiveCClass("NSNumber"), sel_numberWithShort, value));
-        }
-
-        public static NSNumber Number(int value)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(new ObjectiveCClass("NSNumber"), sel_numberWithInt, value));
-        }
-
-        public static NSNumber Number(uint value)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(new ObjectiveCClass("NSNumber"), sel_numberWithUnsignedInt, value));
-        }
-
-        public static NSNumber Number(long value)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(new ObjectiveCClass("NSNumber"), sel_numberWithLong, value));
-        }
-
-        public static NSNumber Number(ulong value)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(new ObjectiveCClass("NSNumber"), sel_numberWithUnsignedLong, value));
-        }
-
-        public static NSNumber Number(float value)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(new ObjectiveCClass("NSNumber"), sel_numberWithFloat, value));
-        }
-
-        public static NSNumber Number(double value)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(new ObjectiveCClass("NSNumber"), sel_numberWithDouble, value));
-        }
-
-        public static NSNumber Number(bool value)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(new ObjectiveCClass("NSNumber"), sel_numberWithBool, value));
-        }
-
-        public NSNumber Init(IntPtr pCoder)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithCoder, pCoder));
-        }
-
-        public NSNumber Init(ushort value)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithChar, value));
-        }
-
-        public NSNumber Init(byte value)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithUnsignedChar, value));
-        }
-
-        public NSNumber Init(short value)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithShort, value));
-        }
-
-        public NSNumber Init(int value)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithInt, value));
-        }
-
-        public NSNumber Init(uint value)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithUnsignedInt, value));
-        }
-
-        public NSNumber Init(long value)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithLong, value));
-        }
-
-        public NSNumber Init(ulong value)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithUnsignedLong, value));
-        }
-
-        public NSNumber Init(float value)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithFloat, value));
-        }
-
-        public NSNumber Init(double value)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithDouble, value));
-        }
-
-        public NSNumber Init(bool value)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithBool, value));
-        }
-
-        public NSComparisonResult Compare(NSNumber pOtherNumber)
-        {
-            return (NSComparisonResult)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_compare, pOtherNumber);
-        }
-
-        public bool IsEqualToNumber(NSNumber pNumber)
-        {
-            return ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isEqualToNumber, pNumber);
-        }
-
-        public NSString DescriptionWithLocale(NSObject pLocale)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_descriptionWithLocale, pLocale));
-        }
-
-        private static readonly Selector sel_numberWithChar = "numberWithChar:";
-        private static readonly Selector sel_numberWithUnsignedChar = "numberWithUnsignedChar:";
-        private static readonly Selector sel_numberWithShort = "numberWithShort:";
-        private static readonly Selector sel_numberWithUnsignedShort = "numberWithUnsignedShort:";
-        private static readonly Selector sel_numberWithInt = "numberWithInt:";
-        private static readonly Selector sel_numberWithUnsignedInt = "numberWithUnsignedInt:";
-        private static readonly Selector sel_numberWithLong = "numberWithLong:";
-        private static readonly Selector sel_numberWithUnsignedLong = "numberWithUnsignedLong:";
-        private static readonly Selector sel_numberWithLongLong = "numberWithLongLong:";
-        private static readonly Selector sel_numberWithUnsignedLongLong = "numberWithUnsignedLongLong:";
-        private static readonly Selector sel_numberWithFloat = "numberWithFloat:";
-        private static readonly Selector sel_numberWithDouble = "numberWithDouble:";
-        private static readonly Selector sel_numberWithBool = "numberWithBool:";
-        private static readonly Selector sel_initWithCoder = "initWithCoder:";
-        private static readonly Selector sel_initWithChar = "initWithChar:";
-        private static readonly Selector sel_initWithUnsignedChar = "initWithUnsignedChar:";
-        private static readonly Selector sel_initWithShort = "initWithShort:";
-        private static readonly Selector sel_initWithUnsignedShort = "initWithUnsignedShort:";
-        private static readonly Selector sel_initWithInt = "initWithInt:";
-        private static readonly Selector sel_initWithUnsignedInt = "initWithUnsignedInt:";
-        private static readonly Selector sel_initWithLong = "initWithLong:";
-        private static readonly Selector sel_initWithUnsignedLong = "initWithUnsignedLong:";
-        private static readonly Selector sel_initWithLongLong = "initWithLongLong:";
-        private static readonly Selector sel_initWithUnsignedLongLong = "initWithUnsignedLongLong:";
-        private static readonly Selector sel_initWithFloat = "initWithFloat:";
-        private static readonly Selector sel_initWithDouble = "initWithDouble:";
-        private static readonly Selector sel_initWithBool = "initWithBool:";
-        private static readonly Selector sel_charValue = "charValue";
-        private static readonly Selector sel_unsignedCharValue = "unsignedCharValue";
-        private static readonly Selector sel_shortValue = "shortValue";
-        private static readonly Selector sel_unsignedShortValue = "unsignedShortValue";
-        private static readonly Selector sel_intValue = "intValue";
-        private static readonly Selector sel_unsignedIntValue = "unsignedIntValue";
-        private static readonly Selector sel_longValue = "longValue";
-        private static readonly Selector sel_unsignedLongValue = "unsignedLongValue";
-        private static readonly Selector sel_longLongValue = "longLongValue";
-        private static readonly Selector sel_unsignedLongLongValue = "unsignedLongLongValue";
-        private static readonly Selector sel_floatValue = "floatValue";
-        private static readonly Selector sel_doubleValue = "doubleValue";
-        private static readonly Selector sel_boolValue = "boolValue";
-        private static readonly Selector sel_integerValue = "integerValue";
-        private static readonly Selector sel_unsignedIntegerValue = "unsignedIntegerValue";
-        private static readonly Selector sel_stringValue = "stringValue";
-        private static readonly Selector sel_compare = "compare:";
-        private static readonly Selector sel_isEqualToNumber = "isEqualToNumber:";
-        private static readonly Selector sel_descriptionWithLocale = "descriptionWithLocale:";
+        private static readonly Selector sel_valueWithBytesobjCType = "valueWithBytes:objCType:";
+        private static readonly Selector sel_valueWithPointer = "valueWithPointer:";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Foundation/NSObject.cs
+++ b/src/SharpMetal/Foundation/NSObject.cs
@@ -4,8 +4,6 @@ using SharpMetal.ObjectiveCCore;
 namespace SharpMetal.Foundation
 {
     [SupportedOSPlatform("macos")]
-
-    [SupportedOSPlatform("macos")]
     public struct NSCopying : IDisposable
     {
         public IntPtr NativePtr;
@@ -21,20 +19,6 @@ namespace SharpMetal.Foundation
     }
 
     [SupportedOSPlatform("macos")]
-    public struct NSSecureCoding : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(NSSecureCoding obj) => obj.NativePtr;
-        public NSSecureCoding(IntPtr ptr) => NativePtr = ptr;
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
     public struct NSObject : IDisposable
     {
         public IntPtr NativePtr;
@@ -46,25 +30,39 @@ namespace SharpMetal.Foundation
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public ulong Hash => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_hash);
+        public NSString DebugDescription => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_debugDescription));
 
         public NSString Description => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_description));
 
-        public NSString DebugDescription => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_debugDescription));
+        public ulong Hash => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_hash);
 
         public bool IsEqual(NSObject pObject)
         {
             return ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isEqual, pObject);
         }
 
+        private static readonly Selector sel_alloc = "alloc";
+        private static readonly Selector sel_debugDescription = "debugDescription";
+        private static readonly Selector sel_description = "description";
+        private static readonly Selector sel_hash = "hash";
+        private static readonly Selector sel_init = "init";
+        private static readonly Selector sel_isEqual = "isEqual:";
         private static readonly Selector sel_methodSignatureForSelector = "methodSignatureForSelector:";
         private static readonly Selector sel_respondsToSelector = "respondsToSelector:";
-        private static readonly Selector sel_alloc = "alloc";
-        private static readonly Selector sel_init = "init";
-        private static readonly Selector sel_hash = "hash";
-        private static readonly Selector sel_isEqual = "isEqual:";
-        private static readonly Selector sel_description = "description";
-        private static readonly Selector sel_debugDescription = "debugDescription";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
+    public struct NSSecureCoding : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(NSSecureCoding obj) => obj.NativePtr;
+        public NSSecureCoding(IntPtr ptr) => NativePtr = ptr;
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Foundation/NSProcessInfo.cs
+++ b/src/SharpMetal/Foundation/NSProcessInfo.cs
@@ -4,15 +4,6 @@ using SharpMetal.ObjectiveCCore;
 namespace SharpMetal.Foundation
 {
     [SupportedOSPlatform("macos")]
-    public enum NSProcessInfoThermalState : long
-    {
-        Nominal = 0,
-        Fair = 1,
-        Serious = 2,
-        Critical = 3,
-    }
-
-    [SupportedOSPlatform("macos")]
     [Flags]
     public enum NSActivityOptions : ulong
     {
@@ -27,6 +18,15 @@ namespace SharpMetal.Foundation
     }
 
     [SupportedOSPlatform("macos")]
+    public enum NSProcessInfoThermalState : long
+    {
+        Nominal = 0,
+        Fair = 1,
+        Serious = 2,
+        Critical = 3,
+    }
+
+    [SupportedOSPlatform("macos")]
     public struct NSProcessInfo : IDisposable
     {
         public IntPtr NativePtr;
@@ -38,39 +38,9 @@ namespace SharpMetal.Foundation
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public NSArray Arguments => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_arguments));
-
-        public NSDictionary Environment => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_environment));
-
-        public NSString HostName => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_hostName));
-
-        public NSString ProcessName
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_processName));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setProcessName, value);
-        }
-
-        public int ProcessIdentifier => ObjectiveCRuntime.int_objc_msgSend(NativePtr, sel_processIdentifier);
-
-        public NSString GloballyUniqueString => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_globallyUniqueString));
-
-        public NSString UserName => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_userName));
-
-        public NSString FullUserName => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_fullUserName));
-
-        public ulong OperatingSystem => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_operatingSystem);
-
-        public NSOperatingSystemVersion OperatingSystemVersion => ObjectiveCRuntime.NSOperatingSystemVersion_objc_msgSend(NativePtr, sel_operatingSystemVersion);
-
-        public NSString OperatingSystemVersionString => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_operatingSystemVersionString));
-
-        public ulong ProcessorCount => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_processorCount);
-
         public ulong ActiveProcessorCount => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_activeProcessorCount);
 
-        public ulong PhysicalMemory => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_physicalMemory);
-
-        public IntPtr SystemUptime => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_systemUptime));
+        public NSArray Arguments => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_arguments));
 
         public bool AutomaticTerminationSupportEnabled
         {
@@ -78,27 +48,47 @@ namespace SharpMetal.Foundation
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setAutomaticTerminationSupportEnabled, value);
         }
 
-        public NSProcessInfoThermalState ThermalState => (NSProcessInfoThermalState)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_thermalState);
+        public NSDictionary Environment => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_environment));
 
-        public bool IsLowPowerModeEnabled => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isLowPowerModeEnabled);
+        public NSString FullUserName => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_fullUserName));
+
+        public NSString GloballyUniqueString => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_globallyUniqueString));
+
+        public NSString HostName => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_hostName));
 
         public bool IsiOSAppOnMac => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isiOSAppOnMac);
 
+        public bool IsLowPowerModeEnabled => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isLowPowerModeEnabled);
+
         public bool IsMacCatalystApp => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isMacCatalystApp);
 
-        public bool IsOperatingSystemAtLeastVersion(NSOperatingSystemVersion version)
+        public ulong OperatingSystem => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_operatingSystem);
+
+        public NSOperatingSystemVersion OperatingSystemVersion => ObjectiveCRuntime.NSOperatingSystemVersion_objc_msgSend(NativePtr, sel_operatingSystemVersion);
+
+        public NSString OperatingSystemVersionString => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_operatingSystemVersionString));
+
+        public ulong PhysicalMemory => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_physicalMemory);
+
+        public int ProcessIdentifier => ObjectiveCRuntime.int_objc_msgSend(NativePtr, sel_processIdentifier);
+
+        public NSString ProcessName
         {
-            return ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isOperatingSystemAtLeastVersion, version);
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_processName));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setProcessName, value);
         }
 
-        public void DisableSuddenTermination()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_disableSuddenTermination);
-        }
+        public ulong ProcessorCount => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_processorCount);
 
-        public void EnableSuddenTermination()
+        public IntPtr SystemUptime => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_systemUptime));
+
+        public NSProcessInfoThermalState ThermalState => (NSProcessInfoThermalState)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_thermalState);
+
+        public NSString UserName => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_userName));
+
+        public NSObject BeginActivity(NSActivityOptions options, NSString pReason)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_enableSuddenTermination);
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_beginActivityWithOptionsreason, (ulong)options, pReason));
         }
 
         public void DisableAutomaticTermination(NSString pReason)
@@ -106,14 +96,19 @@ namespace SharpMetal.Foundation
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_disableAutomaticTermination, pReason);
         }
 
+        public void DisableSuddenTermination()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_disableSuddenTermination);
+        }
+
         public void EnableAutomaticTermination(NSString pReason)
         {
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_enableAutomaticTermination, pReason);
         }
 
-        public NSObject BeginActivity(NSActivityOptions options, NSString pReason)
+        public void EnableSuddenTermination()
         {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_beginActivityWithOptionsreason, (ulong)options, pReason));
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_enableSuddenTermination);
         }
 
         public void EndActivity(NSObject pActivity)
@@ -121,38 +116,43 @@ namespace SharpMetal.Foundation
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_endActivity, pActivity);
         }
 
-        private static readonly Selector sel_processInfo = "processInfo";
+        public bool IsOperatingSystemAtLeastVersion(NSOperatingSystemVersion version)
+        {
+            return ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isOperatingSystemAtLeastVersion, version);
+        }
+
+        private static readonly Selector sel_activeProcessorCount = "activeProcessorCount";
         private static readonly Selector sel_arguments = "arguments";
+        private static readonly Selector sel_automaticTerminationSupportEnabled = "automaticTerminationSupportEnabled";
+        private static readonly Selector sel_beginActivityWithOptionsreason = "beginActivityWithOptions:reason:";
+        private static readonly Selector sel_disableAutomaticTermination = "disableAutomaticTermination:";
+        private static readonly Selector sel_disableSuddenTermination = "disableSuddenTermination";
+        private static readonly Selector sel_enableAutomaticTermination = "enableAutomaticTermination:";
+        private static readonly Selector sel_enableSuddenTermination = "enableSuddenTermination";
+        private static readonly Selector sel_endActivity = "endActivity:";
         private static readonly Selector sel_environment = "environment";
-        private static readonly Selector sel_hostName = "hostName";
-        private static readonly Selector sel_processName = "processName";
-        private static readonly Selector sel_setProcessName = "setProcessName:";
-        private static readonly Selector sel_processIdentifier = "processIdentifier";
-        private static readonly Selector sel_globallyUniqueString = "globallyUniqueString";
-        private static readonly Selector sel_userName = "userName";
         private static readonly Selector sel_fullUserName = "fullUserName";
+        private static readonly Selector sel_globallyUniqueString = "globallyUniqueString";
+        private static readonly Selector sel_hostName = "hostName";
+        private static readonly Selector sel_isiOSAppOnMac = "isiOSAppOnMac";
+        private static readonly Selector sel_isLowPowerModeEnabled = "isLowPowerModeEnabled";
+        private static readonly Selector sel_isMacCatalystApp = "isMacCatalystApp";
+        private static readonly Selector sel_isOperatingSystemAtLeastVersion = "isOperatingSystemAtLeastVersion:";
         private static readonly Selector sel_operatingSystem = "operatingSystem";
         private static readonly Selector sel_operatingSystemVersion = "operatingSystemVersion";
         private static readonly Selector sel_operatingSystemVersionString = "operatingSystemVersionString";
-        private static readonly Selector sel_isOperatingSystemAtLeastVersion = "isOperatingSystemAtLeastVersion:";
-        private static readonly Selector sel_processorCount = "processorCount";
-        private static readonly Selector sel_activeProcessorCount = "activeProcessorCount";
-        private static readonly Selector sel_physicalMemory = "physicalMemory";
-        private static readonly Selector sel_systemUptime = "systemUptime";
-        private static readonly Selector sel_disableSuddenTermination = "disableSuddenTermination";
-        private static readonly Selector sel_enableSuddenTermination = "enableSuddenTermination";
-        private static readonly Selector sel_disableAutomaticTermination = "disableAutomaticTermination:";
-        private static readonly Selector sel_enableAutomaticTermination = "enableAutomaticTermination:";
-        private static readonly Selector sel_automaticTerminationSupportEnabled = "automaticTerminationSupportEnabled";
-        private static readonly Selector sel_setAutomaticTerminationSupportEnabled = "setAutomaticTerminationSupportEnabled:";
-        private static readonly Selector sel_beginActivityWithOptionsreason = "beginActivityWithOptions:reason:";
-        private static readonly Selector sel_endActivity = "endActivity:";
         private static readonly Selector sel_performActivityWithOptionsreasonusingBlock = "performActivityWithOptions:reason:usingBlock:";
         private static readonly Selector sel_performExpiringActivityWithReasonusingBlock = "performExpiringActivityWithReason:usingBlock:";
+        private static readonly Selector sel_physicalMemory = "physicalMemory";
+        private static readonly Selector sel_processIdentifier = "processIdentifier";
+        private static readonly Selector sel_processInfo = "processInfo";
+        private static readonly Selector sel_processName = "processName";
+        private static readonly Selector sel_processorCount = "processorCount";
+        private static readonly Selector sel_setAutomaticTerminationSupportEnabled = "setAutomaticTerminationSupportEnabled:";
+        private static readonly Selector sel_setProcessName = "setProcessName:";
+        private static readonly Selector sel_systemUptime = "systemUptime";
         private static readonly Selector sel_thermalState = "thermalState";
-        private static readonly Selector sel_isLowPowerModeEnabled = "isLowPowerModeEnabled";
-        private static readonly Selector sel_isiOSAppOnMac = "isiOSAppOnMac";
-        private static readonly Selector sel_isMacCatalystApp = "isMacCatalystApp";
+        private static readonly Selector sel_userName = "userName";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Foundation/NSSet.cs
+++ b/src/SharpMetal/Foundation/NSSet.cs
@@ -36,9 +36,9 @@ namespace SharpMetal.Foundation
         }
 
         private static readonly Selector sel_count = "count";
-        private static readonly Selector sel_objectEnumerator = "objectEnumerator";
-        private static readonly Selector sel_initWithObjectscount = "initWithObjects:count:";
         private static readonly Selector sel_initWithCoder = "initWithCoder:";
+        private static readonly Selector sel_initWithObjectscount = "initWithObjects:count:";
+        private static readonly Selector sel_objectEnumerator = "objectEnumerator";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Foundation/NSString.cs
+++ b/src/SharpMetal/Foundation/NSString.cs
@@ -1,9 +1,23 @@
-using System.Diagnostics;
 using System.Runtime.Versioning;
 using SharpMetal.ObjectiveCCore;
 
 namespace SharpMetal.Foundation
 {
+    [SupportedOSPlatform("macos")]
+    [Flags]
+    public enum NSStringCompareOptions : ulong
+    {
+        CaseInsensitiveSearch = 1,
+        LiteralSearch = 2,
+        BackwardsSearch = 4,
+        AnchoredSearch = 8,
+        NumericSearch = 64,
+        DiacriticInsensitiveSearch = 128,
+        WidthInsensitiveSearch = 256,
+        ForcedOrderingSearch = 512,
+        RegularExpressionSearch = 1024,
+    }
+
     [SupportedOSPlatform("macos")]
     public enum NSStringEncoding : ulong
     {
@@ -33,27 +47,11 @@ namespace SharpMetal.Foundation
     }
 
     [SupportedOSPlatform("macos")]
-    [Flags]
-    public enum NSStringCompareOptions : ulong
-    {
-        CaseInsensitiveSearch = 1,
-        LiteralSearch = 2,
-        BackwardsSearch = 4,
-        AnchoredSearch = 8,
-        NumericSearch = 64,
-        DiacriticInsensitiveSearch = 128,
-        WidthInsensitiveSearch = 256,
-        ForcedOrderingSearch = 512,
-        RegularExpressionSearch = 1024,
-    }
-
-    [SupportedOSPlatform("macos")]
     public struct NSString : IDisposable
     {
         public IntPtr NativePtr;
         public static implicit operator IntPtr(NSString obj) => obj.NativePtr;
         public static implicit operator NSString(string? value) => String(value);
-
         public NSString(IntPtr ptr) => NativePtr = ptr;
 
         public NSString()
@@ -67,11 +65,61 @@ namespace SharpMetal.Foundation
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
+        public ushort FileSystemRepresentation => ObjectiveCRuntime.ushort_objc_msgSend(NativePtr, sel_fileSystemRepresentation);
+
         public ulong Length => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_length);
 
         public ushort Utf8String => ObjectiveCRuntime.ushort_objc_msgSend(NativePtr, sel_UTF8String);
 
-        public ushort FileSystemRepresentation => ObjectiveCRuntime.ushort_objc_msgSend(NativePtr, sel_fileSystemRepresentation);
+        public NSComparisonResult CaseInsensitiveCompare(NSString pString)
+        {
+            return (NSComparisonResult)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_caseInsensitiveCompare, pString);
+        }
+
+        public ushort Character(ulong index)
+        {
+            return ObjectiveCRuntime.ushort_objc_msgSend(NativePtr, sel_characterAtIndex, index);
+        }
+
+        public ushort CString(NSStringEncoding encoding)
+        {
+            return ObjectiveCRuntime.ushort_objc_msgSend(NativePtr, sel_cStringUsingEncoding, (ulong)encoding);
+        }
+
+        public NSString Init(NSString pString)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithString, pString));
+        }
+
+        public NSString Init(ushort pString, NSStringEncoding encoding)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithCStringencoding, pString, (ulong)encoding));
+        }
+
+        public NSString Init(IntPtr pBytes, ulong len, NSStringEncoding encoding, bool freeBuffer)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithBytesNoCopylengthencodingfreeWhenDone, pBytes, len, (ulong)encoding, freeBuffer));
+        }
+
+        public bool IsEqualToString(NSString pString)
+        {
+            return ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isEqualToString, pString);
+        }
+
+        public ulong LengthOfBytes(NSStringEncoding encoding)
+        {
+            return ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_lengthOfBytesUsingEncoding, (ulong)encoding);
+        }
+
+        public ulong MaximumLengthOfBytes(NSStringEncoding encoding)
+        {
+            return ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maximumLengthOfBytesUsingEncoding, (ulong)encoding);
+        }
+
+        public NSRange RangeOfString(NSString pString, NSStringCompareOptions options)
+        {
+            return ObjectiveCRuntime.NSRange_objc_msgSend(NativePtr, sel_rangeOfStringoptions, pString, (ulong)options);
+        }
 
         public static NSString String(NSString pString)
         {
@@ -92,59 +140,9 @@ namespace SharpMetal.Foundation
             return new(ObjectiveC.IntPtr_objc_msgSend(new ObjectiveCClass("NSString"), sel_cStringWithUTF8String, value));
         }
 
-        public NSString Init(NSString pString)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithString, pString));
-        }
-
-        public NSString Init(ushort pString, NSStringEncoding encoding)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithCStringencoding, pString, (ulong)encoding));
-        }
-
-        public NSString Init(IntPtr pBytes, ulong len, NSStringEncoding encoding, bool freeBuffer)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithBytesNoCopylengthencodingfreeWhenDone, pBytes, len, (ulong)encoding, freeBuffer));
-        }
-
-        public ushort Character(ulong index)
-        {
-            return ObjectiveCRuntime.ushort_objc_msgSend(NativePtr, sel_characterAtIndex, index);
-        }
-
-        public ushort CString(NSStringEncoding encoding)
-        {
-            return ObjectiveCRuntime.ushort_objc_msgSend(NativePtr, sel_cStringUsingEncoding, (ulong)encoding);
-        }
-
-        public ulong MaximumLengthOfBytes(NSStringEncoding encoding)
-        {
-            return ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maximumLengthOfBytesUsingEncoding, (ulong)encoding);
-        }
-
-        public ulong LengthOfBytes(NSStringEncoding encoding)
-        {
-            return ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maximumLengthOfBytesUsingEncoding, (ulong)encoding);
-        }
-
-        public bool IsEqualToString(NSString pString)
-        {
-            return ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isEqualToString, pString);
-        }
-
-        public NSRange RangeOfString(NSString pString, NSStringCompareOptions options)
-        {
-            return ObjectiveCRuntime.NSRange_objc_msgSend(NativePtr, sel_rangeOfStringoptions, pString, (ulong)options);
-        }
-
         public NSString StringByAppendingString(NSString pString)
         {
             return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_stringByAppendingString, pString));
-        }
-
-        public NSComparisonResult CaseInsensitiveCompare(NSString pString)
-        {
-            return (NSComparisonResult)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_caseInsensitiveCompare, pString);
         }
 
         public override unsafe string? ToString()
@@ -163,24 +161,24 @@ namespace SharpMetal.Foundation
             }
         }
 
-        private static readonly Selector sel_string = "string";
-        private static readonly Selector sel_stringWithString = "stringWithString:";
-        private static readonly Selector sel_stringWithCStringencoding = "stringWithCString:encoding:";
-        private static readonly Selector sel_initWithString = "initWithString:";
-        private static readonly Selector sel_initWithCStringencoding = "initWithCString:encoding:";
-        private static readonly Selector sel_initWithBytesNoCopylengthencodingfreeWhenDone = "initWithBytesNoCopy:length:encoding:freeWhenDone:";
+        private static readonly Selector sel_caseInsensitiveCompare = "caseInsensitiveCompare:";
         private static readonly Selector sel_characterAtIndex = "characterAtIndex:";
-        private static readonly Selector sel_length = "length";
         private static readonly Selector sel_cStringUsingEncoding = "cStringUsingEncoding:";
         private static readonly Selector sel_cStringWithUTF8String = "stringWithUTF8String:";
-        private static readonly Selector sel_UTF8String = "UTF8String";
-        private static readonly Selector sel_maximumLengthOfBytesUsingEncoding = "maximumLengthOfBytesUsingEncoding:";
-        private static readonly Selector sel_lengthOfBytesUsingEncoding = "lengthOfBytesUsingEncoding:";
-        private static readonly Selector sel_isEqualToString = "isEqualToString:";
-        private static readonly Selector sel_rangeOfStringoptions = "rangeOfString:options:";
         private static readonly Selector sel_fileSystemRepresentation = "fileSystemRepresentation";
+        private static readonly Selector sel_initWithBytesNoCopylengthencodingfreeWhenDone = "initWithBytesNoCopy:length:encoding:freeWhenDone:";
+        private static readonly Selector sel_initWithCStringencoding = "initWithCString:encoding:";
+        private static readonly Selector sel_initWithString = "initWithString:";
+        private static readonly Selector sel_isEqualToString = "isEqualToString:";
+        private static readonly Selector sel_length = "length";
+        private static readonly Selector sel_lengthOfBytesUsingEncoding = "lengthOfBytesUsingEncoding:";
+        private static readonly Selector sel_maximumLengthOfBytesUsingEncoding = "maximumLengthOfBytesUsingEncoding:";
+        private static readonly Selector sel_rangeOfStringoptions = "rangeOfString:options:";
+        private static readonly Selector sel_string = "string";
         private static readonly Selector sel_stringByAppendingString = "stringByAppendingString:";
-        private static readonly Selector sel_caseInsensitiveCompare = "caseInsensitiveCompare:";
+        private static readonly Selector sel_stringWithCStringencoding = "stringWithCString:encoding:";
+        private static readonly Selector sel_stringWithString = "stringWithString:";
+        private static readonly Selector sel_UTF8String = "UTF8String";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Foundation/NSURL.cs
+++ b/src/SharpMetal/Foundation/NSURL.cs
@@ -38,10 +38,10 @@ namespace SharpMetal.Foundation
             return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initFileURLWithPath, pPath));
         }
 
-        private static readonly Selector sel_fileURLWithPath = "fileURLWithPath:";
-        private static readonly Selector sel_initWithString = "initWithString:";
-        private static readonly Selector sel_initFileURLWithPath = "initFileURLWithPath:";
         private static readonly Selector sel_fileSystemRepresentation = "fileSystemRepresentation";
+        private static readonly Selector sel_fileURLWithPath = "fileURLWithPath:";
+        private static readonly Selector sel_initFileURLWithPath = "initFileURLWithPath:";
+        private static readonly Selector sel_initWithString = "initWithString:";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLAccelerationStructure.cs
+++ b/src/SharpMetal/Metal/MTLAccelerationStructure.cs
@@ -6,13 +6,13 @@ using SharpMetal.Foundation;
 namespace SharpMetal.Metal
 {
     [SupportedOSPlatform("macos")]
-    [Flags]
-    public enum MTLAccelerationStructureUsage : ulong
+    public enum MTLAccelerationStructureInstanceDescriptorType : ulong
     {
-        None = 0,
-        Refit = 1,
-        PreferFastBuild = 2,
-        ExtendedLimits = 4,
+        Default = 0,
+        UserID = 1,
+        Motion = 2,
+        Indirect = 3,
+        IndirectMotion = 4,
     }
 
     [SupportedOSPlatform("macos")]
@@ -27,17 +27,13 @@ namespace SharpMetal.Metal
     }
 
     [SupportedOSPlatform("macos")]
-    public enum MTLMotionBorderMode : uint
+    [Flags]
+    public enum MTLAccelerationStructureUsage : ulong
     {
-        Clamp = 0,
-        Vanish = 1,
-    }
-
-    [SupportedOSPlatform("macos")]
-    public enum MTLCurveType : long
-    {
-        Round = 0,
-        Flat = 1,
+        None = 0,
+        Refit = 1,
+        PreferFastBuild = 2,
+        ExtendedLimits = 4,
     }
 
     [SupportedOSPlatform("macos")]
@@ -58,13 +54,17 @@ namespace SharpMetal.Metal
     }
 
     [SupportedOSPlatform("macos")]
-    public enum MTLAccelerationStructureInstanceDescriptorType : ulong
+    public enum MTLCurveType : long
     {
-        Default = 0,
-        UserID = 1,
-        Motion = 2,
-        Indirect = 3,
-        IndirectMotion = 4,
+        Round = 0,
+        Flat = 1,
+    }
+
+    [SupportedOSPlatform("macos")]
+    public enum MTLMotionBorderMode : uint
+    {
+        Clamp = 0,
+        Vanish = 1,
     }
 
     [SupportedOSPlatform("macos")]
@@ -76,18 +76,6 @@ namespace SharpMetal.Metal
         public uint mask;
         public uint intersectionFunctionTableOffset;
         public uint accelerationStructureIndex;
-    }
-
-    [SupportedOSPlatform("macos")]
-    [StructLayout(LayoutKind.Sequential)]
-    public struct MTLAccelerationStructureUserIDInstanceDescriptor
-    {
-        public MTLPackedFloat4x3 transformationMatrix;
-        public MTLAccelerationStructureInstanceOptions options;
-        public uint mask;
-        public uint intersectionFunctionTableOffset;
-        public uint accelerationStructureIndex;
-        public uint userID;
     }
 
     [SupportedOSPlatform("macos")]
@@ -105,6 +93,18 @@ namespace SharpMetal.Metal
         public MTLMotionBorderMode motionEndBorderMode;
         public float motionStartTime;
         public float motionEndTime;
+    }
+
+    [SupportedOSPlatform("macos")]
+    [StructLayout(LayoutKind.Sequential)]
+    public struct MTLAccelerationStructureUserIDInstanceDescriptor
+    {
+        public MTLPackedFloat4x3 transformationMatrix;
+        public MTLAccelerationStructureInstanceOptions options;
+        public uint mask;
+        public uint intersectionFunctionTableOffset;
+        public uint accelerationStructureIndex;
+        public uint userID;
     }
 
     [SupportedOSPlatform("macos")]
@@ -137,6 +137,417 @@ namespace SharpMetal.Metal
     }
 
     [SupportedOSPlatform("macos")]
+    public struct MTLAccelerationStructure : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLAccelerationStructure obj) => obj.NativePtr;
+        public static implicit operator MTLResource(MTLAccelerationStructure obj) => new(obj.NativePtr);
+        public MTLAccelerationStructure(IntPtr ptr) => NativePtr = ptr;
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public ulong AllocatedSize => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_allocatedSize);
+
+        public MTLCPUCacheMode CpuCacheMode => (MTLCPUCacheMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_cpuCacheMode);
+
+        public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
+
+        public MTLResourceID GpuResourceID => ObjectiveCRuntime.MTLResourceID_objc_msgSend(NativePtr, sel_gpuResourceID);
+
+        public MTLHazardTrackingMode HazardTrackingMode => (MTLHazardTrackingMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_hazardTrackingMode);
+
+        public MTLHeap Heap => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_heap));
+
+        public ulong HeapOffset => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_heapOffset);
+
+        public bool IsAliasable => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isAliasable);
+
+        public NSString Label
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
+        }
+
+        public MTLResourceOptions ResourceOptions => (MTLResourceOptions)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_resourceOptions);
+
+        public ulong Size => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_size);
+
+        public MTLStorageMode StorageMode => (MTLStorageMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_storageMode);
+
+        public void MakeAliasable()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_makeAliasable);
+        }
+
+        public MTLPurgeableState SetPurgeableState(MTLPurgeableState state)
+        {
+            return (MTLPurgeableState)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_setPurgeableState, (ulong)state);
+        }
+
+        private static readonly Selector sel_allocatedSize = "allocatedSize";
+        private static readonly Selector sel_cpuCacheMode = "cpuCacheMode";
+        private static readonly Selector sel_device = "device";
+        private static readonly Selector sel_gpuResourceID = "gpuResourceID";
+        private static readonly Selector sel_hazardTrackingMode = "hazardTrackingMode";
+        private static readonly Selector sel_heap = "heap";
+        private static readonly Selector sel_heapOffset = "heapOffset";
+        private static readonly Selector sel_isAliasable = "isAliasable";
+        private static readonly Selector sel_label = "label";
+        private static readonly Selector sel_makeAliasable = "makeAliasable";
+        private static readonly Selector sel_resourceOptions = "resourceOptions";
+        private static readonly Selector sel_setLabel = "setLabel:";
+        private static readonly Selector sel_setPurgeableState = "setPurgeableState:";
+        private static readonly Selector sel_size = "size";
+        private static readonly Selector sel_storageMode = "storageMode";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
+    public struct MTLAccelerationStructureBoundingBoxGeometryDescriptor : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLAccelerationStructureBoundingBoxGeometryDescriptor obj) => obj.NativePtr;
+        public static implicit operator MTLAccelerationStructureGeometryDescriptor(MTLAccelerationStructureBoundingBoxGeometryDescriptor obj) => new(obj.NativePtr);
+        public MTLAccelerationStructureBoundingBoxGeometryDescriptor(IntPtr ptr) => NativePtr = ptr;
+
+        public MTLAccelerationStructureBoundingBoxGeometryDescriptor()
+        {
+            var cls = new ObjectiveCClass("MTLAccelerationStructureBoundingBoxGeometryDescriptor");
+            NativePtr = cls.AllocInit();
+        }
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public bool AllowDuplicateIntersectionFunctionInvocation
+        {
+            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_allowDuplicateIntersectionFunctionInvocation);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setAllowDuplicateIntersectionFunctionInvocation, value);
+        }
+
+        public MTLBuffer BoundingBoxBuffer
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_boundingBoxBuffer));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBoundingBoxBuffer, value);
+        }
+
+        public ulong BoundingBoxBufferOffset
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_boundingBoxBufferOffset);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBoundingBoxBufferOffset, value);
+        }
+
+        public ulong BoundingBoxCount
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_boundingBoxCount);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBoundingBoxCount, value);
+        }
+
+        public ulong BoundingBoxStride
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_boundingBoxStride);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBoundingBoxStride, value);
+        }
+
+        public ulong IntersectionFunctionTableOffset
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_intersectionFunctionTableOffset);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIntersectionFunctionTableOffset, value);
+        }
+
+        public NSString Label
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
+        }
+
+        public bool Opaque
+        {
+            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_opaque);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setOpaque, value);
+        }
+
+        public MTLBuffer PrimitiveDataBuffer
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_primitiveDataBuffer));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataBuffer, value);
+        }
+
+        public ulong PrimitiveDataBufferOffset
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_primitiveDataBufferOffset);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataBufferOffset, value);
+        }
+
+        public ulong PrimitiveDataElementSize
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_primitiveDataElementSize);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataElementSize, value);
+        }
+
+        public ulong PrimitiveDataStride
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_primitiveDataStride);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataStride, value);
+        }
+
+        private static readonly Selector sel_allowDuplicateIntersectionFunctionInvocation = "allowDuplicateIntersectionFunctionInvocation";
+        private static readonly Selector sel_boundingBoxBuffer = "boundingBoxBuffer";
+        private static readonly Selector sel_boundingBoxBufferOffset = "boundingBoxBufferOffset";
+        private static readonly Selector sel_boundingBoxCount = "boundingBoxCount";
+        private static readonly Selector sel_boundingBoxStride = "boundingBoxStride";
+        private static readonly Selector sel_descriptor = "descriptor";
+        private static readonly Selector sel_intersectionFunctionTableOffset = "intersectionFunctionTableOffset";
+        private static readonly Selector sel_label = "label";
+        private static readonly Selector sel_opaque = "opaque";
+        private static readonly Selector sel_primitiveDataBuffer = "primitiveDataBuffer";
+        private static readonly Selector sel_primitiveDataBufferOffset = "primitiveDataBufferOffset";
+        private static readonly Selector sel_primitiveDataElementSize = "primitiveDataElementSize";
+        private static readonly Selector sel_primitiveDataStride = "primitiveDataStride";
+        private static readonly Selector sel_setAllowDuplicateIntersectionFunctionInvocation = "setAllowDuplicateIntersectionFunctionInvocation:";
+        private static readonly Selector sel_setBoundingBoxBuffer = "setBoundingBoxBuffer:";
+        private static readonly Selector sel_setBoundingBoxBufferOffset = "setBoundingBoxBufferOffset:";
+        private static readonly Selector sel_setBoundingBoxCount = "setBoundingBoxCount:";
+        private static readonly Selector sel_setBoundingBoxStride = "setBoundingBoxStride:";
+        private static readonly Selector sel_setIntersectionFunctionTableOffset = "setIntersectionFunctionTableOffset:";
+        private static readonly Selector sel_setLabel = "setLabel:";
+        private static readonly Selector sel_setOpaque = "setOpaque:";
+        private static readonly Selector sel_setPrimitiveDataBuffer = "setPrimitiveDataBuffer:";
+        private static readonly Selector sel_setPrimitiveDataBufferOffset = "setPrimitiveDataBufferOffset:";
+        private static readonly Selector sel_setPrimitiveDataElementSize = "setPrimitiveDataElementSize:";
+        private static readonly Selector sel_setPrimitiveDataStride = "setPrimitiveDataStride:";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
+    public struct MTLAccelerationStructureCurveGeometryDescriptor : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLAccelerationStructureCurveGeometryDescriptor obj) => obj.NativePtr;
+        public static implicit operator MTLAccelerationStructureGeometryDescriptor(MTLAccelerationStructureCurveGeometryDescriptor obj) => new(obj.NativePtr);
+        public MTLAccelerationStructureCurveGeometryDescriptor(IntPtr ptr) => NativePtr = ptr;
+
+        public MTLAccelerationStructureCurveGeometryDescriptor()
+        {
+            var cls = new ObjectiveCClass("MTLAccelerationStructureCurveGeometryDescriptor");
+            NativePtr = cls.AllocInit();
+        }
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public bool AllowDuplicateIntersectionFunctionInvocation
+        {
+            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_allowDuplicateIntersectionFunctionInvocation);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setAllowDuplicateIntersectionFunctionInvocation, value);
+        }
+
+        public MTLBuffer ControlPointBuffer
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_controlPointBuffer));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setControlPointBuffer, value);
+        }
+
+        public ulong ControlPointBufferOffset
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_controlPointBufferOffset);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setControlPointBufferOffset, value);
+        }
+
+        public ulong ControlPointCount
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_controlPointCount);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setControlPointCount, value);
+        }
+
+        public MTLAttributeFormat ControlPointFormat
+        {
+            get => (MTLAttributeFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_controlPointFormat);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setControlPointFormat, (ulong)value);
+        }
+
+        public ulong ControlPointStride
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_controlPointStride);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setControlPointStride, value);
+        }
+
+        public MTLCurveBasis CurveBasis
+        {
+            get => (MTLCurveBasis)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_curveBasis);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setCurveBasis, (long)value);
+        }
+
+        public MTLCurveEndCaps CurveEndCaps
+        {
+            get => (MTLCurveEndCaps)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_curveEndCaps);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setCurveEndCaps, (long)value);
+        }
+
+        public MTLCurveType CurveType
+        {
+            get => (MTLCurveType)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_curveType);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setCurveType, (long)value);
+        }
+
+        public MTLBuffer IndexBuffer
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_indexBuffer));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIndexBuffer, value);
+        }
+
+        public ulong IndexBufferOffset
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_indexBufferOffset);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIndexBufferOffset, value);
+        }
+
+        public MTLIndexType IndexType
+        {
+            get => (MTLIndexType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_indexType);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIndexType, (ulong)value);
+        }
+
+        public ulong IntersectionFunctionTableOffset
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_intersectionFunctionTableOffset);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIntersectionFunctionTableOffset, value);
+        }
+
+        public NSString Label
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
+        }
+
+        public bool Opaque
+        {
+            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_opaque);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setOpaque, value);
+        }
+
+        public MTLBuffer PrimitiveDataBuffer
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_primitiveDataBuffer));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataBuffer, value);
+        }
+
+        public ulong PrimitiveDataBufferOffset
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_primitiveDataBufferOffset);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataBufferOffset, value);
+        }
+
+        public ulong PrimitiveDataElementSize
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_primitiveDataElementSize);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataElementSize, value);
+        }
+
+        public ulong PrimitiveDataStride
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_primitiveDataStride);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataStride, value);
+        }
+
+        public MTLBuffer RadiusBuffer
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_radiusBuffer));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRadiusBuffer, value);
+        }
+
+        public ulong RadiusBufferOffset
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_radiusBufferOffset);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRadiusBufferOffset, value);
+        }
+
+        public MTLAttributeFormat RadiusFormat
+        {
+            get => (MTLAttributeFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_radiusFormat);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRadiusFormat, (ulong)value);
+        }
+
+        public ulong RadiusStride
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_radiusStride);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRadiusStride, value);
+        }
+
+        public ulong SegmentControlPointCount
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_segmentControlPointCount);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSegmentControlPointCount, value);
+        }
+
+        public ulong SegmentCount
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_segmentCount);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSegmentCount, value);
+        }
+
+        private static readonly Selector sel_allowDuplicateIntersectionFunctionInvocation = "allowDuplicateIntersectionFunctionInvocation";
+        private static readonly Selector sel_controlPointBuffer = "controlPointBuffer";
+        private static readonly Selector sel_controlPointBufferOffset = "controlPointBufferOffset";
+        private static readonly Selector sel_controlPointCount = "controlPointCount";
+        private static readonly Selector sel_controlPointFormat = "controlPointFormat";
+        private static readonly Selector sel_controlPointStride = "controlPointStride";
+        private static readonly Selector sel_curveBasis = "curveBasis";
+        private static readonly Selector sel_curveEndCaps = "curveEndCaps";
+        private static readonly Selector sel_curveType = "curveType";
+        private static readonly Selector sel_descriptor = "descriptor";
+        private static readonly Selector sel_indexBuffer = "indexBuffer";
+        private static readonly Selector sel_indexBufferOffset = "indexBufferOffset";
+        private static readonly Selector sel_indexType = "indexType";
+        private static readonly Selector sel_intersectionFunctionTableOffset = "intersectionFunctionTableOffset";
+        private static readonly Selector sel_label = "label";
+        private static readonly Selector sel_opaque = "opaque";
+        private static readonly Selector sel_primitiveDataBuffer = "primitiveDataBuffer";
+        private static readonly Selector sel_primitiveDataBufferOffset = "primitiveDataBufferOffset";
+        private static readonly Selector sel_primitiveDataElementSize = "primitiveDataElementSize";
+        private static readonly Selector sel_primitiveDataStride = "primitiveDataStride";
+        private static readonly Selector sel_radiusBuffer = "radiusBuffer";
+        private static readonly Selector sel_radiusBufferOffset = "radiusBufferOffset";
+        private static readonly Selector sel_radiusFormat = "radiusFormat";
+        private static readonly Selector sel_radiusStride = "radiusStride";
+        private static readonly Selector sel_segmentControlPointCount = "segmentControlPointCount";
+        private static readonly Selector sel_segmentCount = "segmentCount";
+        private static readonly Selector sel_setAllowDuplicateIntersectionFunctionInvocation = "setAllowDuplicateIntersectionFunctionInvocation:";
+        private static readonly Selector sel_setControlPointBuffer = "setControlPointBuffer:";
+        private static readonly Selector sel_setControlPointBufferOffset = "setControlPointBufferOffset:";
+        private static readonly Selector sel_setControlPointCount = "setControlPointCount:";
+        private static readonly Selector sel_setControlPointFormat = "setControlPointFormat:";
+        private static readonly Selector sel_setControlPointStride = "setControlPointStride:";
+        private static readonly Selector sel_setCurveBasis = "setCurveBasis:";
+        private static readonly Selector sel_setCurveEndCaps = "setCurveEndCaps:";
+        private static readonly Selector sel_setCurveType = "setCurveType:";
+        private static readonly Selector sel_setIndexBuffer = "setIndexBuffer:";
+        private static readonly Selector sel_setIndexBufferOffset = "setIndexBufferOffset:";
+        private static readonly Selector sel_setIndexType = "setIndexType:";
+        private static readonly Selector sel_setIntersectionFunctionTableOffset = "setIntersectionFunctionTableOffset:";
+        private static readonly Selector sel_setLabel = "setLabel:";
+        private static readonly Selector sel_setOpaque = "setOpaque:";
+        private static readonly Selector sel_setPrimitiveDataBuffer = "setPrimitiveDataBuffer:";
+        private static readonly Selector sel_setPrimitiveDataBufferOffset = "setPrimitiveDataBufferOffset:";
+        private static readonly Selector sel_setPrimitiveDataElementSize = "setPrimitiveDataElementSize:";
+        private static readonly Selector sel_setPrimitiveDataStride = "setPrimitiveDataStride:";
+        private static readonly Selector sel_setRadiusBuffer = "setRadiusBuffer:";
+        private static readonly Selector sel_setRadiusBufferOffset = "setRadiusBufferOffset:";
+        private static readonly Selector sel_setRadiusFormat = "setRadiusFormat:";
+        private static readonly Selector sel_setRadiusStride = "setRadiusStride:";
+        private static readonly Selector sel_setSegmentControlPointCount = "setSegmentControlPointCount:";
+        private static readonly Selector sel_setSegmentCount = "setSegmentCount:";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
     public struct MTLAccelerationStructureDescriptor : IDisposable
     {
         public IntPtr NativePtr;
@@ -160,8 +571,8 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setUsage, (ulong)value);
         }
 
-        private static readonly Selector sel_usage = "usage";
         private static readonly Selector sel_setUsage = "setUsage:";
+        private static readonly Selector sel_usage = "usage";
         private static readonly Selector sel_release = "release";
     }
 
@@ -183,28 +594,28 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public ulong IntersectionFunctionTableOffset
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_intersectionFunctionTableOffset);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIntersectionFunctionTableOffset, value);
-        }
-
-        public bool Opaque
-        {
-            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_opaque);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setOpaque, value);
-        }
-
         public bool AllowDuplicateIntersectionFunctionInvocation
         {
             get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_allowDuplicateIntersectionFunctionInvocation);
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setAllowDuplicateIntersectionFunctionInvocation, value);
         }
 
+        public ulong IntersectionFunctionTableOffset
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_intersectionFunctionTableOffset);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIntersectionFunctionTableOffset, value);
+        }
+
         public NSString Label
         {
             get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
+        }
+
+        public bool Opaque
+        {
+            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_opaque);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setOpaque, value);
         }
 
         public MTLBuffer PrimitiveDataBuffer
@@ -219,48 +630,48 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataBufferOffset, value);
         }
 
-        public ulong PrimitiveDataStride
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_primitiveDataStride);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataStride, value);
-        }
-
         public ulong PrimitiveDataElementSize
         {
             get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_primitiveDataElementSize);
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataElementSize, value);
         }
 
-        private static readonly Selector sel_intersectionFunctionTableOffset = "intersectionFunctionTableOffset";
-        private static readonly Selector sel_setIntersectionFunctionTableOffset = "setIntersectionFunctionTableOffset:";
-        private static readonly Selector sel_opaque = "opaque";
-        private static readonly Selector sel_setOpaque = "setOpaque:";
+        public ulong PrimitiveDataStride
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_primitiveDataStride);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataStride, value);
+        }
+
         private static readonly Selector sel_allowDuplicateIntersectionFunctionInvocation = "allowDuplicateIntersectionFunctionInvocation";
-        private static readonly Selector sel_setAllowDuplicateIntersectionFunctionInvocation = "setAllowDuplicateIntersectionFunctionInvocation:";
+        private static readonly Selector sel_intersectionFunctionTableOffset = "intersectionFunctionTableOffset";
         private static readonly Selector sel_label = "label";
-        private static readonly Selector sel_setLabel = "setLabel:";
+        private static readonly Selector sel_opaque = "opaque";
         private static readonly Selector sel_primitiveDataBuffer = "primitiveDataBuffer";
-        private static readonly Selector sel_setPrimitiveDataBuffer = "setPrimitiveDataBuffer:";
         private static readonly Selector sel_primitiveDataBufferOffset = "primitiveDataBufferOffset";
-        private static readonly Selector sel_setPrimitiveDataBufferOffset = "setPrimitiveDataBufferOffset:";
-        private static readonly Selector sel_primitiveDataStride = "primitiveDataStride";
-        private static readonly Selector sel_setPrimitiveDataStride = "setPrimitiveDataStride:";
         private static readonly Selector sel_primitiveDataElementSize = "primitiveDataElementSize";
+        private static readonly Selector sel_primitiveDataStride = "primitiveDataStride";
+        private static readonly Selector sel_setAllowDuplicateIntersectionFunctionInvocation = "setAllowDuplicateIntersectionFunctionInvocation:";
+        private static readonly Selector sel_setIntersectionFunctionTableOffset = "setIntersectionFunctionTableOffset:";
+        private static readonly Selector sel_setLabel = "setLabel:";
+        private static readonly Selector sel_setOpaque = "setOpaque:";
+        private static readonly Selector sel_setPrimitiveDataBuffer = "setPrimitiveDataBuffer:";
+        private static readonly Selector sel_setPrimitiveDataBufferOffset = "setPrimitiveDataBufferOffset:";
         private static readonly Selector sel_setPrimitiveDataElementSize = "setPrimitiveDataElementSize:";
+        private static readonly Selector sel_setPrimitiveDataStride = "setPrimitiveDataStride:";
         private static readonly Selector sel_release = "release";
     }
 
     [SupportedOSPlatform("macos")]
-    public struct MTLPrimitiveAccelerationStructureDescriptor : IDisposable
+    public struct MTLAccelerationStructureMotionBoundingBoxGeometryDescriptor : IDisposable
     {
         public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLPrimitiveAccelerationStructureDescriptor obj) => obj.NativePtr;
-        public static implicit operator MTLAccelerationStructureDescriptor(MTLPrimitiveAccelerationStructureDescriptor obj) => new(obj.NativePtr);
-        public MTLPrimitiveAccelerationStructureDescriptor(IntPtr ptr) => NativePtr = ptr;
+        public static implicit operator IntPtr(MTLAccelerationStructureMotionBoundingBoxGeometryDescriptor obj) => obj.NativePtr;
+        public static implicit operator MTLAccelerationStructureGeometryDescriptor(MTLAccelerationStructureMotionBoundingBoxGeometryDescriptor obj) => new(obj.NativePtr);
+        public MTLAccelerationStructureMotionBoundingBoxGeometryDescriptor(IntPtr ptr) => NativePtr = ptr;
 
-        public MTLPrimitiveAccelerationStructureDescriptor()
+        public MTLAccelerationStructureMotionBoundingBoxGeometryDescriptor()
         {
-            var cls = new ObjectiveCClass("MTLPrimitiveAccelerationStructureDescriptor");
+            var cls = new ObjectiveCClass("MTLAccelerationStructureMotionBoundingBoxGeometryDescriptor");
             NativePtr = cls.AllocInit();
         }
 
@@ -269,63 +680,461 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public NSArray GeometryDescriptors
+        public bool AllowDuplicateIntersectionFunctionInvocation
         {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_geometryDescriptors));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setGeometryDescriptors, value);
+            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_allowDuplicateIntersectionFunctionInvocation);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setAllowDuplicateIntersectionFunctionInvocation, value);
         }
 
-        public MTLMotionBorderMode MotionStartBorderMode
+        public NSArray BoundingBoxBuffers
         {
-            get => (MTLMotionBorderMode)ObjectiveCRuntime.uint_objc_msgSend(NativePtr, sel_motionStartBorderMode);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMotionStartBorderMode, (uint)value);
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_boundingBoxBuffers));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBoundingBoxBuffers, value);
         }
 
-        public MTLMotionBorderMode MotionEndBorderMode
+        public ulong BoundingBoxCount
         {
-            get => (MTLMotionBorderMode)ObjectiveCRuntime.uint_objc_msgSend(NativePtr, sel_motionEndBorderMode);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMotionEndBorderMode, (uint)value);
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_boundingBoxCount);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBoundingBoxCount, value);
         }
 
-        public float MotionStartTime
+        public ulong BoundingBoxStride
         {
-            get => ObjectiveCRuntime.float_objc_msgSend(NativePtr, sel_motionStartTime);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMotionStartTime, value);
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_boundingBoxStride);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBoundingBoxStride, value);
         }
 
-        public float MotionEndTime
+        public ulong IntersectionFunctionTableOffset
         {
-            get => ObjectiveCRuntime.float_objc_msgSend(NativePtr, sel_motionEndTime);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMotionEndTime, value);
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_intersectionFunctionTableOffset);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIntersectionFunctionTableOffset, value);
         }
 
-        public ulong MotionKeyframeCount
+        public NSString Label
         {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_motionKeyframeCount);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMotionKeyframeCount, value);
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
         }
 
-        public MTLAccelerationStructureUsage Usage
+        public bool Opaque
         {
-            get => (MTLAccelerationStructureUsage)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_usage);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setUsage, (ulong)value);
+            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_opaque);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setOpaque, value);
         }
 
-        private static readonly Selector sel_geometryDescriptors = "geometryDescriptors";
-        private static readonly Selector sel_setGeometryDescriptors = "setGeometryDescriptors:";
-        private static readonly Selector sel_motionStartBorderMode = "motionStartBorderMode";
-        private static readonly Selector sel_setMotionStartBorderMode = "setMotionStartBorderMode:";
-        private static readonly Selector sel_motionEndBorderMode = "motionEndBorderMode";
-        private static readonly Selector sel_setMotionEndBorderMode = "setMotionEndBorderMode:";
-        private static readonly Selector sel_motionStartTime = "motionStartTime";
-        private static readonly Selector sel_setMotionStartTime = "setMotionStartTime:";
-        private static readonly Selector sel_motionEndTime = "motionEndTime";
-        private static readonly Selector sel_setMotionEndTime = "setMotionEndTime:";
-        private static readonly Selector sel_motionKeyframeCount = "motionKeyframeCount";
-        private static readonly Selector sel_setMotionKeyframeCount = "setMotionKeyframeCount:";
+        public MTLBuffer PrimitiveDataBuffer
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_primitiveDataBuffer));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataBuffer, value);
+        }
+
+        public ulong PrimitiveDataBufferOffset
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_primitiveDataBufferOffset);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataBufferOffset, value);
+        }
+
+        public ulong PrimitiveDataElementSize
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_primitiveDataElementSize);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataElementSize, value);
+        }
+
+        public ulong PrimitiveDataStride
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_primitiveDataStride);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataStride, value);
+        }
+
+        private static readonly Selector sel_allowDuplicateIntersectionFunctionInvocation = "allowDuplicateIntersectionFunctionInvocation";
+        private static readonly Selector sel_boundingBoxBuffers = "boundingBoxBuffers";
+        private static readonly Selector sel_boundingBoxCount = "boundingBoxCount";
+        private static readonly Selector sel_boundingBoxStride = "boundingBoxStride";
         private static readonly Selector sel_descriptor = "descriptor";
-        private static readonly Selector sel_usage = "usage";
-        private static readonly Selector sel_setUsage = "setUsage:";
+        private static readonly Selector sel_intersectionFunctionTableOffset = "intersectionFunctionTableOffset";
+        private static readonly Selector sel_label = "label";
+        private static readonly Selector sel_opaque = "opaque";
+        private static readonly Selector sel_primitiveDataBuffer = "primitiveDataBuffer";
+        private static readonly Selector sel_primitiveDataBufferOffset = "primitiveDataBufferOffset";
+        private static readonly Selector sel_primitiveDataElementSize = "primitiveDataElementSize";
+        private static readonly Selector sel_primitiveDataStride = "primitiveDataStride";
+        private static readonly Selector sel_setAllowDuplicateIntersectionFunctionInvocation = "setAllowDuplicateIntersectionFunctionInvocation:";
+        private static readonly Selector sel_setBoundingBoxBuffers = "setBoundingBoxBuffers:";
+        private static readonly Selector sel_setBoundingBoxCount = "setBoundingBoxCount:";
+        private static readonly Selector sel_setBoundingBoxStride = "setBoundingBoxStride:";
+        private static readonly Selector sel_setIntersectionFunctionTableOffset = "setIntersectionFunctionTableOffset:";
+        private static readonly Selector sel_setLabel = "setLabel:";
+        private static readonly Selector sel_setOpaque = "setOpaque:";
+        private static readonly Selector sel_setPrimitiveDataBuffer = "setPrimitiveDataBuffer:";
+        private static readonly Selector sel_setPrimitiveDataBufferOffset = "setPrimitiveDataBufferOffset:";
+        private static readonly Selector sel_setPrimitiveDataElementSize = "setPrimitiveDataElementSize:";
+        private static readonly Selector sel_setPrimitiveDataStride = "setPrimitiveDataStride:";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
+    public struct MTLAccelerationStructureMotionCurveGeometryDescriptor : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLAccelerationStructureMotionCurveGeometryDescriptor obj) => obj.NativePtr;
+        public static implicit operator MTLAccelerationStructureGeometryDescriptor(MTLAccelerationStructureMotionCurveGeometryDescriptor obj) => new(obj.NativePtr);
+        public MTLAccelerationStructureMotionCurveGeometryDescriptor(IntPtr ptr) => NativePtr = ptr;
+
+        public MTLAccelerationStructureMotionCurveGeometryDescriptor()
+        {
+            var cls = new ObjectiveCClass("MTLAccelerationStructureMotionCurveGeometryDescriptor");
+            NativePtr = cls.AllocInit();
+        }
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public bool AllowDuplicateIntersectionFunctionInvocation
+        {
+            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_allowDuplicateIntersectionFunctionInvocation);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setAllowDuplicateIntersectionFunctionInvocation, value);
+        }
+
+        public NSArray ControlPointBuffers
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_controlPointBuffers));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setControlPointBuffers, value);
+        }
+
+        public ulong ControlPointCount
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_controlPointCount);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setControlPointCount, value);
+        }
+
+        public MTLAttributeFormat ControlPointFormat
+        {
+            get => (MTLAttributeFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_controlPointFormat);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setControlPointFormat, (ulong)value);
+        }
+
+        public ulong ControlPointStride
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_controlPointStride);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setControlPointStride, value);
+        }
+
+        public MTLCurveBasis CurveBasis
+        {
+            get => (MTLCurveBasis)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_curveBasis);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setCurveBasis, (long)value);
+        }
+
+        public MTLCurveEndCaps CurveEndCaps
+        {
+            get => (MTLCurveEndCaps)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_curveEndCaps);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setCurveEndCaps, (long)value);
+        }
+
+        public MTLCurveType CurveType
+        {
+            get => (MTLCurveType)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_curveType);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setCurveType, (long)value);
+        }
+
+        public MTLBuffer IndexBuffer
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_indexBuffer));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIndexBuffer, value);
+        }
+
+        public ulong IndexBufferOffset
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_indexBufferOffset);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIndexBufferOffset, value);
+        }
+
+        public MTLIndexType IndexType
+        {
+            get => (MTLIndexType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_indexType);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIndexType, (ulong)value);
+        }
+
+        public ulong IntersectionFunctionTableOffset
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_intersectionFunctionTableOffset);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIntersectionFunctionTableOffset, value);
+        }
+
+        public NSString Label
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
+        }
+
+        public bool Opaque
+        {
+            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_opaque);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setOpaque, value);
+        }
+
+        public MTLBuffer PrimitiveDataBuffer
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_primitiveDataBuffer));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataBuffer, value);
+        }
+
+        public ulong PrimitiveDataBufferOffset
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_primitiveDataBufferOffset);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataBufferOffset, value);
+        }
+
+        public ulong PrimitiveDataElementSize
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_primitiveDataElementSize);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataElementSize, value);
+        }
+
+        public ulong PrimitiveDataStride
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_primitiveDataStride);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataStride, value);
+        }
+
+        public NSArray RadiusBuffers
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_radiusBuffers));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRadiusBuffers, value);
+        }
+
+        public MTLAttributeFormat RadiusFormat
+        {
+            get => (MTLAttributeFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_radiusFormat);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRadiusFormat, (ulong)value);
+        }
+
+        public ulong RadiusStride
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_radiusStride);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRadiusStride, value);
+        }
+
+        public ulong SegmentControlPointCount
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_segmentControlPointCount);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSegmentControlPointCount, value);
+        }
+
+        public ulong SegmentCount
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_segmentCount);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSegmentCount, value);
+        }
+
+        private static readonly Selector sel_allowDuplicateIntersectionFunctionInvocation = "allowDuplicateIntersectionFunctionInvocation";
+        private static readonly Selector sel_controlPointBuffers = "controlPointBuffers";
+        private static readonly Selector sel_controlPointCount = "controlPointCount";
+        private static readonly Selector sel_controlPointFormat = "controlPointFormat";
+        private static readonly Selector sel_controlPointStride = "controlPointStride";
+        private static readonly Selector sel_curveBasis = "curveBasis";
+        private static readonly Selector sel_curveEndCaps = "curveEndCaps";
+        private static readonly Selector sel_curveType = "curveType";
+        private static readonly Selector sel_descriptor = "descriptor";
+        private static readonly Selector sel_indexBuffer = "indexBuffer";
+        private static readonly Selector sel_indexBufferOffset = "indexBufferOffset";
+        private static readonly Selector sel_indexType = "indexType";
+        private static readonly Selector sel_intersectionFunctionTableOffset = "intersectionFunctionTableOffset";
+        private static readonly Selector sel_label = "label";
+        private static readonly Selector sel_opaque = "opaque";
+        private static readonly Selector sel_primitiveDataBuffer = "primitiveDataBuffer";
+        private static readonly Selector sel_primitiveDataBufferOffset = "primitiveDataBufferOffset";
+        private static readonly Selector sel_primitiveDataElementSize = "primitiveDataElementSize";
+        private static readonly Selector sel_primitiveDataStride = "primitiveDataStride";
+        private static readonly Selector sel_radiusBuffers = "radiusBuffers";
+        private static readonly Selector sel_radiusFormat = "radiusFormat";
+        private static readonly Selector sel_radiusStride = "radiusStride";
+        private static readonly Selector sel_segmentControlPointCount = "segmentControlPointCount";
+        private static readonly Selector sel_segmentCount = "segmentCount";
+        private static readonly Selector sel_setAllowDuplicateIntersectionFunctionInvocation = "setAllowDuplicateIntersectionFunctionInvocation:";
+        private static readonly Selector sel_setControlPointBuffers = "setControlPointBuffers:";
+        private static readonly Selector sel_setControlPointCount = "setControlPointCount:";
+        private static readonly Selector sel_setControlPointFormat = "setControlPointFormat:";
+        private static readonly Selector sel_setControlPointStride = "setControlPointStride:";
+        private static readonly Selector sel_setCurveBasis = "setCurveBasis:";
+        private static readonly Selector sel_setCurveEndCaps = "setCurveEndCaps:";
+        private static readonly Selector sel_setCurveType = "setCurveType:";
+        private static readonly Selector sel_setIndexBuffer = "setIndexBuffer:";
+        private static readonly Selector sel_setIndexBufferOffset = "setIndexBufferOffset:";
+        private static readonly Selector sel_setIndexType = "setIndexType:";
+        private static readonly Selector sel_setIntersectionFunctionTableOffset = "setIntersectionFunctionTableOffset:";
+        private static readonly Selector sel_setLabel = "setLabel:";
+        private static readonly Selector sel_setOpaque = "setOpaque:";
+        private static readonly Selector sel_setPrimitiveDataBuffer = "setPrimitiveDataBuffer:";
+        private static readonly Selector sel_setPrimitiveDataBufferOffset = "setPrimitiveDataBufferOffset:";
+        private static readonly Selector sel_setPrimitiveDataElementSize = "setPrimitiveDataElementSize:";
+        private static readonly Selector sel_setPrimitiveDataStride = "setPrimitiveDataStride:";
+        private static readonly Selector sel_setRadiusBuffers = "setRadiusBuffers:";
+        private static readonly Selector sel_setRadiusFormat = "setRadiusFormat:";
+        private static readonly Selector sel_setRadiusStride = "setRadiusStride:";
+        private static readonly Selector sel_setSegmentControlPointCount = "setSegmentControlPointCount:";
+        private static readonly Selector sel_setSegmentCount = "setSegmentCount:";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
+    public struct MTLAccelerationStructureMotionTriangleGeometryDescriptor : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLAccelerationStructureMotionTriangleGeometryDescriptor obj) => obj.NativePtr;
+        public static implicit operator MTLAccelerationStructureGeometryDescriptor(MTLAccelerationStructureMotionTriangleGeometryDescriptor obj) => new(obj.NativePtr);
+        public MTLAccelerationStructureMotionTriangleGeometryDescriptor(IntPtr ptr) => NativePtr = ptr;
+
+        public MTLAccelerationStructureMotionTriangleGeometryDescriptor()
+        {
+            var cls = new ObjectiveCClass("MTLAccelerationStructureMotionTriangleGeometryDescriptor");
+            NativePtr = cls.AllocInit();
+        }
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public bool AllowDuplicateIntersectionFunctionInvocation
+        {
+            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_allowDuplicateIntersectionFunctionInvocation);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setAllowDuplicateIntersectionFunctionInvocation, value);
+        }
+
+        public MTLBuffer IndexBuffer
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_indexBuffer));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIndexBuffer, value);
+        }
+
+        public ulong IndexBufferOffset
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_indexBufferOffset);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIndexBufferOffset, value);
+        }
+
+        public MTLIndexType IndexType
+        {
+            get => (MTLIndexType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_indexType);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIndexType, (ulong)value);
+        }
+
+        public ulong IntersectionFunctionTableOffset
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_intersectionFunctionTableOffset);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIntersectionFunctionTableOffset, value);
+        }
+
+        public NSString Label
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
+        }
+
+        public bool Opaque
+        {
+            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_opaque);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setOpaque, value);
+        }
+
+        public MTLBuffer PrimitiveDataBuffer
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_primitiveDataBuffer));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataBuffer, value);
+        }
+
+        public ulong PrimitiveDataBufferOffset
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_primitiveDataBufferOffset);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataBufferOffset, value);
+        }
+
+        public ulong PrimitiveDataElementSize
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_primitiveDataElementSize);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataElementSize, value);
+        }
+
+        public ulong PrimitiveDataStride
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_primitiveDataStride);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataStride, value);
+        }
+
+        public MTLBuffer TransformationMatrixBuffer
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_transformationMatrixBuffer));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTransformationMatrixBuffer, value);
+        }
+
+        public ulong TransformationMatrixBufferOffset
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_transformationMatrixBufferOffset);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTransformationMatrixBufferOffset, value);
+        }
+
+        public ulong TriangleCount
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_triangleCount);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTriangleCount, value);
+        }
+
+        public NSArray VertexBuffers
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_vertexBuffers));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexBuffers, value);
+        }
+
+        public MTLAttributeFormat VertexFormat
+        {
+            get => (MTLAttributeFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_vertexFormat);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexFormat, (ulong)value);
+        }
+
+        public ulong VertexStride
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_vertexStride);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexStride, value);
+        }
+
+        private static readonly Selector sel_allowDuplicateIntersectionFunctionInvocation = "allowDuplicateIntersectionFunctionInvocation";
+        private static readonly Selector sel_descriptor = "descriptor";
+        private static readonly Selector sel_indexBuffer = "indexBuffer";
+        private static readonly Selector sel_indexBufferOffset = "indexBufferOffset";
+        private static readonly Selector sel_indexType = "indexType";
+        private static readonly Selector sel_intersectionFunctionTableOffset = "intersectionFunctionTableOffset";
+        private static readonly Selector sel_label = "label";
+        private static readonly Selector sel_opaque = "opaque";
+        private static readonly Selector sel_primitiveDataBuffer = "primitiveDataBuffer";
+        private static readonly Selector sel_primitiveDataBufferOffset = "primitiveDataBufferOffset";
+        private static readonly Selector sel_primitiveDataElementSize = "primitiveDataElementSize";
+        private static readonly Selector sel_primitiveDataStride = "primitiveDataStride";
+        private static readonly Selector sel_setAllowDuplicateIntersectionFunctionInvocation = "setAllowDuplicateIntersectionFunctionInvocation:";
+        private static readonly Selector sel_setIndexBuffer = "setIndexBuffer:";
+        private static readonly Selector sel_setIndexBufferOffset = "setIndexBufferOffset:";
+        private static readonly Selector sel_setIndexType = "setIndexType:";
+        private static readonly Selector sel_setIntersectionFunctionTableOffset = "setIntersectionFunctionTableOffset:";
+        private static readonly Selector sel_setLabel = "setLabel:";
+        private static readonly Selector sel_setOpaque = "setOpaque:";
+        private static readonly Selector sel_setPrimitiveDataBuffer = "setPrimitiveDataBuffer:";
+        private static readonly Selector sel_setPrimitiveDataBufferOffset = "setPrimitiveDataBufferOffset:";
+        private static readonly Selector sel_setPrimitiveDataElementSize = "setPrimitiveDataElementSize:";
+        private static readonly Selector sel_setPrimitiveDataStride = "setPrimitiveDataStride:";
+        private static readonly Selector sel_setTransformationMatrixBuffer = "setTransformationMatrixBuffer:";
+        private static readonly Selector sel_setTransformationMatrixBufferOffset = "setTransformationMatrixBufferOffset:";
+        private static readonly Selector sel_setTriangleCount = "setTriangleCount:";
+        private static readonly Selector sel_setVertexBuffers = "setVertexBuffers:";
+        private static readonly Selector sel_setVertexFormat = "setVertexFormat:";
+        private static readonly Selector sel_setVertexStride = "setVertexStride:";
+        private static readonly Selector sel_transformationMatrixBuffer = "transformationMatrixBuffer";
+        private static readonly Selector sel_transformationMatrixBufferOffset = "transformationMatrixBufferOffset";
+        private static readonly Selector sel_triangleCount = "triangleCount";
+        private static readonly Selector sel_vertexBuffers = "vertexBuffers";
+        private static readonly Selector sel_vertexFormat = "vertexFormat";
+        private static readonly Selector sel_vertexStride = "vertexStride";
         private static readonly Selector sel_release = "release";
     }
 
@@ -346,6 +1155,90 @@ namespace SharpMetal.Metal
         public void Dispose()
         {
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public bool AllowDuplicateIntersectionFunctionInvocation
+        {
+            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_allowDuplicateIntersectionFunctionInvocation);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setAllowDuplicateIntersectionFunctionInvocation, value);
+        }
+
+        public MTLBuffer IndexBuffer
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_indexBuffer));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIndexBuffer, value);
+        }
+
+        public ulong IndexBufferOffset
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_indexBufferOffset);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIndexBufferOffset, value);
+        }
+
+        public MTLIndexType IndexType
+        {
+            get => (MTLIndexType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_indexType);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIndexType, (ulong)value);
+        }
+
+        public ulong IntersectionFunctionTableOffset
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_intersectionFunctionTableOffset);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIntersectionFunctionTableOffset, value);
+        }
+
+        public NSString Label
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
+        }
+
+        public bool Opaque
+        {
+            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_opaque);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setOpaque, value);
+        }
+
+        public MTLBuffer PrimitiveDataBuffer
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_primitiveDataBuffer));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataBuffer, value);
+        }
+
+        public ulong PrimitiveDataBufferOffset
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_primitiveDataBufferOffset);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataBufferOffset, value);
+        }
+
+        public ulong PrimitiveDataElementSize
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_primitiveDataElementSize);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataElementSize, value);
+        }
+
+        public ulong PrimitiveDataStride
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_primitiveDataStride);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataStride, value);
+        }
+
+        public MTLBuffer TransformationMatrixBuffer
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_transformationMatrixBuffer));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTransformationMatrixBuffer, value);
+        }
+
+        public ulong TransformationMatrixBufferOffset
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_transformationMatrixBufferOffset);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTransformationMatrixBufferOffset, value);
+        }
+
+        public ulong TriangleCount
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_triangleCount);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTriangleCount, value);
         }
 
         public MTLBuffer VertexBuffer
@@ -372,141 +1265,57 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexStride, value);
         }
 
-        public MTLBuffer IndexBuffer
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_indexBuffer));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIndexBuffer, value);
-        }
-
-        public ulong IndexBufferOffset
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_indexBufferOffset);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIndexBufferOffset, value);
-        }
-
-        public MTLIndexType IndexType
-        {
-            get => (MTLIndexType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_indexType);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIndexType, (ulong)value);
-        }
-
-        public ulong TriangleCount
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_triangleCount);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTriangleCount, value);
-        }
-
-        public MTLBuffer TransformationMatrixBuffer
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_transformationMatrixBuffer));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTransformationMatrixBuffer, value);
-        }
-
-        public ulong TransformationMatrixBufferOffset
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_transformationMatrixBufferOffset);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTransformationMatrixBufferOffset, value);
-        }
-
-        public ulong IntersectionFunctionTableOffset
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_intersectionFunctionTableOffset);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIntersectionFunctionTableOffset, value);
-        }
-
-        public bool Opaque
-        {
-            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_opaque);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setOpaque, value);
-        }
-
-        public bool AllowDuplicateIntersectionFunctionInvocation
-        {
-            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_allowDuplicateIntersectionFunctionInvocation);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setAllowDuplicateIntersectionFunctionInvocation, value);
-        }
-
-        public NSString Label
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
-        }
-
-        public MTLBuffer PrimitiveDataBuffer
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_primitiveDataBuffer));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataBuffer, value);
-        }
-
-        public ulong PrimitiveDataBufferOffset
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_primitiveDataBufferOffset);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataBufferOffset, value);
-        }
-
-        public ulong PrimitiveDataStride
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_primitiveDataStride);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataStride, value);
-        }
-
-        public ulong PrimitiveDataElementSize
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_primitiveDataElementSize);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataElementSize, value);
-        }
-
-        private static readonly Selector sel_vertexBuffer = "vertexBuffer";
-        private static readonly Selector sel_setVertexBuffer = "setVertexBuffer:";
-        private static readonly Selector sel_vertexBufferOffset = "vertexBufferOffset";
-        private static readonly Selector sel_setVertexBufferOffset = "setVertexBufferOffset:";
-        private static readonly Selector sel_vertexFormat = "vertexFormat";
-        private static readonly Selector sel_setVertexFormat = "setVertexFormat:";
-        private static readonly Selector sel_vertexStride = "vertexStride";
-        private static readonly Selector sel_setVertexStride = "setVertexStride:";
-        private static readonly Selector sel_indexBuffer = "indexBuffer";
-        private static readonly Selector sel_setIndexBuffer = "setIndexBuffer:";
-        private static readonly Selector sel_indexBufferOffset = "indexBufferOffset";
-        private static readonly Selector sel_setIndexBufferOffset = "setIndexBufferOffset:";
-        private static readonly Selector sel_indexType = "indexType";
-        private static readonly Selector sel_setIndexType = "setIndexType:";
-        private static readonly Selector sel_triangleCount = "triangleCount";
-        private static readonly Selector sel_setTriangleCount = "setTriangleCount:";
-        private static readonly Selector sel_transformationMatrixBuffer = "transformationMatrixBuffer";
-        private static readonly Selector sel_setTransformationMatrixBuffer = "setTransformationMatrixBuffer:";
-        private static readonly Selector sel_transformationMatrixBufferOffset = "transformationMatrixBufferOffset";
-        private static readonly Selector sel_setTransformationMatrixBufferOffset = "setTransformationMatrixBufferOffset:";
-        private static readonly Selector sel_descriptor = "descriptor";
-        private static readonly Selector sel_intersectionFunctionTableOffset = "intersectionFunctionTableOffset";
-        private static readonly Selector sel_setIntersectionFunctionTableOffset = "setIntersectionFunctionTableOffset:";
-        private static readonly Selector sel_opaque = "opaque";
-        private static readonly Selector sel_setOpaque = "setOpaque:";
         private static readonly Selector sel_allowDuplicateIntersectionFunctionInvocation = "allowDuplicateIntersectionFunctionInvocation";
-        private static readonly Selector sel_setAllowDuplicateIntersectionFunctionInvocation = "setAllowDuplicateIntersectionFunctionInvocation:";
+        private static readonly Selector sel_descriptor = "descriptor";
+        private static readonly Selector sel_indexBuffer = "indexBuffer";
+        private static readonly Selector sel_indexBufferOffset = "indexBufferOffset";
+        private static readonly Selector sel_indexType = "indexType";
+        private static readonly Selector sel_intersectionFunctionTableOffset = "intersectionFunctionTableOffset";
         private static readonly Selector sel_label = "label";
-        private static readonly Selector sel_setLabel = "setLabel:";
+        private static readonly Selector sel_opaque = "opaque";
         private static readonly Selector sel_primitiveDataBuffer = "primitiveDataBuffer";
-        private static readonly Selector sel_setPrimitiveDataBuffer = "setPrimitiveDataBuffer:";
         private static readonly Selector sel_primitiveDataBufferOffset = "primitiveDataBufferOffset";
-        private static readonly Selector sel_setPrimitiveDataBufferOffset = "setPrimitiveDataBufferOffset:";
-        private static readonly Selector sel_primitiveDataStride = "primitiveDataStride";
-        private static readonly Selector sel_setPrimitiveDataStride = "setPrimitiveDataStride:";
         private static readonly Selector sel_primitiveDataElementSize = "primitiveDataElementSize";
+        private static readonly Selector sel_primitiveDataStride = "primitiveDataStride";
+        private static readonly Selector sel_setAllowDuplicateIntersectionFunctionInvocation = "setAllowDuplicateIntersectionFunctionInvocation:";
+        private static readonly Selector sel_setIndexBuffer = "setIndexBuffer:";
+        private static readonly Selector sel_setIndexBufferOffset = "setIndexBufferOffset:";
+        private static readonly Selector sel_setIndexType = "setIndexType:";
+        private static readonly Selector sel_setIntersectionFunctionTableOffset = "setIntersectionFunctionTableOffset:";
+        private static readonly Selector sel_setLabel = "setLabel:";
+        private static readonly Selector sel_setOpaque = "setOpaque:";
+        private static readonly Selector sel_setPrimitiveDataBuffer = "setPrimitiveDataBuffer:";
+        private static readonly Selector sel_setPrimitiveDataBufferOffset = "setPrimitiveDataBufferOffset:";
         private static readonly Selector sel_setPrimitiveDataElementSize = "setPrimitiveDataElementSize:";
+        private static readonly Selector sel_setPrimitiveDataStride = "setPrimitiveDataStride:";
+        private static readonly Selector sel_setTransformationMatrixBuffer = "setTransformationMatrixBuffer:";
+        private static readonly Selector sel_setTransformationMatrixBufferOffset = "setTransformationMatrixBufferOffset:";
+        private static readonly Selector sel_setTriangleCount = "setTriangleCount:";
+        private static readonly Selector sel_setVertexBuffer = "setVertexBuffer:";
+        private static readonly Selector sel_setVertexBufferOffset = "setVertexBufferOffset:";
+        private static readonly Selector sel_setVertexFormat = "setVertexFormat:";
+        private static readonly Selector sel_setVertexStride = "setVertexStride:";
+        private static readonly Selector sel_transformationMatrixBuffer = "transformationMatrixBuffer";
+        private static readonly Selector sel_transformationMatrixBufferOffset = "transformationMatrixBufferOffset";
+        private static readonly Selector sel_triangleCount = "triangleCount";
+        private static readonly Selector sel_vertexBuffer = "vertexBuffer";
+        private static readonly Selector sel_vertexBufferOffset = "vertexBufferOffset";
+        private static readonly Selector sel_vertexFormat = "vertexFormat";
+        private static readonly Selector sel_vertexStride = "vertexStride";
         private static readonly Selector sel_release = "release";
     }
 
     [SupportedOSPlatform("macos")]
-    public struct MTLAccelerationStructureBoundingBoxGeometryDescriptor : IDisposable
+    public struct MTLIndirectInstanceAccelerationStructureDescriptor : IDisposable
     {
         public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLAccelerationStructureBoundingBoxGeometryDescriptor obj) => obj.NativePtr;
-        public static implicit operator MTLAccelerationStructureGeometryDescriptor(MTLAccelerationStructureBoundingBoxGeometryDescriptor obj) => new(obj.NativePtr);
-        public MTLAccelerationStructureBoundingBoxGeometryDescriptor(IntPtr ptr) => NativePtr = ptr;
+        public static implicit operator IntPtr(MTLIndirectInstanceAccelerationStructureDescriptor obj) => obj.NativePtr;
+        public static implicit operator MTLAccelerationStructureDescriptor(MTLIndirectInstanceAccelerationStructureDescriptor obj) => new(obj.NativePtr);
+        public MTLIndirectInstanceAccelerationStructureDescriptor(IntPtr ptr) => NativePtr = ptr;
 
-        public MTLAccelerationStructureBoundingBoxGeometryDescriptor()
+        public MTLIndirectInstanceAccelerationStructureDescriptor()
         {
-            var cls = new ObjectiveCClass("MTLAccelerationStructureBoundingBoxGeometryDescriptor");
+            var cls = new ObjectiveCClass("MTLIndirectInstanceAccelerationStructureDescriptor");
             NativePtr = cls.AllocInit();
         }
 
@@ -515,103 +1324,214 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public MTLBuffer BoundingBoxBuffer
+        public MTLBuffer InstanceCountBuffer
         {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_boundingBoxBuffer));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBoundingBoxBuffer, value);
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_instanceCountBuffer));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setInstanceCountBuffer, value);
         }
 
-        public ulong BoundingBoxBufferOffset
+        public ulong InstanceCountBufferOffset
         {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_boundingBoxBufferOffset);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBoundingBoxBufferOffset, value);
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_instanceCountBufferOffset);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setInstanceCountBufferOffset, value);
         }
 
-        public ulong BoundingBoxStride
+        public MTLBuffer InstanceDescriptorBuffer
         {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_boundingBoxStride);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBoundingBoxStride, value);
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_instanceDescriptorBuffer));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setInstanceDescriptorBuffer, value);
         }
 
-        public ulong BoundingBoxCount
+        public ulong InstanceDescriptorBufferOffset
         {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_boundingBoxCount);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBoundingBoxCount, value);
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_instanceDescriptorBufferOffset);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setInstanceDescriptorBufferOffset, value);
         }
 
-        public ulong IntersectionFunctionTableOffset
+        public ulong InstanceDescriptorStride
         {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_intersectionFunctionTableOffset);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIntersectionFunctionTableOffset, value);
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_instanceDescriptorStride);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setInstanceDescriptorStride, value);
         }
 
-        public bool Opaque
+        public MTLAccelerationStructureInstanceDescriptorType InstanceDescriptorType
         {
-            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_opaque);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setOpaque, value);
+            get => (MTLAccelerationStructureInstanceDescriptorType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_instanceDescriptorType);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setInstanceDescriptorType, (ulong)value);
         }
 
-        public bool AllowDuplicateIntersectionFunctionInvocation
+        public ulong MaxInstanceCount
         {
-            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_allowDuplicateIntersectionFunctionInvocation);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setAllowDuplicateIntersectionFunctionInvocation, value);
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxInstanceCount);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxInstanceCount, value);
         }
 
-        public NSString Label
+        public ulong MaxMotionTransformCount
         {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxMotionTransformCount);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxMotionTransformCount, value);
         }
 
-        public MTLBuffer PrimitiveDataBuffer
+        public MTLBuffer MotionTransformBuffer
         {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_primitiveDataBuffer));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataBuffer, value);
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_motionTransformBuffer));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMotionTransformBuffer, value);
         }
 
-        public ulong PrimitiveDataBufferOffset
+        public ulong MotionTransformBufferOffset
         {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_primitiveDataBufferOffset);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataBufferOffset, value);
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_motionTransformBufferOffset);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMotionTransformBufferOffset, value);
         }
 
-        public ulong PrimitiveDataStride
+        public MTLBuffer MotionTransformCountBuffer
         {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_primitiveDataStride);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataStride, value);
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_motionTransformCountBuffer));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMotionTransformCountBuffer, value);
         }
 
-        public ulong PrimitiveDataElementSize
+        public ulong MotionTransformCountBufferOffset
         {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_primitiveDataElementSize);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataElementSize, value);
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_motionTransformCountBufferOffset);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMotionTransformCountBufferOffset, value);
         }
 
-        private static readonly Selector sel_boundingBoxBuffer = "boundingBoxBuffer";
-        private static readonly Selector sel_setBoundingBoxBuffer = "setBoundingBoxBuffer:";
-        private static readonly Selector sel_boundingBoxBufferOffset = "boundingBoxBufferOffset";
-        private static readonly Selector sel_setBoundingBoxBufferOffset = "setBoundingBoxBufferOffset:";
-        private static readonly Selector sel_boundingBoxStride = "boundingBoxStride";
-        private static readonly Selector sel_setBoundingBoxStride = "setBoundingBoxStride:";
-        private static readonly Selector sel_boundingBoxCount = "boundingBoxCount";
-        private static readonly Selector sel_setBoundingBoxCount = "setBoundingBoxCount:";
+        public MTLAccelerationStructureUsage Usage
+        {
+            get => (MTLAccelerationStructureUsage)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_usage);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setUsage, (ulong)value);
+        }
+
         private static readonly Selector sel_descriptor = "descriptor";
-        private static readonly Selector sel_intersectionFunctionTableOffset = "intersectionFunctionTableOffset";
-        private static readonly Selector sel_setIntersectionFunctionTableOffset = "setIntersectionFunctionTableOffset:";
-        private static readonly Selector sel_opaque = "opaque";
-        private static readonly Selector sel_setOpaque = "setOpaque:";
-        private static readonly Selector sel_allowDuplicateIntersectionFunctionInvocation = "allowDuplicateIntersectionFunctionInvocation";
-        private static readonly Selector sel_setAllowDuplicateIntersectionFunctionInvocation = "setAllowDuplicateIntersectionFunctionInvocation:";
-        private static readonly Selector sel_label = "label";
-        private static readonly Selector sel_setLabel = "setLabel:";
-        private static readonly Selector sel_primitiveDataBuffer = "primitiveDataBuffer";
-        private static readonly Selector sel_setPrimitiveDataBuffer = "setPrimitiveDataBuffer:";
-        private static readonly Selector sel_primitiveDataBufferOffset = "primitiveDataBufferOffset";
-        private static readonly Selector sel_setPrimitiveDataBufferOffset = "setPrimitiveDataBufferOffset:";
-        private static readonly Selector sel_primitiveDataStride = "primitiveDataStride";
-        private static readonly Selector sel_setPrimitiveDataStride = "setPrimitiveDataStride:";
-        private static readonly Selector sel_primitiveDataElementSize = "primitiveDataElementSize";
-        private static readonly Selector sel_setPrimitiveDataElementSize = "setPrimitiveDataElementSize:";
+        private static readonly Selector sel_instanceCountBuffer = "instanceCountBuffer";
+        private static readonly Selector sel_instanceCountBufferOffset = "instanceCountBufferOffset";
+        private static readonly Selector sel_instanceDescriptorBuffer = "instanceDescriptorBuffer";
+        private static readonly Selector sel_instanceDescriptorBufferOffset = "instanceDescriptorBufferOffset";
+        private static readonly Selector sel_instanceDescriptorStride = "instanceDescriptorStride";
+        private static readonly Selector sel_instanceDescriptorType = "instanceDescriptorType";
+        private static readonly Selector sel_maxInstanceCount = "maxInstanceCount";
+        private static readonly Selector sel_maxMotionTransformCount = "maxMotionTransformCount";
+        private static readonly Selector sel_motionTransformBuffer = "motionTransformBuffer";
+        private static readonly Selector sel_motionTransformBufferOffset = "motionTransformBufferOffset";
+        private static readonly Selector sel_motionTransformCountBuffer = "motionTransformCountBuffer";
+        private static readonly Selector sel_motionTransformCountBufferOffset = "motionTransformCountBufferOffset";
+        private static readonly Selector sel_setInstanceCountBuffer = "setInstanceCountBuffer:";
+        private static readonly Selector sel_setInstanceCountBufferOffset = "setInstanceCountBufferOffset:";
+        private static readonly Selector sel_setInstanceDescriptorBuffer = "setInstanceDescriptorBuffer:";
+        private static readonly Selector sel_setInstanceDescriptorBufferOffset = "setInstanceDescriptorBufferOffset:";
+        private static readonly Selector sel_setInstanceDescriptorStride = "setInstanceDescriptorStride:";
+        private static readonly Selector sel_setInstanceDescriptorType = "setInstanceDescriptorType:";
+        private static readonly Selector sel_setMaxInstanceCount = "setMaxInstanceCount:";
+        private static readonly Selector sel_setMaxMotionTransformCount = "setMaxMotionTransformCount:";
+        private static readonly Selector sel_setMotionTransformBuffer = "setMotionTransformBuffer:";
+        private static readonly Selector sel_setMotionTransformBufferOffset = "setMotionTransformBufferOffset:";
+        private static readonly Selector sel_setMotionTransformCountBuffer = "setMotionTransformCountBuffer:";
+        private static readonly Selector sel_setMotionTransformCountBufferOffset = "setMotionTransformCountBufferOffset:";
+        private static readonly Selector sel_setUsage = "setUsage:";
+        private static readonly Selector sel_usage = "usage";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
+    public struct MTLInstanceAccelerationStructureDescriptor : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLInstanceAccelerationStructureDescriptor obj) => obj.NativePtr;
+        public static implicit operator MTLAccelerationStructureDescriptor(MTLInstanceAccelerationStructureDescriptor obj) => new(obj.NativePtr);
+        public MTLInstanceAccelerationStructureDescriptor(IntPtr ptr) => NativePtr = ptr;
+
+        public MTLInstanceAccelerationStructureDescriptor()
+        {
+            var cls = new ObjectiveCClass("MTLInstanceAccelerationStructureDescriptor");
+            NativePtr = cls.AllocInit();
+        }
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public ulong InstanceCount
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_instanceCount);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setInstanceCount, value);
+        }
+
+        public NSArray InstancedAccelerationStructures
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_instancedAccelerationStructures));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setInstancedAccelerationStructures, value);
+        }
+
+        public MTLBuffer InstanceDescriptorBuffer
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_instanceDescriptorBuffer));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setInstanceDescriptorBuffer, value);
+        }
+
+        public ulong InstanceDescriptorBufferOffset
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_instanceDescriptorBufferOffset);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setInstanceDescriptorBufferOffset, value);
+        }
+
+        public ulong InstanceDescriptorStride
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_instanceDescriptorStride);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setInstanceDescriptorStride, value);
+        }
+
+        public MTLAccelerationStructureInstanceDescriptorType InstanceDescriptorType
+        {
+            get => (MTLAccelerationStructureInstanceDescriptorType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_instanceDescriptorType);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setInstanceDescriptorType, (ulong)value);
+        }
+
+        public MTLBuffer MotionTransformBuffer
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_motionTransformBuffer));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMotionTransformBuffer, value);
+        }
+
+        public ulong MotionTransformBufferOffset
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_motionTransformBufferOffset);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMotionTransformBufferOffset, value);
+        }
+
+        public ulong MotionTransformCount
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_motionTransformCount);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMotionTransformCount, value);
+        }
+
+        public MTLAccelerationStructureUsage Usage
+        {
+            get => (MTLAccelerationStructureUsage)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_usage);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setUsage, (ulong)value);
+        }
+
+        private static readonly Selector sel_descriptor = "descriptor";
+        private static readonly Selector sel_instanceCount = "instanceCount";
+        private static readonly Selector sel_instancedAccelerationStructures = "instancedAccelerationStructures";
+        private static readonly Selector sel_instanceDescriptorBuffer = "instanceDescriptorBuffer";
+        private static readonly Selector sel_instanceDescriptorBufferOffset = "instanceDescriptorBufferOffset";
+        private static readonly Selector sel_instanceDescriptorStride = "instanceDescriptorStride";
+        private static readonly Selector sel_instanceDescriptorType = "instanceDescriptorType";
+        private static readonly Selector sel_motionTransformBuffer = "motionTransformBuffer";
+        private static readonly Selector sel_motionTransformBufferOffset = "motionTransformBufferOffset";
+        private static readonly Selector sel_motionTransformCount = "motionTransformCount";
+        private static readonly Selector sel_setInstanceCount = "setInstanceCount:";
+        private static readonly Selector sel_setInstancedAccelerationStructures = "setInstancedAccelerationStructures:";
+        private static readonly Selector sel_setInstanceDescriptorBuffer = "setInstanceDescriptorBuffer:";
+        private static readonly Selector sel_setInstanceDescriptorBufferOffset = "setInstanceDescriptorBufferOffset:";
+        private static readonly Selector sel_setInstanceDescriptorStride = "setInstanceDescriptorStride:";
+        private static readonly Selector sel_setInstanceDescriptorType = "setInstanceDescriptorType:";
+        private static readonly Selector sel_setMotionTransformBuffer = "setMotionTransformBuffer:";
+        private static readonly Selector sel_setMotionTransformBufferOffset = "setMotionTransformBufferOffset:";
+        private static readonly Selector sel_setMotionTransformCount = "setMotionTransformCount:";
+        private static readonly Selector sel_setUsage = "setUsage:";
+        private static readonly Selector sel_usage = "usage";
         private static readonly Selector sel_release = "release";
     }
 
@@ -646,24 +1566,24 @@ namespace SharpMetal.Metal
         }
 
         private static readonly Selector sel_buffer = "buffer";
-        private static readonly Selector sel_setBuffer = "setBuffer:";
-        private static readonly Selector sel_offset = "offset";
-        private static readonly Selector sel_setOffset = "setOffset:";
         private static readonly Selector sel_data = "data";
+        private static readonly Selector sel_offset = "offset";
+        private static readonly Selector sel_setBuffer = "setBuffer:";
+        private static readonly Selector sel_setOffset = "setOffset:";
         private static readonly Selector sel_release = "release";
     }
 
     [SupportedOSPlatform("macos")]
-    public struct MTLAccelerationStructureMotionTriangleGeometryDescriptor : IDisposable
+    public struct MTLPrimitiveAccelerationStructureDescriptor : IDisposable
     {
         public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLAccelerationStructureMotionTriangleGeometryDescriptor obj) => obj.NativePtr;
-        public static implicit operator MTLAccelerationStructureGeometryDescriptor(MTLAccelerationStructureMotionTriangleGeometryDescriptor obj) => new(obj.NativePtr);
-        public MTLAccelerationStructureMotionTriangleGeometryDescriptor(IntPtr ptr) => NativePtr = ptr;
+        public static implicit operator IntPtr(MTLPrimitiveAccelerationStructureDescriptor obj) => obj.NativePtr;
+        public static implicit operator MTLAccelerationStructureDescriptor(MTLPrimitiveAccelerationStructureDescriptor obj) => new(obj.NativePtr);
+        public MTLPrimitiveAccelerationStructureDescriptor(IntPtr ptr) => NativePtr = ptr;
 
-        public MTLAccelerationStructureMotionTriangleGeometryDescriptor()
+        public MTLPrimitiveAccelerationStructureDescriptor()
         {
-            var cls = new ObjectiveCClass("MTLAccelerationStructureMotionTriangleGeometryDescriptor");
+            var cls = new ObjectiveCClass("MTLPrimitiveAccelerationStructureDescriptor");
             NativePtr = cls.AllocInit();
         }
 
@@ -672,758 +1592,40 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public NSArray VertexBuffers
+        public NSArray GeometryDescriptors
         {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_vertexBuffers));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexBuffers, value);
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_geometryDescriptors));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setGeometryDescriptors, value);
         }
 
-        public MTLAttributeFormat VertexFormat
+        public MTLMotionBorderMode MotionEndBorderMode
         {
-            get => (MTLAttributeFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_vertexFormat);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexFormat, (ulong)value);
+            get => (MTLMotionBorderMode)ObjectiveCRuntime.uint_objc_msgSend(NativePtr, sel_motionEndBorderMode);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMotionEndBorderMode, (uint)value);
         }
 
-        public ulong VertexStride
+        public float MotionEndTime
         {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_vertexStride);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexStride, value);
+            get => ObjectiveCRuntime.float_objc_msgSend(NativePtr, sel_motionEndTime);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMotionEndTime, value);
         }
 
-        public MTLBuffer IndexBuffer
+        public ulong MotionKeyframeCount
         {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_indexBuffer));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIndexBuffer, value);
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_motionKeyframeCount);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMotionKeyframeCount, value);
         }
 
-        public ulong IndexBufferOffset
+        public MTLMotionBorderMode MotionStartBorderMode
         {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_indexBufferOffset);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIndexBufferOffset, value);
+            get => (MTLMotionBorderMode)ObjectiveCRuntime.uint_objc_msgSend(NativePtr, sel_motionStartBorderMode);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMotionStartBorderMode, (uint)value);
         }
 
-        public MTLIndexType IndexType
+        public float MotionStartTime
         {
-            get => (MTLIndexType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_indexType);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIndexType, (ulong)value);
-        }
-
-        public ulong TriangleCount
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_triangleCount);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTriangleCount, value);
-        }
-
-        public MTLBuffer TransformationMatrixBuffer
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_transformationMatrixBuffer));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTransformationMatrixBuffer, value);
-        }
-
-        public ulong TransformationMatrixBufferOffset
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_transformationMatrixBufferOffset);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTransformationMatrixBufferOffset, value);
-        }
-
-        public ulong IntersectionFunctionTableOffset
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_intersectionFunctionTableOffset);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIntersectionFunctionTableOffset, value);
-        }
-
-        public bool Opaque
-        {
-            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_opaque);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setOpaque, value);
-        }
-
-        public bool AllowDuplicateIntersectionFunctionInvocation
-        {
-            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_allowDuplicateIntersectionFunctionInvocation);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setAllowDuplicateIntersectionFunctionInvocation, value);
-        }
-
-        public NSString Label
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
-        }
-
-        public MTLBuffer PrimitiveDataBuffer
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_primitiveDataBuffer));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataBuffer, value);
-        }
-
-        public ulong PrimitiveDataBufferOffset
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_primitiveDataBufferOffset);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataBufferOffset, value);
-        }
-
-        public ulong PrimitiveDataStride
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_primitiveDataStride);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataStride, value);
-        }
-
-        public ulong PrimitiveDataElementSize
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_primitiveDataElementSize);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataElementSize, value);
-        }
-
-        private static readonly Selector sel_vertexBuffers = "vertexBuffers";
-        private static readonly Selector sel_setVertexBuffers = "setVertexBuffers:";
-        private static readonly Selector sel_vertexFormat = "vertexFormat";
-        private static readonly Selector sel_setVertexFormat = "setVertexFormat:";
-        private static readonly Selector sel_vertexStride = "vertexStride";
-        private static readonly Selector sel_setVertexStride = "setVertexStride:";
-        private static readonly Selector sel_indexBuffer = "indexBuffer";
-        private static readonly Selector sel_setIndexBuffer = "setIndexBuffer:";
-        private static readonly Selector sel_indexBufferOffset = "indexBufferOffset";
-        private static readonly Selector sel_setIndexBufferOffset = "setIndexBufferOffset:";
-        private static readonly Selector sel_indexType = "indexType";
-        private static readonly Selector sel_setIndexType = "setIndexType:";
-        private static readonly Selector sel_triangleCount = "triangleCount";
-        private static readonly Selector sel_setTriangleCount = "setTriangleCount:";
-        private static readonly Selector sel_transformationMatrixBuffer = "transformationMatrixBuffer";
-        private static readonly Selector sel_setTransformationMatrixBuffer = "setTransformationMatrixBuffer:";
-        private static readonly Selector sel_transformationMatrixBufferOffset = "transformationMatrixBufferOffset";
-        private static readonly Selector sel_setTransformationMatrixBufferOffset = "setTransformationMatrixBufferOffset:";
-        private static readonly Selector sel_descriptor = "descriptor";
-        private static readonly Selector sel_intersectionFunctionTableOffset = "intersectionFunctionTableOffset";
-        private static readonly Selector sel_setIntersectionFunctionTableOffset = "setIntersectionFunctionTableOffset:";
-        private static readonly Selector sel_opaque = "opaque";
-        private static readonly Selector sel_setOpaque = "setOpaque:";
-        private static readonly Selector sel_allowDuplicateIntersectionFunctionInvocation = "allowDuplicateIntersectionFunctionInvocation";
-        private static readonly Selector sel_setAllowDuplicateIntersectionFunctionInvocation = "setAllowDuplicateIntersectionFunctionInvocation:";
-        private static readonly Selector sel_label = "label";
-        private static readonly Selector sel_setLabel = "setLabel:";
-        private static readonly Selector sel_primitiveDataBuffer = "primitiveDataBuffer";
-        private static readonly Selector sel_setPrimitiveDataBuffer = "setPrimitiveDataBuffer:";
-        private static readonly Selector sel_primitiveDataBufferOffset = "primitiveDataBufferOffset";
-        private static readonly Selector sel_setPrimitiveDataBufferOffset = "setPrimitiveDataBufferOffset:";
-        private static readonly Selector sel_primitiveDataStride = "primitiveDataStride";
-        private static readonly Selector sel_setPrimitiveDataStride = "setPrimitiveDataStride:";
-        private static readonly Selector sel_primitiveDataElementSize = "primitiveDataElementSize";
-        private static readonly Selector sel_setPrimitiveDataElementSize = "setPrimitiveDataElementSize:";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLAccelerationStructureMotionBoundingBoxGeometryDescriptor : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLAccelerationStructureMotionBoundingBoxGeometryDescriptor obj) => obj.NativePtr;
-        public static implicit operator MTLAccelerationStructureGeometryDescriptor(MTLAccelerationStructureMotionBoundingBoxGeometryDescriptor obj) => new(obj.NativePtr);
-        public MTLAccelerationStructureMotionBoundingBoxGeometryDescriptor(IntPtr ptr) => NativePtr = ptr;
-
-        public MTLAccelerationStructureMotionBoundingBoxGeometryDescriptor()
-        {
-            var cls = new ObjectiveCClass("MTLAccelerationStructureMotionBoundingBoxGeometryDescriptor");
-            NativePtr = cls.AllocInit();
-        }
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public NSArray BoundingBoxBuffers
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_boundingBoxBuffers));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBoundingBoxBuffers, value);
-        }
-
-        public ulong BoundingBoxStride
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_boundingBoxStride);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBoundingBoxStride, value);
-        }
-
-        public ulong BoundingBoxCount
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_boundingBoxCount);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBoundingBoxCount, value);
-        }
-
-        public ulong IntersectionFunctionTableOffset
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_intersectionFunctionTableOffset);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIntersectionFunctionTableOffset, value);
-        }
-
-        public bool Opaque
-        {
-            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_opaque);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setOpaque, value);
-        }
-
-        public bool AllowDuplicateIntersectionFunctionInvocation
-        {
-            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_allowDuplicateIntersectionFunctionInvocation);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setAllowDuplicateIntersectionFunctionInvocation, value);
-        }
-
-        public NSString Label
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
-        }
-
-        public MTLBuffer PrimitiveDataBuffer
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_primitiveDataBuffer));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataBuffer, value);
-        }
-
-        public ulong PrimitiveDataBufferOffset
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_primitiveDataBufferOffset);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataBufferOffset, value);
-        }
-
-        public ulong PrimitiveDataStride
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_primitiveDataStride);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataStride, value);
-        }
-
-        public ulong PrimitiveDataElementSize
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_primitiveDataElementSize);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataElementSize, value);
-        }
-
-        private static readonly Selector sel_boundingBoxBuffers = "boundingBoxBuffers";
-        private static readonly Selector sel_setBoundingBoxBuffers = "setBoundingBoxBuffers:";
-        private static readonly Selector sel_boundingBoxStride = "boundingBoxStride";
-        private static readonly Selector sel_setBoundingBoxStride = "setBoundingBoxStride:";
-        private static readonly Selector sel_boundingBoxCount = "boundingBoxCount";
-        private static readonly Selector sel_setBoundingBoxCount = "setBoundingBoxCount:";
-        private static readonly Selector sel_descriptor = "descriptor";
-        private static readonly Selector sel_intersectionFunctionTableOffset = "intersectionFunctionTableOffset";
-        private static readonly Selector sel_setIntersectionFunctionTableOffset = "setIntersectionFunctionTableOffset:";
-        private static readonly Selector sel_opaque = "opaque";
-        private static readonly Selector sel_setOpaque = "setOpaque:";
-        private static readonly Selector sel_allowDuplicateIntersectionFunctionInvocation = "allowDuplicateIntersectionFunctionInvocation";
-        private static readonly Selector sel_setAllowDuplicateIntersectionFunctionInvocation = "setAllowDuplicateIntersectionFunctionInvocation:";
-        private static readonly Selector sel_label = "label";
-        private static readonly Selector sel_setLabel = "setLabel:";
-        private static readonly Selector sel_primitiveDataBuffer = "primitiveDataBuffer";
-        private static readonly Selector sel_setPrimitiveDataBuffer = "setPrimitiveDataBuffer:";
-        private static readonly Selector sel_primitiveDataBufferOffset = "primitiveDataBufferOffset";
-        private static readonly Selector sel_setPrimitiveDataBufferOffset = "setPrimitiveDataBufferOffset:";
-        private static readonly Selector sel_primitiveDataStride = "primitiveDataStride";
-        private static readonly Selector sel_setPrimitiveDataStride = "setPrimitiveDataStride:";
-        private static readonly Selector sel_primitiveDataElementSize = "primitiveDataElementSize";
-        private static readonly Selector sel_setPrimitiveDataElementSize = "setPrimitiveDataElementSize:";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLAccelerationStructureCurveGeometryDescriptor : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLAccelerationStructureCurveGeometryDescriptor obj) => obj.NativePtr;
-        public static implicit operator MTLAccelerationStructureGeometryDescriptor(MTLAccelerationStructureCurveGeometryDescriptor obj) => new(obj.NativePtr);
-        public MTLAccelerationStructureCurveGeometryDescriptor(IntPtr ptr) => NativePtr = ptr;
-
-        public MTLAccelerationStructureCurveGeometryDescriptor()
-        {
-            var cls = new ObjectiveCClass("MTLAccelerationStructureCurveGeometryDescriptor");
-            NativePtr = cls.AllocInit();
-        }
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public MTLBuffer ControlPointBuffer
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_controlPointBuffer));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setControlPointBuffer, value);
-        }
-
-        public ulong ControlPointBufferOffset
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_controlPointBufferOffset);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setControlPointBufferOffset, value);
-        }
-
-        public ulong ControlPointCount
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_controlPointCount);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setControlPointCount, value);
-        }
-
-        public ulong ControlPointStride
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_controlPointStride);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setControlPointStride, value);
-        }
-
-        public MTLAttributeFormat ControlPointFormat
-        {
-            get => (MTLAttributeFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_controlPointFormat);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setControlPointFormat, (ulong)value);
-        }
-
-        public MTLBuffer RadiusBuffer
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_radiusBuffer));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRadiusBuffer, value);
-        }
-
-        public ulong RadiusBufferOffset
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_radiusBufferOffset);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRadiusBufferOffset, value);
-        }
-
-        public MTLAttributeFormat RadiusFormat
-        {
-            get => (MTLAttributeFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_radiusFormat);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRadiusFormat, (ulong)value);
-        }
-
-        public ulong RadiusStride
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_radiusStride);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRadiusStride, value);
-        }
-
-        public MTLBuffer IndexBuffer
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_indexBuffer));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIndexBuffer, value);
-        }
-
-        public ulong IndexBufferOffset
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_indexBufferOffset);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIndexBufferOffset, value);
-        }
-
-        public MTLIndexType IndexType
-        {
-            get => (MTLIndexType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_indexType);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIndexType, (ulong)value);
-        }
-
-        public ulong SegmentCount
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_segmentCount);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSegmentCount, value);
-        }
-
-        public ulong SegmentControlPointCount
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_segmentControlPointCount);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSegmentControlPointCount, value);
-        }
-
-        public MTLCurveType CurveType
-        {
-            get => (MTLCurveType)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_curveType);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setCurveType, (long)value);
-        }
-
-        public MTLCurveBasis CurveBasis
-        {
-            get => (MTLCurveBasis)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_curveBasis);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setCurveBasis, (long)value);
-        }
-
-        public MTLCurveEndCaps CurveEndCaps
-        {
-            get => (MTLCurveEndCaps)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_curveEndCaps);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setCurveEndCaps, (long)value);
-        }
-
-        public ulong IntersectionFunctionTableOffset
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_intersectionFunctionTableOffset);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIntersectionFunctionTableOffset, value);
-        }
-
-        public bool Opaque
-        {
-            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_opaque);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setOpaque, value);
-        }
-
-        public bool AllowDuplicateIntersectionFunctionInvocation
-        {
-            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_allowDuplicateIntersectionFunctionInvocation);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setAllowDuplicateIntersectionFunctionInvocation, value);
-        }
-
-        public NSString Label
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
-        }
-
-        public MTLBuffer PrimitiveDataBuffer
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_primitiveDataBuffer));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataBuffer, value);
-        }
-
-        public ulong PrimitiveDataBufferOffset
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_primitiveDataBufferOffset);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataBufferOffset, value);
-        }
-
-        public ulong PrimitiveDataStride
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_primitiveDataStride);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataStride, value);
-        }
-
-        public ulong PrimitiveDataElementSize
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_primitiveDataElementSize);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataElementSize, value);
-        }
-
-        private static readonly Selector sel_controlPointBuffer = "controlPointBuffer";
-        private static readonly Selector sel_setControlPointBuffer = "setControlPointBuffer:";
-        private static readonly Selector sel_controlPointBufferOffset = "controlPointBufferOffset";
-        private static readonly Selector sel_setControlPointBufferOffset = "setControlPointBufferOffset:";
-        private static readonly Selector sel_controlPointCount = "controlPointCount";
-        private static readonly Selector sel_setControlPointCount = "setControlPointCount:";
-        private static readonly Selector sel_controlPointStride = "controlPointStride";
-        private static readonly Selector sel_setControlPointStride = "setControlPointStride:";
-        private static readonly Selector sel_controlPointFormat = "controlPointFormat";
-        private static readonly Selector sel_setControlPointFormat = "setControlPointFormat:";
-        private static readonly Selector sel_radiusBuffer = "radiusBuffer";
-        private static readonly Selector sel_setRadiusBuffer = "setRadiusBuffer:";
-        private static readonly Selector sel_radiusBufferOffset = "radiusBufferOffset";
-        private static readonly Selector sel_setRadiusBufferOffset = "setRadiusBufferOffset:";
-        private static readonly Selector sel_radiusFormat = "radiusFormat";
-        private static readonly Selector sel_setRadiusFormat = "setRadiusFormat:";
-        private static readonly Selector sel_radiusStride = "radiusStride";
-        private static readonly Selector sel_setRadiusStride = "setRadiusStride:";
-        private static readonly Selector sel_indexBuffer = "indexBuffer";
-        private static readonly Selector sel_setIndexBuffer = "setIndexBuffer:";
-        private static readonly Selector sel_indexBufferOffset = "indexBufferOffset";
-        private static readonly Selector sel_setIndexBufferOffset = "setIndexBufferOffset:";
-        private static readonly Selector sel_indexType = "indexType";
-        private static readonly Selector sel_setIndexType = "setIndexType:";
-        private static readonly Selector sel_segmentCount = "segmentCount";
-        private static readonly Selector sel_setSegmentCount = "setSegmentCount:";
-        private static readonly Selector sel_segmentControlPointCount = "segmentControlPointCount";
-        private static readonly Selector sel_setSegmentControlPointCount = "setSegmentControlPointCount:";
-        private static readonly Selector sel_curveType = "curveType";
-        private static readonly Selector sel_setCurveType = "setCurveType:";
-        private static readonly Selector sel_curveBasis = "curveBasis";
-        private static readonly Selector sel_setCurveBasis = "setCurveBasis:";
-        private static readonly Selector sel_curveEndCaps = "curveEndCaps";
-        private static readonly Selector sel_setCurveEndCaps = "setCurveEndCaps:";
-        private static readonly Selector sel_descriptor = "descriptor";
-        private static readonly Selector sel_intersectionFunctionTableOffset = "intersectionFunctionTableOffset";
-        private static readonly Selector sel_setIntersectionFunctionTableOffset = "setIntersectionFunctionTableOffset:";
-        private static readonly Selector sel_opaque = "opaque";
-        private static readonly Selector sel_setOpaque = "setOpaque:";
-        private static readonly Selector sel_allowDuplicateIntersectionFunctionInvocation = "allowDuplicateIntersectionFunctionInvocation";
-        private static readonly Selector sel_setAllowDuplicateIntersectionFunctionInvocation = "setAllowDuplicateIntersectionFunctionInvocation:";
-        private static readonly Selector sel_label = "label";
-        private static readonly Selector sel_setLabel = "setLabel:";
-        private static readonly Selector sel_primitiveDataBuffer = "primitiveDataBuffer";
-        private static readonly Selector sel_setPrimitiveDataBuffer = "setPrimitiveDataBuffer:";
-        private static readonly Selector sel_primitiveDataBufferOffset = "primitiveDataBufferOffset";
-        private static readonly Selector sel_setPrimitiveDataBufferOffset = "setPrimitiveDataBufferOffset:";
-        private static readonly Selector sel_primitiveDataStride = "primitiveDataStride";
-        private static readonly Selector sel_setPrimitiveDataStride = "setPrimitiveDataStride:";
-        private static readonly Selector sel_primitiveDataElementSize = "primitiveDataElementSize";
-        private static readonly Selector sel_setPrimitiveDataElementSize = "setPrimitiveDataElementSize:";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLAccelerationStructureMotionCurveGeometryDescriptor : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLAccelerationStructureMotionCurveGeometryDescriptor obj) => obj.NativePtr;
-        public static implicit operator MTLAccelerationStructureGeometryDescriptor(MTLAccelerationStructureMotionCurveGeometryDescriptor obj) => new(obj.NativePtr);
-        public MTLAccelerationStructureMotionCurveGeometryDescriptor(IntPtr ptr) => NativePtr = ptr;
-
-        public MTLAccelerationStructureMotionCurveGeometryDescriptor()
-        {
-            var cls = new ObjectiveCClass("MTLAccelerationStructureMotionCurveGeometryDescriptor");
-            NativePtr = cls.AllocInit();
-        }
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public NSArray ControlPointBuffers
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_controlPointBuffers));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setControlPointBuffers, value);
-        }
-
-        public ulong ControlPointCount
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_controlPointCount);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setControlPointCount, value);
-        }
-
-        public ulong ControlPointStride
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_controlPointStride);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setControlPointStride, value);
-        }
-
-        public MTLAttributeFormat ControlPointFormat
-        {
-            get => (MTLAttributeFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_controlPointFormat);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setControlPointFormat, (ulong)value);
-        }
-
-        public NSArray RadiusBuffers
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_radiusBuffers));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRadiusBuffers, value);
-        }
-
-        public MTLAttributeFormat RadiusFormat
-        {
-            get => (MTLAttributeFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_radiusFormat);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRadiusFormat, (ulong)value);
-        }
-
-        public ulong RadiusStride
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_radiusStride);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRadiusStride, value);
-        }
-
-        public MTLBuffer IndexBuffer
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_indexBuffer));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIndexBuffer, value);
-        }
-
-        public ulong IndexBufferOffset
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_indexBufferOffset);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIndexBufferOffset, value);
-        }
-
-        public MTLIndexType IndexType
-        {
-            get => (MTLIndexType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_indexType);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIndexType, (ulong)value);
-        }
-
-        public ulong SegmentCount
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_segmentCount);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSegmentCount, value);
-        }
-
-        public ulong SegmentControlPointCount
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_segmentControlPointCount);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSegmentControlPointCount, value);
-        }
-
-        public MTLCurveType CurveType
-        {
-            get => (MTLCurveType)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_curveType);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setCurveType, (long)value);
-        }
-
-        public MTLCurveBasis CurveBasis
-        {
-            get => (MTLCurveBasis)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_curveBasis);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setCurveBasis, (long)value);
-        }
-
-        public MTLCurveEndCaps CurveEndCaps
-        {
-            get => (MTLCurveEndCaps)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_curveEndCaps);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setCurveEndCaps, (long)value);
-        }
-
-        public ulong IntersectionFunctionTableOffset
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_intersectionFunctionTableOffset);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIntersectionFunctionTableOffset, value);
-        }
-
-        public bool Opaque
-        {
-            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_opaque);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setOpaque, value);
-        }
-
-        public bool AllowDuplicateIntersectionFunctionInvocation
-        {
-            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_allowDuplicateIntersectionFunctionInvocation);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setAllowDuplicateIntersectionFunctionInvocation, value);
-        }
-
-        public NSString Label
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
-        }
-
-        public MTLBuffer PrimitiveDataBuffer
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_primitiveDataBuffer));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataBuffer, value);
-        }
-
-        public ulong PrimitiveDataBufferOffset
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_primitiveDataBufferOffset);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataBufferOffset, value);
-        }
-
-        public ulong PrimitiveDataStride
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_primitiveDataStride);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataStride, value);
-        }
-
-        public ulong PrimitiveDataElementSize
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_primitiveDataElementSize);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrimitiveDataElementSize, value);
-        }
-
-        private static readonly Selector sel_controlPointBuffers = "controlPointBuffers";
-        private static readonly Selector sel_setControlPointBuffers = "setControlPointBuffers:";
-        private static readonly Selector sel_controlPointCount = "controlPointCount";
-        private static readonly Selector sel_setControlPointCount = "setControlPointCount:";
-        private static readonly Selector sel_controlPointStride = "controlPointStride";
-        private static readonly Selector sel_setControlPointStride = "setControlPointStride:";
-        private static readonly Selector sel_controlPointFormat = "controlPointFormat";
-        private static readonly Selector sel_setControlPointFormat = "setControlPointFormat:";
-        private static readonly Selector sel_radiusBuffers = "radiusBuffers";
-        private static readonly Selector sel_setRadiusBuffers = "setRadiusBuffers:";
-        private static readonly Selector sel_radiusFormat = "radiusFormat";
-        private static readonly Selector sel_setRadiusFormat = "setRadiusFormat:";
-        private static readonly Selector sel_radiusStride = "radiusStride";
-        private static readonly Selector sel_setRadiusStride = "setRadiusStride:";
-        private static readonly Selector sel_indexBuffer = "indexBuffer";
-        private static readonly Selector sel_setIndexBuffer = "setIndexBuffer:";
-        private static readonly Selector sel_indexBufferOffset = "indexBufferOffset";
-        private static readonly Selector sel_setIndexBufferOffset = "setIndexBufferOffset:";
-        private static readonly Selector sel_indexType = "indexType";
-        private static readonly Selector sel_setIndexType = "setIndexType:";
-        private static readonly Selector sel_segmentCount = "segmentCount";
-        private static readonly Selector sel_setSegmentCount = "setSegmentCount:";
-        private static readonly Selector sel_segmentControlPointCount = "segmentControlPointCount";
-        private static readonly Selector sel_setSegmentControlPointCount = "setSegmentControlPointCount:";
-        private static readonly Selector sel_curveType = "curveType";
-        private static readonly Selector sel_setCurveType = "setCurveType:";
-        private static readonly Selector sel_curveBasis = "curveBasis";
-        private static readonly Selector sel_setCurveBasis = "setCurveBasis:";
-        private static readonly Selector sel_curveEndCaps = "curveEndCaps";
-        private static readonly Selector sel_setCurveEndCaps = "setCurveEndCaps:";
-        private static readonly Selector sel_descriptor = "descriptor";
-        private static readonly Selector sel_intersectionFunctionTableOffset = "intersectionFunctionTableOffset";
-        private static readonly Selector sel_setIntersectionFunctionTableOffset = "setIntersectionFunctionTableOffset:";
-        private static readonly Selector sel_opaque = "opaque";
-        private static readonly Selector sel_setOpaque = "setOpaque:";
-        private static readonly Selector sel_allowDuplicateIntersectionFunctionInvocation = "allowDuplicateIntersectionFunctionInvocation";
-        private static readonly Selector sel_setAllowDuplicateIntersectionFunctionInvocation = "setAllowDuplicateIntersectionFunctionInvocation:";
-        private static readonly Selector sel_label = "label";
-        private static readonly Selector sel_setLabel = "setLabel:";
-        private static readonly Selector sel_primitiveDataBuffer = "primitiveDataBuffer";
-        private static readonly Selector sel_setPrimitiveDataBuffer = "setPrimitiveDataBuffer:";
-        private static readonly Selector sel_primitiveDataBufferOffset = "primitiveDataBufferOffset";
-        private static readonly Selector sel_setPrimitiveDataBufferOffset = "setPrimitiveDataBufferOffset:";
-        private static readonly Selector sel_primitiveDataStride = "primitiveDataStride";
-        private static readonly Selector sel_setPrimitiveDataStride = "setPrimitiveDataStride:";
-        private static readonly Selector sel_primitiveDataElementSize = "primitiveDataElementSize";
-        private static readonly Selector sel_setPrimitiveDataElementSize = "setPrimitiveDataElementSize:";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLInstanceAccelerationStructureDescriptor : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLInstanceAccelerationStructureDescriptor obj) => obj.NativePtr;
-        public static implicit operator MTLAccelerationStructureDescriptor(MTLInstanceAccelerationStructureDescriptor obj) => new(obj.NativePtr);
-        public MTLInstanceAccelerationStructureDescriptor(IntPtr ptr) => NativePtr = ptr;
-
-        public MTLInstanceAccelerationStructureDescriptor()
-        {
-            var cls = new ObjectiveCClass("MTLInstanceAccelerationStructureDescriptor");
-            NativePtr = cls.AllocInit();
-        }
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public MTLBuffer InstanceDescriptorBuffer
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_instanceDescriptorBuffer));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setInstanceDescriptorBuffer, value);
-        }
-
-        public ulong InstanceDescriptorBufferOffset
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_instanceDescriptorBufferOffset);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setInstanceDescriptorBufferOffset, value);
-        }
-
-        public ulong InstanceDescriptorStride
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_instanceDescriptorStride);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setInstanceDescriptorStride, value);
-        }
-
-        public ulong InstanceCount
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_instanceCount);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setInstanceCount, value);
-        }
-
-        public NSArray InstancedAccelerationStructures
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_instancedAccelerationStructures));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setInstancedAccelerationStructures, value);
-        }
-
-        public MTLAccelerationStructureInstanceDescriptorType InstanceDescriptorType
-        {
-            get => (MTLAccelerationStructureInstanceDescriptorType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_instanceDescriptorType);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setInstanceDescriptorType, (ulong)value);
-        }
-
-        public MTLBuffer MotionTransformBuffer
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_motionTransformBuffer));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMotionTransformBuffer, value);
-        }
-
-        public ulong MotionTransformBufferOffset
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_motionTransformBufferOffset);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMotionTransformBufferOffset, value);
-        }
-
-        public ulong MotionTransformCount
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_motionTransformCount);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMotionTransformCount, value);
+            get => ObjectiveCRuntime.float_objc_msgSend(NativePtr, sel_motionStartTime);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMotionStartTime, value);
         }
 
         public MTLAccelerationStructureUsage Usage
@@ -1432,223 +1634,21 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setUsage, (ulong)value);
         }
 
-        private static readonly Selector sel_instanceDescriptorBuffer = "instanceDescriptorBuffer";
-        private static readonly Selector sel_setInstanceDescriptorBuffer = "setInstanceDescriptorBuffer:";
-        private static readonly Selector sel_instanceDescriptorBufferOffset = "instanceDescriptorBufferOffset";
-        private static readonly Selector sel_setInstanceDescriptorBufferOffset = "setInstanceDescriptorBufferOffset:";
-        private static readonly Selector sel_instanceDescriptorStride = "instanceDescriptorStride";
-        private static readonly Selector sel_setInstanceDescriptorStride = "setInstanceDescriptorStride:";
-        private static readonly Selector sel_instanceCount = "instanceCount";
-        private static readonly Selector sel_setInstanceCount = "setInstanceCount:";
-        private static readonly Selector sel_instancedAccelerationStructures = "instancedAccelerationStructures";
-        private static readonly Selector sel_setInstancedAccelerationStructures = "setInstancedAccelerationStructures:";
-        private static readonly Selector sel_instanceDescriptorType = "instanceDescriptorType";
-        private static readonly Selector sel_setInstanceDescriptorType = "setInstanceDescriptorType:";
-        private static readonly Selector sel_motionTransformBuffer = "motionTransformBuffer";
-        private static readonly Selector sel_setMotionTransformBuffer = "setMotionTransformBuffer:";
-        private static readonly Selector sel_motionTransformBufferOffset = "motionTransformBufferOffset";
-        private static readonly Selector sel_setMotionTransformBufferOffset = "setMotionTransformBufferOffset:";
-        private static readonly Selector sel_motionTransformCount = "motionTransformCount";
-        private static readonly Selector sel_setMotionTransformCount = "setMotionTransformCount:";
         private static readonly Selector sel_descriptor = "descriptor";
-        private static readonly Selector sel_usage = "usage";
+        private static readonly Selector sel_geometryDescriptors = "geometryDescriptors";
+        private static readonly Selector sel_motionEndBorderMode = "motionEndBorderMode";
+        private static readonly Selector sel_motionEndTime = "motionEndTime";
+        private static readonly Selector sel_motionKeyframeCount = "motionKeyframeCount";
+        private static readonly Selector sel_motionStartBorderMode = "motionStartBorderMode";
+        private static readonly Selector sel_motionStartTime = "motionStartTime";
+        private static readonly Selector sel_setGeometryDescriptors = "setGeometryDescriptors:";
+        private static readonly Selector sel_setMotionEndBorderMode = "setMotionEndBorderMode:";
+        private static readonly Selector sel_setMotionEndTime = "setMotionEndTime:";
+        private static readonly Selector sel_setMotionKeyframeCount = "setMotionKeyframeCount:";
+        private static readonly Selector sel_setMotionStartBorderMode = "setMotionStartBorderMode:";
+        private static readonly Selector sel_setMotionStartTime = "setMotionStartTime:";
         private static readonly Selector sel_setUsage = "setUsage:";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLIndirectInstanceAccelerationStructureDescriptor : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLIndirectInstanceAccelerationStructureDescriptor obj) => obj.NativePtr;
-        public static implicit operator MTLAccelerationStructureDescriptor(MTLIndirectInstanceAccelerationStructureDescriptor obj) => new(obj.NativePtr);
-        public MTLIndirectInstanceAccelerationStructureDescriptor(IntPtr ptr) => NativePtr = ptr;
-
-        public MTLIndirectInstanceAccelerationStructureDescriptor()
-        {
-            var cls = new ObjectiveCClass("MTLIndirectInstanceAccelerationStructureDescriptor");
-            NativePtr = cls.AllocInit();
-        }
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public MTLBuffer InstanceDescriptorBuffer
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_instanceDescriptorBuffer));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setInstanceDescriptorBuffer, value);
-        }
-
-        public ulong InstanceDescriptorBufferOffset
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_instanceDescriptorBufferOffset);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setInstanceDescriptorBufferOffset, value);
-        }
-
-        public ulong InstanceDescriptorStride
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_instanceDescriptorStride);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setInstanceDescriptorStride, value);
-        }
-
-        public ulong MaxInstanceCount
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxInstanceCount);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxInstanceCount, value);
-        }
-
-        public MTLBuffer InstanceCountBuffer
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_instanceCountBuffer));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setInstanceCountBuffer, value);
-        }
-
-        public ulong InstanceCountBufferOffset
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_instanceCountBufferOffset);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setInstanceCountBufferOffset, value);
-        }
-
-        public MTLAccelerationStructureInstanceDescriptorType InstanceDescriptorType
-        {
-            get => (MTLAccelerationStructureInstanceDescriptorType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_instanceDescriptorType);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setInstanceDescriptorType, (ulong)value);
-        }
-
-        public MTLBuffer MotionTransformBuffer
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_motionTransformBuffer));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMotionTransformBuffer, value);
-        }
-
-        public ulong MotionTransformBufferOffset
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_motionTransformBufferOffset);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMotionTransformBufferOffset, value);
-        }
-
-        public ulong MaxMotionTransformCount
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxMotionTransformCount);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxMotionTransformCount, value);
-        }
-
-        public MTLBuffer MotionTransformCountBuffer
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_motionTransformCountBuffer));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMotionTransformCountBuffer, value);
-        }
-
-        public ulong MotionTransformCountBufferOffset
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_motionTransformCountBufferOffset);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMotionTransformCountBufferOffset, value);
-        }
-
-        public MTLAccelerationStructureUsage Usage
-        {
-            get => (MTLAccelerationStructureUsage)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_usage);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setUsage, (ulong)value);
-        }
-
-        private static readonly Selector sel_instanceDescriptorBuffer = "instanceDescriptorBuffer";
-        private static readonly Selector sel_setInstanceDescriptorBuffer = "setInstanceDescriptorBuffer:";
-        private static readonly Selector sel_instanceDescriptorBufferOffset = "instanceDescriptorBufferOffset";
-        private static readonly Selector sel_setInstanceDescriptorBufferOffset = "setInstanceDescriptorBufferOffset:";
-        private static readonly Selector sel_instanceDescriptorStride = "instanceDescriptorStride";
-        private static readonly Selector sel_setInstanceDescriptorStride = "setInstanceDescriptorStride:";
-        private static readonly Selector sel_maxInstanceCount = "maxInstanceCount";
-        private static readonly Selector sel_setMaxInstanceCount = "setMaxInstanceCount:";
-        private static readonly Selector sel_instanceCountBuffer = "instanceCountBuffer";
-        private static readonly Selector sel_setInstanceCountBuffer = "setInstanceCountBuffer:";
-        private static readonly Selector sel_instanceCountBufferOffset = "instanceCountBufferOffset";
-        private static readonly Selector sel_setInstanceCountBufferOffset = "setInstanceCountBufferOffset:";
-        private static readonly Selector sel_instanceDescriptorType = "instanceDescriptorType";
-        private static readonly Selector sel_setInstanceDescriptorType = "setInstanceDescriptorType:";
-        private static readonly Selector sel_motionTransformBuffer = "motionTransformBuffer";
-        private static readonly Selector sel_setMotionTransformBuffer = "setMotionTransformBuffer:";
-        private static readonly Selector sel_motionTransformBufferOffset = "motionTransformBufferOffset";
-        private static readonly Selector sel_setMotionTransformBufferOffset = "setMotionTransformBufferOffset:";
-        private static readonly Selector sel_maxMotionTransformCount = "maxMotionTransformCount";
-        private static readonly Selector sel_setMaxMotionTransformCount = "setMaxMotionTransformCount:";
-        private static readonly Selector sel_motionTransformCountBuffer = "motionTransformCountBuffer";
-        private static readonly Selector sel_setMotionTransformCountBuffer = "setMotionTransformCountBuffer:";
-        private static readonly Selector sel_motionTransformCountBufferOffset = "motionTransformCountBufferOffset";
-        private static readonly Selector sel_setMotionTransformCountBufferOffset = "setMotionTransformCountBufferOffset:";
-        private static readonly Selector sel_descriptor = "descriptor";
         private static readonly Selector sel_usage = "usage";
-        private static readonly Selector sel_setUsage = "setUsage:";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLAccelerationStructure : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLAccelerationStructure obj) => obj.NativePtr;
-        public static implicit operator MTLResource(MTLAccelerationStructure obj) => new(obj.NativePtr);
-        public MTLAccelerationStructure(IntPtr ptr) => NativePtr = ptr;
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public ulong Size => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_size);
-
-        public MTLResourceID GpuResourceID => ObjectiveCRuntime.MTLResourceID_objc_msgSend(NativePtr, sel_gpuResourceID);
-
-        public NSString Label
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
-        }
-
-        public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
-
-        public MTLCPUCacheMode CpuCacheMode => (MTLCPUCacheMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_cpuCacheMode);
-
-        public MTLStorageMode StorageMode => (MTLStorageMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_storageMode);
-
-        public MTLHazardTrackingMode HazardTrackingMode => (MTLHazardTrackingMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_hazardTrackingMode);
-
-        public MTLResourceOptions ResourceOptions => (MTLResourceOptions)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_resourceOptions);
-
-        public MTLHeap Heap => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_heap));
-
-        public ulong HeapOffset => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_heapOffset);
-
-        public ulong AllocatedSize => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_allocatedSize);
-
-        public bool IsAliasable => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isAliasable);
-
-        public MTLPurgeableState SetPurgeableState(MTLPurgeableState state)
-        {
-            return (MTLPurgeableState)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_setPurgeableState, (ulong)state);
-        }
-
-        public void MakeAliasable()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_makeAliasable);
-        }
-
-        private static readonly Selector sel_size = "size";
-        private static readonly Selector sel_gpuResourceID = "gpuResourceID";
-        private static readonly Selector sel_label = "label";
-        private static readonly Selector sel_setLabel = "setLabel:";
-        private static readonly Selector sel_device = "device";
-        private static readonly Selector sel_cpuCacheMode = "cpuCacheMode";
-        private static readonly Selector sel_storageMode = "storageMode";
-        private static readonly Selector sel_hazardTrackingMode = "hazardTrackingMode";
-        private static readonly Selector sel_resourceOptions = "resourceOptions";
-        private static readonly Selector sel_setPurgeableState = "setPurgeableState:";
-        private static readonly Selector sel_heap = "heap";
-        private static readonly Selector sel_heapOffset = "heapOffset";
-        private static readonly Selector sel_allocatedSize = "allocatedSize";
-        private static readonly Selector sel_makeAliasable = "makeAliasable";
-        private static readonly Selector sel_isAliasable = "isAliasable";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLAccelerationStructureCommandEncoder.cs
+++ b/src/SharpMetal/Metal/MTLAccelerationStructureCommandEncoder.cs
@@ -38,69 +38,14 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_buildAccelerationStructuredescriptorscratchBufferscratchBufferOffset, accelerationStructure, descriptor, scratchBuffer, scratchBufferOffset);
         }
 
-        public void RefitAccelerationStructure(MTLAccelerationStructure sourceAccelerationStructure, MTLAccelerationStructureDescriptor descriptor, MTLAccelerationStructure destinationAccelerationStructure, MTLBuffer scratchBuffer, ulong scratchBufferOffset)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_refitAccelerationStructuredescriptordestinationscratchBufferscratchBufferOffset, sourceAccelerationStructure, descriptor, destinationAccelerationStructure, scratchBuffer, scratchBufferOffset);
-        }
-
-        public void RefitAccelerationStructure(MTLAccelerationStructure sourceAccelerationStructure, MTLAccelerationStructureDescriptor descriptor, MTLAccelerationStructure destinationAccelerationStructure, MTLBuffer scratchBuffer, ulong scratchBufferOffset, MTLAccelerationStructureRefitOptions options)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_refitAccelerationStructuredescriptordestinationscratchBufferscratchBufferOffsetoptions, sourceAccelerationStructure, descriptor, destinationAccelerationStructure, scratchBuffer, scratchBufferOffset, (ulong)options);
-        }
-
         public void CopyAccelerationStructure(MTLAccelerationStructure sourceAccelerationStructure, MTLAccelerationStructure destinationAccelerationStructure)
         {
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_copyAccelerationStructuretoAccelerationStructure, sourceAccelerationStructure, destinationAccelerationStructure);
         }
 
-        public void WriteCompactedAccelerationStructureSize(MTLAccelerationStructure accelerationStructure, MTLBuffer buffer, ulong offset)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_writeCompactedAccelerationStructureSizetoBufferoffset, accelerationStructure, buffer, offset);
-        }
-
-        public void WriteCompactedAccelerationStructureSize(MTLAccelerationStructure accelerationStructure, MTLBuffer buffer, ulong offset, MTLDataType sizeDataType)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_writeCompactedAccelerationStructureSizetoBufferoffsetsizeDataType, accelerationStructure, buffer, offset, (ulong)sizeDataType);
-        }
-
         public void CopyAndCompactAccelerationStructure(MTLAccelerationStructure sourceAccelerationStructure, MTLAccelerationStructure destinationAccelerationStructure)
         {
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_copyAndCompactAccelerationStructuretoAccelerationStructure, sourceAccelerationStructure, destinationAccelerationStructure);
-        }
-
-        public void UpdateFence(MTLFence fence)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_updateFence, fence);
-        }
-
-        public void WaitForFence(MTLFence fence)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_waitForFence, fence);
-        }
-
-        public void UseResource(MTLResource resource, MTLResourceUsage usage)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_useResourceusage, resource, (ulong)usage);
-        }
-
-        public void UseResources(MTLResource[] resources, ulong count, MTLResourceUsage usage)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void UseHeap(MTLHeap heap)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_useHeap, heap);
-        }
-
-        public void UseHeaps(MTLHeap[] heaps, ulong count)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void SampleCountersInBuffer(MTLCounterSampleBuffer sampleBuffer, ulong sampleIndex, bool barrier)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_sampleCountersInBufferatSampleIndexwithBarrier, sampleBuffer, sampleIndex, barrier);
         }
 
         public void EndEncoding()
@@ -113,37 +58,117 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_insertDebugSignpost, nsString);
         }
 
-        public void PushDebugGroup(NSString nsString)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_pushDebugGroup, nsString);
-        }
-
         public void PopDebugGroup()
         {
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_popDebugGroup);
         }
 
+        public void PushDebugGroup(NSString nsString)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_pushDebugGroup, nsString);
+        }
+
+        public void RefitAccelerationStructure(MTLAccelerationStructure sourceAccelerationStructure, MTLAccelerationStructureDescriptor descriptor, MTLAccelerationStructure destinationAccelerationStructure, MTLBuffer scratchBuffer, ulong scratchBufferOffset)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_refitAccelerationStructuredescriptordestinationscratchBufferscratchBufferOffset, sourceAccelerationStructure, descriptor, destinationAccelerationStructure, scratchBuffer, scratchBufferOffset);
+        }
+
+        public void RefitAccelerationStructure(MTLAccelerationStructure sourceAccelerationStructure, MTLAccelerationStructureDescriptor descriptor, MTLAccelerationStructure destinationAccelerationStructure, MTLBuffer scratchBuffer, ulong scratchBufferOffset, MTLAccelerationStructureRefitOptions options)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_refitAccelerationStructuredescriptordestinationscratchBufferscratchBufferOffsetoptions, sourceAccelerationStructure, descriptor, destinationAccelerationStructure, scratchBuffer, scratchBufferOffset, (ulong)options);
+        }
+
+        public void SampleCountersInBuffer(MTLCounterSampleBuffer sampleBuffer, ulong sampleIndex, bool barrier)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_sampleCountersInBufferatSampleIndexwithBarrier, sampleBuffer, sampleIndex, barrier);
+        }
+
+        public void UpdateFence(MTLFence fence)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_updateFence, fence);
+        }
+
+        public void UseHeap(MTLHeap heap)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_useHeap, heap);
+        }
+
+        public void UseHeaps(MTLHeap[] heaps, ulong count)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void UseResource(MTLResource resource, MTLResourceUsage usage)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_useResourceusage, resource, (ulong)usage);
+        }
+
+        public void UseResources(MTLResource[] resources, ulong count, MTLResourceUsage usage)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WaitForFence(MTLFence fence)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_waitForFence, fence);
+        }
+
+        public void WriteCompactedAccelerationStructureSize(MTLAccelerationStructure accelerationStructure, MTLBuffer buffer, ulong offset, MTLDataType sizeDataType)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_writeCompactedAccelerationStructureSizetoBufferoffsetsizeDataType, accelerationStructure, buffer, offset, (ulong)sizeDataType);
+        }
+
+        public void WriteCompactedAccelerationStructureSize(MTLAccelerationStructure accelerationStructure, MTLBuffer buffer, ulong offset)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_writeCompactedAccelerationStructureSizetoBufferoffset, accelerationStructure, buffer, offset);
+        }
+
         private static readonly Selector sel_buildAccelerationStructuredescriptorscratchBufferscratchBufferOffset = "buildAccelerationStructure:descriptor:scratchBuffer:scratchBufferOffset:";
-        private static readonly Selector sel_refitAccelerationStructuredescriptordestinationscratchBufferscratchBufferOffset = "refitAccelerationStructure:descriptor:destination:scratchBuffer:scratchBufferOffset:";
-        private static readonly Selector sel_refitAccelerationStructuredescriptordestinationscratchBufferscratchBufferOffsetoptions = "refitAccelerationStructure:descriptor:destination:scratchBuffer:scratchBufferOffset:options:";
         private static readonly Selector sel_copyAccelerationStructuretoAccelerationStructure = "copyAccelerationStructure:toAccelerationStructure:";
-        private static readonly Selector sel_writeCompactedAccelerationStructureSizetoBufferoffset = "writeCompactedAccelerationStructureSize:toBuffer:offset:";
-        private static readonly Selector sel_writeCompactedAccelerationStructureSizetoBufferoffsetsizeDataType = "writeCompactedAccelerationStructureSize:toBuffer:offset:sizeDataType:";
         private static readonly Selector sel_copyAndCompactAccelerationStructuretoAccelerationStructure = "copyAndCompactAccelerationStructure:toAccelerationStructure:";
-        private static readonly Selector sel_updateFence = "updateFence:";
-        private static readonly Selector sel_waitForFence = "waitForFence:";
-        private static readonly Selector sel_useResourceusage = "useResource:usage:";
-        private static readonly Selector sel_useResourcescountusage = "useResources:count:usage:";
-        private static readonly Selector sel_useHeap = "useHeap:";
-        private static readonly Selector sel_useHeapscount = "useHeaps:count:";
-        private static readonly Selector sel_sampleCountersInBufferatSampleIndexwithBarrier = "sampleCountersInBuffer:atSampleIndex:withBarrier:";
         private static readonly Selector sel_device = "device";
-        private static readonly Selector sel_label = "label";
-        private static readonly Selector sel_setLabel = "setLabel:";
         private static readonly Selector sel_endEncoding = "endEncoding";
         private static readonly Selector sel_insertDebugSignpost = "insertDebugSignpost:";
-        private static readonly Selector sel_pushDebugGroup = "pushDebugGroup:";
+        private static readonly Selector sel_label = "label";
         private static readonly Selector sel_popDebugGroup = "popDebugGroup";
+        private static readonly Selector sel_pushDebugGroup = "pushDebugGroup:";
+        private static readonly Selector sel_refitAccelerationStructuredescriptordestinationscratchBufferscratchBufferOffset = "refitAccelerationStructure:descriptor:destination:scratchBuffer:scratchBufferOffset:";
+        private static readonly Selector sel_refitAccelerationStructuredescriptordestinationscratchBufferscratchBufferOffsetoptions = "refitAccelerationStructure:descriptor:destination:scratchBuffer:scratchBufferOffset:options:";
+        private static readonly Selector sel_sampleCountersInBufferatSampleIndexwithBarrier = "sampleCountersInBuffer:atSampleIndex:withBarrier:";
+        private static readonly Selector sel_setLabel = "setLabel:";
+        private static readonly Selector sel_updateFence = "updateFence:";
+        private static readonly Selector sel_useHeap = "useHeap:";
+        private static readonly Selector sel_useHeapscount = "useHeaps:count:";
+        private static readonly Selector sel_useResourcescountusage = "useResources:count:usage:";
+        private static readonly Selector sel_useResourceusage = "useResource:usage:";
+        private static readonly Selector sel_waitForFence = "waitForFence:";
+        private static readonly Selector sel_writeCompactedAccelerationStructureSizetoBufferoffset = "writeCompactedAccelerationStructureSize:toBuffer:offset:";
+        private static readonly Selector sel_writeCompactedAccelerationStructureSizetoBufferoffsetsizeDataType = "writeCompactedAccelerationStructureSize:toBuffer:offset:sizeDataType:";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
+    public struct MTLAccelerationStructurePassDescriptor : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLAccelerationStructurePassDescriptor obj) => obj.NativePtr;
+        public MTLAccelerationStructurePassDescriptor(IntPtr ptr) => NativePtr = ptr;
+
+        public MTLAccelerationStructurePassDescriptor()
+        {
+            var cls = new ObjectiveCClass("MTLAccelerationStructurePassDescriptor");
+            NativePtr = cls.AllocInit();
+        }
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public MTLAccelerationStructurePassSampleBufferAttachmentDescriptorArray SampleBufferAttachments => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_sampleBufferAttachments));
+
+        private static readonly Selector sel_accelerationStructurePassDescriptor = "accelerationStructurePassDescriptor";
+        private static readonly Selector sel_sampleBufferAttachments = "sampleBufferAttachments";
         private static readonly Selector sel_release = "release";
     }
 
@@ -165,6 +190,12 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
+        public ulong EndOfEncoderSampleIndex
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_endOfEncoderSampleIndex);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setEndOfEncoderSampleIndex, value);
+        }
+
         public MTLCounterSampleBuffer SampleBuffer
         {
             get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_sampleBuffer));
@@ -177,18 +208,12 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStartOfEncoderSampleIndex, value);
         }
 
-        public ulong EndOfEncoderSampleIndex
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_endOfEncoderSampleIndex);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setEndOfEncoderSampleIndex, value);
-        }
-
-        private static readonly Selector sel_sampleBuffer = "sampleBuffer";
-        private static readonly Selector sel_setSampleBuffer = "setSampleBuffer:";
-        private static readonly Selector sel_startOfEncoderSampleIndex = "startOfEncoderSampleIndex";
-        private static readonly Selector sel_setStartOfEncoderSampleIndex = "setStartOfEncoderSampleIndex:";
         private static readonly Selector sel_endOfEncoderSampleIndex = "endOfEncoderSampleIndex";
+        private static readonly Selector sel_sampleBuffer = "sampleBuffer";
         private static readonly Selector sel_setEndOfEncoderSampleIndex = "setEndOfEncoderSampleIndex:";
+        private static readonly Selector sel_setSampleBuffer = "setSampleBuffer:";
+        private static readonly Selector sel_setStartOfEncoderSampleIndex = "setStartOfEncoderSampleIndex:";
+        private static readonly Selector sel_startOfEncoderSampleIndex = "startOfEncoderSampleIndex";
         private static readonly Selector sel_release = "release";
     }
 
@@ -222,31 +247,6 @@ namespace SharpMetal.Metal
 
         private static readonly Selector sel_objectAtIndexedSubscript = "objectAtIndexedSubscript:";
         private static readonly Selector sel_setObjectatIndexedSubscript = "setObject:atIndexedSubscript:";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLAccelerationStructurePassDescriptor : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLAccelerationStructurePassDescriptor obj) => obj.NativePtr;
-        public MTLAccelerationStructurePassDescriptor(IntPtr ptr) => NativePtr = ptr;
-
-        public MTLAccelerationStructurePassDescriptor()
-        {
-            var cls = new ObjectiveCClass("MTLAccelerationStructurePassDescriptor");
-            NativePtr = cls.AllocInit();
-        }
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public MTLAccelerationStructurePassSampleBufferAttachmentDescriptorArray SampleBufferAttachments => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_sampleBufferAttachments));
-
-        private static readonly Selector sel_accelerationStructurePassDescriptor = "accelerationStructurePassDescriptor";
-        private static readonly Selector sel_sampleBufferAttachments = "sampleBufferAttachments";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLAccelerationStructureTypes.cs
+++ b/src/SharpMetal/Metal/MTLAccelerationStructureTypes.cs
@@ -6,6 +6,14 @@ namespace SharpMetal.Metal
 {
     [SupportedOSPlatform("macos")]
     [StructLayout(LayoutKind.Sequential)]
+    public struct MTLAxisAlignedBoundingBox
+    {
+        public MTLPackedFloat3 min;
+        public MTLPackedFloat3 max;
+    }
+
+    [SupportedOSPlatform("macos")]
+    [StructLayout(LayoutKind.Sequential)]
     public struct MTLPackedFloat3
     {
         public float x;
@@ -18,13 +26,5 @@ namespace SharpMetal.Metal
     public struct MTLPackedFloat4x3
     {
         public MTLPackedFloat3 columns;
-    }
-
-    [SupportedOSPlatform("macos")]
-    [StructLayout(LayoutKind.Sequential)]
-    public struct MTLAxisAlignedBoundingBox
-    {
-        public MTLPackedFloat3 min;
-        public MTLPackedFloat3 max;
     }
 }

--- a/src/SharpMetal/Metal/MTLArgument.cs
+++ b/src/SharpMetal/Metal/MTLArgument.cs
@@ -5,6 +5,45 @@ using SharpMetal.Foundation;
 namespace SharpMetal.Metal
 {
     [SupportedOSPlatform("macos")]
+    public enum MTLArgumentType : ulong
+    {
+        Buffer = 0,
+        ThreadgroupMemory = 1,
+        Texture = 2,
+        Sampler = 3,
+        ImageblockData = 16,
+        Imageblock = 17,
+        VisibleFunctionTable = 24,
+        PrimitiveAccelerationStructure = 25,
+        InstanceAccelerationStructure = 26,
+        IntersectionFunctionTable = 27,
+    }
+
+    [SupportedOSPlatform("macos")]
+    public enum MTLBindingAccess : ulong
+    {
+        ReadOnly = 0,
+        ReadWrite = 1,
+        WriteOnly = 2,
+    }
+
+    [SupportedOSPlatform("macos")]
+    public enum MTLBindingType : long
+    {
+        Buffer = 0,
+        ThreadgroupMemory = 1,
+        Texture = 2,
+        Sampler = 3,
+        ImageblockData = 16,
+        Imageblock = 17,
+        VisibleFunctionTable = 24,
+        PrimitiveAccelerationStructure = 25,
+        InstanceAccelerationStructure = 26,
+        IntersectionFunctionTable = 27,
+        ObjectPayload = 34,
+    }
+
+    [SupportedOSPlatform("macos")]
     public enum MTLDataType : ulong
     {
         None = 0,
@@ -105,54 +144,15 @@ namespace SharpMetal.Metal
     }
 
     [SupportedOSPlatform("macos")]
-    public enum MTLBindingType : long
-    {
-        Buffer = 0,
-        ThreadgroupMemory = 1,
-        Texture = 2,
-        Sampler = 3,
-        ImageblockData = 16,
-        Imageblock = 17,
-        VisibleFunctionTable = 24,
-        PrimitiveAccelerationStructure = 25,
-        InstanceAccelerationStructure = 26,
-        IntersectionFunctionTable = 27,
-        ObjectPayload = 34,
-    }
-
-    [SupportedOSPlatform("macos")]
-    public enum MTLArgumentType : ulong
-    {
-        Buffer = 0,
-        ThreadgroupMemory = 1,
-        Texture = 2,
-        Sampler = 3,
-        ImageblockData = 16,
-        Imageblock = 17,
-        VisibleFunctionTable = 24,
-        PrimitiveAccelerationStructure = 25,
-        InstanceAccelerationStructure = 26,
-        IntersectionFunctionTable = 27,
-    }
-
-    [SupportedOSPlatform("macos")]
-    public enum MTLBindingAccess : ulong
-    {
-        ReadOnly = 0,
-        ReadWrite = 1,
-        WriteOnly = 2,
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLType : IDisposable
+    public struct MTLArgument : IDisposable
     {
         public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLType obj) => obj.NativePtr;
-        public MTLType(IntPtr ptr) => NativePtr = ptr;
+        public static implicit operator IntPtr(MTLArgument obj) => obj.NativePtr;
+        public MTLArgument(IntPtr ptr) => NativePtr = ptr;
 
-        public MTLType()
+        public MTLArgument()
         {
-            var cls = new ObjectiveCClass("MTLType");
+            var cls = new ObjectiveCClass("MTLArgument");
             NativePtr = cls.AllocInit();
         }
 
@@ -161,9 +161,263 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public MTLDataType DataType => (MTLDataType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_dataType);
+        public MTLBindingAccess Access => (MTLBindingAccess)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_access);
 
-        private static readonly Selector sel_dataType = "dataType";
+        public bool Active => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isActive);
+
+        public ulong ArrayLength => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_arrayLength);
+
+        public ulong BufferAlignment => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_bufferAlignment);
+
+        public ulong BufferDataSize => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_bufferDataSize);
+
+        public MTLDataType BufferDataType => (MTLDataType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_bufferDataType);
+
+        public MTLPointerType BufferPointerType => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_bufferPointerType));
+
+        public MTLStructType BufferStructType => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_bufferStructType));
+
+        public ulong Index => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_index);
+
+        public bool IsDepthTexture => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isDepthTexture);
+
+        public NSString Name => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_name));
+
+        public MTLDataType TextureDataType => (MTLDataType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_textureDataType);
+
+        public MTLTextureType TextureType => (MTLTextureType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_textureType);
+
+        public ulong ThreadgroupMemoryAlignment => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_threadgroupMemoryAlignment);
+
+        public ulong ThreadgroupMemoryDataSize => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_threadgroupMemoryDataSize);
+
+        public MTLArgumentType Type => (MTLArgumentType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_type);
+
+        private static readonly Selector sel_access = "access";
+        private static readonly Selector sel_arrayLength = "arrayLength";
+        private static readonly Selector sel_bufferAlignment = "bufferAlignment";
+        private static readonly Selector sel_bufferDataSize = "bufferDataSize";
+        private static readonly Selector sel_bufferDataType = "bufferDataType";
+        private static readonly Selector sel_bufferPointerType = "bufferPointerType";
+        private static readonly Selector sel_bufferStructType = "bufferStructType";
+        private static readonly Selector sel_index = "index";
+        private static readonly Selector sel_isActive = "isActive";
+        private static readonly Selector sel_isDepthTexture = "isDepthTexture";
+        private static readonly Selector sel_name = "name";
+        private static readonly Selector sel_textureDataType = "textureDataType";
+        private static readonly Selector sel_textureType = "textureType";
+        private static readonly Selector sel_threadgroupMemoryAlignment = "threadgroupMemoryAlignment";
+        private static readonly Selector sel_threadgroupMemoryDataSize = "threadgroupMemoryDataSize";
+        private static readonly Selector sel_type = "type";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
+    public struct MTLArrayType : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLArrayType obj) => obj.NativePtr;
+        public MTLArrayType(IntPtr ptr) => NativePtr = ptr;
+
+        public MTLArrayType()
+        {
+            var cls = new ObjectiveCClass("MTLArrayType");
+            NativePtr = cls.AllocInit();
+        }
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public ulong ArgumentIndexStride => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_argumentIndexStride);
+
+        public ulong ArrayLength => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_arrayLength);
+
+        public MTLArrayType ElementArrayType => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_elementArrayType));
+
+        public MTLPointerType ElementPointerType => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_elementPointerType));
+
+        public MTLStructType ElementStructType => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_elementStructType));
+
+        public MTLTextureReferenceType ElementTextureReferenceType => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_elementTextureReferenceType));
+
+        public MTLDataType ElementType => (MTLDataType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_elementType);
+
+        public ulong Stride => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_stride);
+
+        private static readonly Selector sel_argumentIndexStride = "argumentIndexStride";
+        private static readonly Selector sel_arrayLength = "arrayLength";
+        private static readonly Selector sel_elementArrayType = "elementArrayType";
+        private static readonly Selector sel_elementPointerType = "elementPointerType";
+        private static readonly Selector sel_elementStructType = "elementStructType";
+        private static readonly Selector sel_elementTextureReferenceType = "elementTextureReferenceType";
+        private static readonly Selector sel_elementType = "elementType";
+        private static readonly Selector sel_stride = "stride";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
+    public struct MTLBinding : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLBinding obj) => obj.NativePtr;
+        public MTLBinding(IntPtr ptr) => NativePtr = ptr;
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public MTLBindingAccess Access => (MTLBindingAccess)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_access);
+
+        public bool Argument => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isArgument);
+
+        public ulong Index => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_index);
+
+        public NSString Name => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_name));
+
+        public MTLBindingType Type => (MTLBindingType)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_type);
+
+        public bool Used => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isUsed);
+
+        private static readonly Selector sel_access = "access";
+        private static readonly Selector sel_index = "index";
+        private static readonly Selector sel_isArgument = "isArgument";
+        private static readonly Selector sel_isUsed = "isUsed";
+        private static readonly Selector sel_name = "name";
+        private static readonly Selector sel_type = "type";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
+    public struct MTLBufferBinding : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLBufferBinding obj) => obj.NativePtr;
+        public static implicit operator MTLBinding(MTLBufferBinding obj) => new(obj.NativePtr);
+        public MTLBufferBinding(IntPtr ptr) => NativePtr = ptr;
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public MTLBindingAccess Access => (MTLBindingAccess)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_access);
+
+        public bool Argument => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isArgument);
+
+        public ulong BufferAlignment => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_bufferAlignment);
+
+        public ulong BufferDataSize => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_bufferDataSize);
+
+        public MTLDataType BufferDataType => (MTLDataType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_bufferDataType);
+
+        public MTLPointerType BufferPointerType => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_bufferPointerType));
+
+        public MTLStructType BufferStructType => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_bufferStructType));
+
+        public ulong Index => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_index);
+
+        public NSString Name => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_name));
+
+        public MTLBindingType Type => (MTLBindingType)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_type);
+
+        public bool Used => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isUsed);
+
+        private static readonly Selector sel_access = "access";
+        private static readonly Selector sel_bufferAlignment = "bufferAlignment";
+        private static readonly Selector sel_bufferDataSize = "bufferDataSize";
+        private static readonly Selector sel_bufferDataType = "bufferDataType";
+        private static readonly Selector sel_bufferPointerType = "bufferPointerType";
+        private static readonly Selector sel_bufferStructType = "bufferStructType";
+        private static readonly Selector sel_index = "index";
+        private static readonly Selector sel_isArgument = "isArgument";
+        private static readonly Selector sel_isUsed = "isUsed";
+        private static readonly Selector sel_name = "name";
+        private static readonly Selector sel_type = "type";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
+    public struct MTLObjectPayloadBinding : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLObjectPayloadBinding obj) => obj.NativePtr;
+        public static implicit operator MTLBinding(MTLObjectPayloadBinding obj) => new(obj.NativePtr);
+        public MTLObjectPayloadBinding(IntPtr ptr) => NativePtr = ptr;
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public MTLBindingAccess Access => (MTLBindingAccess)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_access);
+
+        public bool Argument => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isArgument);
+
+        public ulong Index => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_index);
+
+        public NSString Name => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_name));
+
+        public ulong ObjectPayloadAlignment => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_objectPayloadAlignment);
+
+        public ulong ObjectPayloadDataSize => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_objectPayloadDataSize);
+
+        public MTLBindingType Type => (MTLBindingType)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_type);
+
+        public bool Used => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isUsed);
+
+        private static readonly Selector sel_access = "access";
+        private static readonly Selector sel_index = "index";
+        private static readonly Selector sel_isArgument = "isArgument";
+        private static readonly Selector sel_isUsed = "isUsed";
+        private static readonly Selector sel_name = "name";
+        private static readonly Selector sel_objectPayloadAlignment = "objectPayloadAlignment";
+        private static readonly Selector sel_objectPayloadDataSize = "objectPayloadDataSize";
+        private static readonly Selector sel_type = "type";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
+    public struct MTLPointerType : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLPointerType obj) => obj.NativePtr;
+        public MTLPointerType(IntPtr ptr) => NativePtr = ptr;
+
+        public MTLPointerType()
+        {
+            var cls = new ObjectiveCClass("MTLPointerType");
+            NativePtr = cls.AllocInit();
+        }
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public MTLBindingAccess Access => (MTLBindingAccess)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_access);
+
+        public ulong Alignment => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_alignment);
+
+        public ulong DataSize => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_dataSize);
+
+        public MTLArrayType ElementArrayType => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_elementArrayType));
+
+        public bool ElementIsArgumentBuffer => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_elementIsArgumentBuffer);
+
+        public MTLStructType ElementStructType => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_elementStructType));
+
+        public MTLDataType ElementType => (MTLDataType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_elementType);
+
+        private static readonly Selector sel_access = "access";
+        private static readonly Selector sel_alignment = "alignment";
+        private static readonly Selector sel_dataSize = "dataSize";
+        private static readonly Selector sel_elementArrayType = "elementArrayType";
+        private static readonly Selector sel_elementIsArgumentBuffer = "elementIsArgumentBuffer";
+        private static readonly Selector sel_elementStructType = "elementStructType";
+        private static readonly Selector sel_elementType = "elementType";
         private static readonly Selector sel_release = "release";
     }
 
@@ -185,30 +439,30 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
+        public ulong ArgumentIndex => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_argumentIndex);
+
+        public MTLArrayType ArrayType => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_arrayType));
+
+        public MTLDataType DataType => (MTLDataType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_dataType);
+
         public NSString Name => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_name));
 
         public ulong Offset => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_offset);
 
-        public MTLDataType DataType => (MTLDataType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_dataType);
+        public MTLPointerType PointerType => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_pointerType));
 
         public MTLStructType StructType => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_structType));
 
-        public MTLArrayType ArrayType => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_arrayType));
-
         public MTLTextureReferenceType TextureReferenceType => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_textureReferenceType));
 
-        public MTLPointerType PointerType => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_pointerType));
-
-        public ulong ArgumentIndex => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_argumentIndex);
-
+        private static readonly Selector sel_argumentIndex = "argumentIndex";
+        private static readonly Selector sel_arrayType = "arrayType";
+        private static readonly Selector sel_dataType = "dataType";
         private static readonly Selector sel_name = "name";
         private static readonly Selector sel_offset = "offset";
-        private static readonly Selector sel_dataType = "dataType";
-        private static readonly Selector sel_structType = "structType";
-        private static readonly Selector sel_arrayType = "arrayType";
-        private static readonly Selector sel_textureReferenceType = "textureReferenceType";
         private static readonly Selector sel_pointerType = "pointerType";
-        private static readonly Selector sel_argumentIndex = "argumentIndex";
+        private static readonly Selector sel_structType = "structType";
+        private static readonly Selector sel_textureReferenceType = "textureReferenceType";
         private static readonly Selector sel_release = "release";
     }
 
@@ -237,95 +491,54 @@ namespace SharpMetal.Metal
             return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_memberByName, name));
         }
 
-        private static readonly Selector sel_members = "members";
         private static readonly Selector sel_memberByName = "memberByName:";
+        private static readonly Selector sel_members = "members";
         private static readonly Selector sel_release = "release";
     }
 
     [SupportedOSPlatform("macos")]
-    public struct MTLArrayType : IDisposable
+    public struct MTLTextureBinding : IDisposable
     {
         public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLArrayType obj) => obj.NativePtr;
-        public MTLArrayType(IntPtr ptr) => NativePtr = ptr;
-
-        public MTLArrayType()
-        {
-            var cls = new ObjectiveCClass("MTLArrayType");
-            NativePtr = cls.AllocInit();
-        }
+        public static implicit operator IntPtr(MTLTextureBinding obj) => obj.NativePtr;
+        public static implicit operator MTLBinding(MTLTextureBinding obj) => new(obj.NativePtr);
+        public MTLTextureBinding(IntPtr ptr) => NativePtr = ptr;
 
         public void Dispose()
         {
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
-
-        public MTLDataType ElementType => (MTLDataType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_elementType);
-
-        public ulong ArrayLength => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_arrayLength);
-
-        public ulong Stride => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_stride);
-
-        public ulong ArgumentIndexStride => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_argumentIndexStride);
-
-        public MTLStructType ElementStructType => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_elementStructType));
-
-        public MTLArrayType ElementArrayType => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_elementArrayType));
-
-        public MTLTextureReferenceType ElementTextureReferenceType => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_elementTextureReferenceType));
-
-        public MTLPointerType ElementPointerType => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_elementPointerType));
-
-        private static readonly Selector sel_elementType = "elementType";
-        private static readonly Selector sel_arrayLength = "arrayLength";
-        private static readonly Selector sel_stride = "stride";
-        private static readonly Selector sel_argumentIndexStride = "argumentIndexStride";
-        private static readonly Selector sel_elementStructType = "elementStructType";
-        private static readonly Selector sel_elementArrayType = "elementArrayType";
-        private static readonly Selector sel_elementTextureReferenceType = "elementTextureReferenceType";
-        private static readonly Selector sel_elementPointerType = "elementPointerType";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLPointerType : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLPointerType obj) => obj.NativePtr;
-        public MTLPointerType(IntPtr ptr) => NativePtr = ptr;
-
-        public MTLPointerType()
-        {
-            var cls = new ObjectiveCClass("MTLPointerType");
-            NativePtr = cls.AllocInit();
-        }
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public MTLDataType ElementType => (MTLDataType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_elementType);
 
         public MTLBindingAccess Access => (MTLBindingAccess)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_access);
 
-        public ulong Alignment => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_alignment);
+        public bool Argument => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isArgument);
 
-        public ulong DataSize => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_dataSize);
+        public ulong ArrayLength => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_arrayLength);
 
-        public bool ElementIsArgumentBuffer => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_elementIsArgumentBuffer);
+        public bool DepthTexture => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isDepthTexture);
 
-        public MTLStructType ElementStructType => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_elementStructType));
+        public ulong Index => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_index);
 
-        public MTLArrayType ElementArrayType => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_elementArrayType));
+        public NSString Name => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_name));
 
-        private static readonly Selector sel_elementType = "elementType";
+        public MTLDataType TextureDataType => (MTLDataType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_textureDataType);
+
+        public MTLTextureType TextureType => (MTLTextureType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_textureType);
+
+        public MTLBindingType Type => (MTLBindingType)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_type);
+
+        public bool Used => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isUsed);
+
         private static readonly Selector sel_access = "access";
-        private static readonly Selector sel_alignment = "alignment";
-        private static readonly Selector sel_dataSize = "dataSize";
-        private static readonly Selector sel_elementIsArgumentBuffer = "elementIsArgumentBuffer";
-        private static readonly Selector sel_elementStructType = "elementStructType";
-        private static readonly Selector sel_elementArrayType = "elementArrayType";
+        private static readonly Selector sel_arrayLength = "arrayLength";
+        private static readonly Selector sel_index = "index";
+        private static readonly Selector sel_isArgument = "isArgument";
+        private static readonly Selector sel_isDepthTexture = "isDepthTexture";
+        private static readonly Selector sel_isUsed = "isUsed";
+        private static readonly Selector sel_name = "name";
+        private static readonly Selector sel_textureDataType = "textureDataType";
+        private static readonly Selector sel_textureType = "textureType";
+        private static readonly Selector sel_type = "type";
         private static readonly Selector sel_release = "release";
     }
 
@@ -347,169 +560,18 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public MTLDataType TextureDataType => (MTLDataType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_textureDataType);
-
-        public MTLTextureType TextureType => (MTLTextureType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_textureType);
-
         public MTLBindingAccess Access => (MTLBindingAccess)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_access);
 
         public bool IsDepthTexture => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isDepthTexture);
 
-        private static readonly Selector sel_textureDataType = "textureDataType";
-        private static readonly Selector sel_textureType = "textureType";
-        private static readonly Selector sel_access = "access";
-        private static readonly Selector sel_isDepthTexture = "isDepthTexture";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLArgument : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLArgument obj) => obj.NativePtr;
-        public MTLArgument(IntPtr ptr) => NativePtr = ptr;
-
-        public MTLArgument()
-        {
-            var cls = new ObjectiveCClass("MTLArgument");
-            NativePtr = cls.AllocInit();
-        }
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public NSString Name => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_name));
-
-        public MTLArgumentType Type => (MTLArgumentType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_type);
-
-        public MTLBindingAccess Access => (MTLBindingAccess)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_access);
-
-        public ulong Index => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_index);
-
-        public bool Active => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isActive);
-
-        public ulong BufferAlignment => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_bufferAlignment);
-
-        public ulong BufferDataSize => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_bufferDataSize);
-
-        public MTLDataType BufferDataType => (MTLDataType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_bufferDataType);
-
-        public MTLStructType BufferStructType => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_bufferStructType));
-
-        public MTLPointerType BufferPointerType => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_bufferPointerType));
-
-        public ulong ThreadgroupMemoryAlignment => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_threadgroupMemoryAlignment);
-
-        public ulong ThreadgroupMemoryDataSize => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_threadgroupMemoryDataSize);
+        public MTLDataType TextureDataType => (MTLDataType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_textureDataType);
 
         public MTLTextureType TextureType => (MTLTextureType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_textureType);
 
-        public MTLDataType TextureDataType => (MTLDataType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_textureDataType);
-
-        public bool IsDepthTexture => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isDepthTexture);
-
-        public ulong ArrayLength => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_arrayLength);
-
-        private static readonly Selector sel_name = "name";
-        private static readonly Selector sel_type = "type";
         private static readonly Selector sel_access = "access";
-        private static readonly Selector sel_index = "index";
-        private static readonly Selector sel_isActive = "isActive";
-        private static readonly Selector sel_bufferAlignment = "bufferAlignment";
-        private static readonly Selector sel_bufferDataSize = "bufferDataSize";
-        private static readonly Selector sel_bufferDataType = "bufferDataType";
-        private static readonly Selector sel_bufferStructType = "bufferStructType";
-        private static readonly Selector sel_bufferPointerType = "bufferPointerType";
-        private static readonly Selector sel_threadgroupMemoryAlignment = "threadgroupMemoryAlignment";
-        private static readonly Selector sel_threadgroupMemoryDataSize = "threadgroupMemoryDataSize";
-        private static readonly Selector sel_textureType = "textureType";
-        private static readonly Selector sel_textureDataType = "textureDataType";
         private static readonly Selector sel_isDepthTexture = "isDepthTexture";
-        private static readonly Selector sel_arrayLength = "arrayLength";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLBinding : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLBinding obj) => obj.NativePtr;
-        public MTLBinding(IntPtr ptr) => NativePtr = ptr;
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public NSString Name => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_name));
-
-        public MTLBindingType Type => (MTLBindingType)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_type);
-
-        public MTLBindingAccess Access => (MTLBindingAccess)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_access);
-
-        public ulong Index => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_index);
-
-        public bool Used => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isUsed);
-
-        public bool Argument => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isArgument);
-
-        private static readonly Selector sel_name = "name";
-        private static readonly Selector sel_type = "type";
-        private static readonly Selector sel_access = "access";
-        private static readonly Selector sel_index = "index";
-        private static readonly Selector sel_isUsed = "isUsed";
-        private static readonly Selector sel_isArgument = "isArgument";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLBufferBinding : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLBufferBinding obj) => obj.NativePtr;
-        public static implicit operator MTLBinding(MTLBufferBinding obj) => new(obj.NativePtr);
-        public MTLBufferBinding(IntPtr ptr) => NativePtr = ptr;
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public ulong BufferAlignment => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_bufferAlignment);
-
-        public ulong BufferDataSize => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_bufferDataSize);
-
-        public MTLDataType BufferDataType => (MTLDataType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_bufferDataType);
-
-        public MTLStructType BufferStructType => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_bufferStructType));
-
-        public MTLPointerType BufferPointerType => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_bufferPointerType));
-
-        public NSString Name => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_name));
-
-        public MTLBindingType Type => (MTLBindingType)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_type);
-
-        public MTLBindingAccess Access => (MTLBindingAccess)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_access);
-
-        public ulong Index => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_index);
-
-        public bool Used => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isUsed);
-
-        public bool Argument => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isArgument);
-
-        private static readonly Selector sel_bufferAlignment = "bufferAlignment";
-        private static readonly Selector sel_bufferDataSize = "bufferDataSize";
-        private static readonly Selector sel_bufferDataType = "bufferDataType";
-        private static readonly Selector sel_bufferStructType = "bufferStructType";
-        private static readonly Selector sel_bufferPointerType = "bufferPointerType";
-        private static readonly Selector sel_name = "name";
-        private static readonly Selector sel_type = "type";
-        private static readonly Selector sel_access = "access";
-        private static readonly Selector sel_index = "index";
-        private static readonly Selector sel_isUsed = "isUsed";
-        private static readonly Selector sel_isArgument = "isArgument";
+        private static readonly Selector sel_textureDataType = "textureDataType";
+        private static readonly Selector sel_textureType = "textureType";
         private static readonly Selector sel_release = "release";
     }
 
@@ -526,116 +588,54 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
+        public MTLBindingAccess Access => (MTLBindingAccess)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_access);
+
+        public bool Argument => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isArgument);
+
+        public ulong Index => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_index);
+
+        public NSString Name => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_name));
+
         public ulong ThreadgroupMemoryAlignment => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_threadgroupMemoryAlignment);
 
         public ulong ThreadgroupMemoryDataSize => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_threadgroupMemoryDataSize);
 
-        public NSString Name => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_name));
-
         public MTLBindingType Type => (MTLBindingType)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_type);
-
-        public MTLBindingAccess Access => (MTLBindingAccess)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_access);
-
-        public ulong Index => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_index);
 
         public bool Used => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isUsed);
 
-        public bool Argument => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isArgument);
-
+        private static readonly Selector sel_access = "access";
+        private static readonly Selector sel_index = "index";
+        private static readonly Selector sel_isArgument = "isArgument";
+        private static readonly Selector sel_isUsed = "isUsed";
+        private static readonly Selector sel_name = "name";
         private static readonly Selector sel_threadgroupMemoryAlignment = "threadgroupMemoryAlignment";
         private static readonly Selector sel_threadgroupMemoryDataSize = "threadgroupMemoryDataSize";
-        private static readonly Selector sel_name = "name";
         private static readonly Selector sel_type = "type";
-        private static readonly Selector sel_access = "access";
-        private static readonly Selector sel_index = "index";
-        private static readonly Selector sel_isUsed = "isUsed";
-        private static readonly Selector sel_isArgument = "isArgument";
         private static readonly Selector sel_release = "release";
     }
 
     [SupportedOSPlatform("macos")]
-    public struct MTLTextureBinding : IDisposable
+    public struct MTLType : IDisposable
     {
         public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLTextureBinding obj) => obj.NativePtr;
-        public static implicit operator MTLBinding(MTLTextureBinding obj) => new(obj.NativePtr);
-        public MTLTextureBinding(IntPtr ptr) => NativePtr = ptr;
+        public static implicit operator IntPtr(MTLType obj) => obj.NativePtr;
+        public MTLType(IntPtr ptr) => NativePtr = ptr;
+
+        public MTLType()
+        {
+            var cls = new ObjectiveCClass("MTLType");
+            NativePtr = cls.AllocInit();
+        }
 
         public void Dispose()
         {
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public MTLTextureType TextureType => (MTLTextureType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_textureType);
+        public MTLDataType DataType => (MTLDataType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_dataType);
 
-        public MTLDataType TextureDataType => (MTLDataType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_textureDataType);
-
-        public bool DepthTexture => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isDepthTexture);
-
-        public ulong ArrayLength => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_arrayLength);
-
-        public NSString Name => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_name));
-
-        public MTLBindingType Type => (MTLBindingType)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_type);
-
-        public MTLBindingAccess Access => (MTLBindingAccess)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_access);
-
-        public ulong Index => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_index);
-
-        public bool Used => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isUsed);
-
-        public bool Argument => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isArgument);
-
-        private static readonly Selector sel_textureType = "textureType";
-        private static readonly Selector sel_textureDataType = "textureDataType";
-        private static readonly Selector sel_isDepthTexture = "isDepthTexture";
-        private static readonly Selector sel_arrayLength = "arrayLength";
-        private static readonly Selector sel_name = "name";
-        private static readonly Selector sel_type = "type";
-        private static readonly Selector sel_access = "access";
-        private static readonly Selector sel_index = "index";
-        private static readonly Selector sel_isUsed = "isUsed";
-        private static readonly Selector sel_isArgument = "isArgument";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLObjectPayloadBinding : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLObjectPayloadBinding obj) => obj.NativePtr;
-        public static implicit operator MTLBinding(MTLObjectPayloadBinding obj) => new(obj.NativePtr);
-        public MTLObjectPayloadBinding(IntPtr ptr) => NativePtr = ptr;
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public ulong ObjectPayloadAlignment => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_objectPayloadAlignment);
-
-        public ulong ObjectPayloadDataSize => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_objectPayloadDataSize);
-
-        public NSString Name => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_name));
-
-        public MTLBindingType Type => (MTLBindingType)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_type);
-
-        public MTLBindingAccess Access => (MTLBindingAccess)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_access);
-
-        public ulong Index => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_index);
-
-        public bool Used => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isUsed);
-
-        public bool Argument => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isArgument);
-
-        private static readonly Selector sel_objectPayloadAlignment = "objectPayloadAlignment";
-        private static readonly Selector sel_objectPayloadDataSize = "objectPayloadDataSize";
-        private static readonly Selector sel_name = "name";
-        private static readonly Selector sel_type = "type";
-        private static readonly Selector sel_access = "access";
-        private static readonly Selector sel_index = "index";
-        private static readonly Selector sel_isUsed = "isUsed";
-        private static readonly Selector sel_isArgument = "isArgument";
+        private static readonly Selector sel_dataType = "dataType";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLArgumentEncoder.cs
+++ b/src/SharpMetal/Metal/MTLArgumentEncoder.cs
@@ -16,7 +16,11 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
+        public ulong Alignment => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_alignment);
+
         public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
+
+        public ulong EncodedLength => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_encodedLength);
 
         public NSString Label
         {
@@ -24,9 +28,20 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
         }
 
-        public ulong EncodedLength => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_encodedLength);
+        public IntPtr ConstantData(ulong index)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_constantDataAtIndex, index));
+        }
 
-        public ulong Alignment => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_alignment);
+        public MTLArgumentEncoder NewArgumentEncoder(ulong index)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newArgumentEncoderForBufferAtIndex, index));
+        }
+
+        public void SetAccelerationStructure(MTLAccelerationStructure accelerationStructure, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setAccelerationStructureatIndex, accelerationStructure, index);
+        }
 
         public void SetArgumentBuffer(MTLBuffer argumentBuffer, ulong offset)
         {
@@ -44,41 +59,6 @@ namespace SharpMetal.Metal
         }
 
         public void SetBuffers(MTLBuffer[] buffers, ulong[] offsets, NSRange range)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void SetTexture(MTLTexture texture, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTextureatIndex, texture, index);
-        }
-
-        public void SetTextures(MTLTexture[] textures, NSRange range)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void SetSamplerState(MTLSamplerState sampler, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSamplerStateatIndex, sampler, index);
-        }
-
-        public void SetSamplerStates(MTLSamplerState[] samplers, NSRange range)
-        {
-            throw new NotImplementedException();
-        }
-
-        public IntPtr ConstantData(ulong index)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_constantDataAtIndex, index));
-        }
-
-        public void SetRenderPipelineState(MTLRenderPipelineState pipeline, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRenderPipelineStateatIndex, pipeline, index);
-        }
-
-        public void SetRenderPipelineStates(MTLRenderPipelineState[] pipelines, NSRange range)
         {
             throw new NotImplementedException();
         }
@@ -103,14 +83,44 @@ namespace SharpMetal.Metal
             throw new NotImplementedException();
         }
 
-        public void SetAccelerationStructure(MTLAccelerationStructure accelerationStructure, ulong index)
+        public void SetIntersectionFunctionTable(MTLIntersectionFunctionTable intersectionFunctionTable, ulong index)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setAccelerationStructureatIndex, accelerationStructure, index);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIntersectionFunctionTableatIndex, intersectionFunctionTable, index);
         }
 
-        public MTLArgumentEncoder NewArgumentEncoder(ulong index)
+        public void SetIntersectionFunctionTables(MTLIntersectionFunctionTable[] intersectionFunctionTables, NSRange range)
         {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newArgumentEncoderForBufferAtIndex, index));
+            throw new NotImplementedException();
+        }
+
+        public void SetRenderPipelineState(MTLRenderPipelineState pipeline, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRenderPipelineStateatIndex, pipeline, index);
+        }
+
+        public void SetRenderPipelineStates(MTLRenderPipelineState[] pipelines, NSRange range)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SetSamplerState(MTLSamplerState sampler, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSamplerStateatIndex, sampler, index);
+        }
+
+        public void SetSamplerStates(MTLSamplerState[] samplers, NSRange range)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SetTexture(MTLTexture texture, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTextureatIndex, texture, index);
+        }
+
+        public void SetTextures(MTLTexture[] textures, NSRange range)
+        {
+            throw new NotImplementedException();
         }
 
         public void SetVisibleFunctionTable(MTLVisibleFunctionTable visibleFunctionTable, ulong index)
@@ -123,42 +133,32 @@ namespace SharpMetal.Metal
             throw new NotImplementedException();
         }
 
-        public void SetIntersectionFunctionTable(MTLIntersectionFunctionTable intersectionFunctionTable, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIntersectionFunctionTableatIndex, intersectionFunctionTable, index);
-        }
-
-        public void SetIntersectionFunctionTables(MTLIntersectionFunctionTable[] intersectionFunctionTables, NSRange range)
-        {
-            throw new NotImplementedException();
-        }
-
-        private static readonly Selector sel_device = "device";
-        private static readonly Selector sel_label = "label";
-        private static readonly Selector sel_setLabel = "setLabel:";
-        private static readonly Selector sel_encodedLength = "encodedLength";
         private static readonly Selector sel_alignment = "alignment";
+        private static readonly Selector sel_constantDataAtIndex = "constantDataAtIndex:";
+        private static readonly Selector sel_device = "device";
+        private static readonly Selector sel_encodedLength = "encodedLength";
+        private static readonly Selector sel_label = "label";
+        private static readonly Selector sel_newArgumentEncoderForBufferAtIndex = "newArgumentEncoderForBufferAtIndex:";
+        private static readonly Selector sel_setAccelerationStructureatIndex = "setAccelerationStructure:atIndex:";
         private static readonly Selector sel_setArgumentBufferoffset = "setArgumentBuffer:offset:";
         private static readonly Selector sel_setArgumentBufferstartOffsetarrayElement = "setArgumentBuffer:startOffset:arrayElement:";
         private static readonly Selector sel_setBufferoffsetatIndex = "setBuffer:offset:atIndex:";
         private static readonly Selector sel_setBuffersoffsetswithRange = "setBuffers:offsets:withRange:";
-        private static readonly Selector sel_setTextureatIndex = "setTexture:atIndex:";
-        private static readonly Selector sel_setTextureswithRange = "setTextures:withRange:";
-        private static readonly Selector sel_setSamplerStateatIndex = "setSamplerState:atIndex:";
-        private static readonly Selector sel_setSamplerStateswithRange = "setSamplerStates:withRange:";
-        private static readonly Selector sel_constantDataAtIndex = "constantDataAtIndex:";
-        private static readonly Selector sel_setRenderPipelineStateatIndex = "setRenderPipelineState:atIndex:";
-        private static readonly Selector sel_setRenderPipelineStateswithRange = "setRenderPipelineStates:withRange:";
         private static readonly Selector sel_setComputePipelineStateatIndex = "setComputePipelineState:atIndex:";
         private static readonly Selector sel_setComputePipelineStateswithRange = "setComputePipelineStates:withRange:";
         private static readonly Selector sel_setIndirectCommandBufferatIndex = "setIndirectCommandBuffer:atIndex:";
         private static readonly Selector sel_setIndirectCommandBufferswithRange = "setIndirectCommandBuffers:withRange:";
-        private static readonly Selector sel_setAccelerationStructureatIndex = "setAccelerationStructure:atIndex:";
-        private static readonly Selector sel_newArgumentEncoderForBufferAtIndex = "newArgumentEncoderForBufferAtIndex:";
-        private static readonly Selector sel_setVisibleFunctionTableatIndex = "setVisibleFunctionTable:atIndex:";
-        private static readonly Selector sel_setVisibleFunctionTableswithRange = "setVisibleFunctionTables:withRange:";
         private static readonly Selector sel_setIntersectionFunctionTableatIndex = "setIntersectionFunctionTable:atIndex:";
         private static readonly Selector sel_setIntersectionFunctionTableswithRange = "setIntersectionFunctionTables:withRange:";
+        private static readonly Selector sel_setLabel = "setLabel:";
+        private static readonly Selector sel_setRenderPipelineStateatIndex = "setRenderPipelineState:atIndex:";
+        private static readonly Selector sel_setRenderPipelineStateswithRange = "setRenderPipelineStates:withRange:";
+        private static readonly Selector sel_setSamplerStateatIndex = "setSamplerState:atIndex:";
+        private static readonly Selector sel_setSamplerStateswithRange = "setSamplerStates:withRange:";
+        private static readonly Selector sel_setTextureatIndex = "setTexture:atIndex:";
+        private static readonly Selector sel_setTextureswithRange = "setTextures:withRange:";
+        private static readonly Selector sel_setVisibleFunctionTableatIndex = "setVisibleFunctionTable:atIndex:";
+        private static readonly Selector sel_setVisibleFunctionTableswithRange = "setVisibleFunctionTables:withRange:";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLBinaryArchive.cs
+++ b/src/SharpMetal/Metal/MTLBinaryArchive.cs
@@ -15,6 +15,62 @@ namespace SharpMetal.Metal
     }
 
     [SupportedOSPlatform("macos")]
+    public struct MTLBinaryArchive : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLBinaryArchive obj) => obj.NativePtr;
+        public MTLBinaryArchive(IntPtr ptr) => NativePtr = ptr;
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
+
+        public NSString Label
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
+        }
+
+        public bool AddComputePipelineFunctions(MTLComputePipelineDescriptor descriptor, ref NSError error)
+        {
+            return ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_addComputePipelineFunctionsWithDescriptorerror, descriptor, ref error.NativePtr);
+        }
+
+        public bool AddFunction(MTLFunctionDescriptor descriptor, MTLLibrary library, ref NSError error)
+        {
+            return ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_addFunctionWithDescriptorlibraryerror, descriptor, library, ref error.NativePtr);
+        }
+
+        public bool AddRenderPipelineFunctions(MTLRenderPipelineDescriptor descriptor, ref NSError error)
+        {
+            return ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_addRenderPipelineFunctionsWithDescriptorerror, descriptor, ref error.NativePtr);
+        }
+
+        public bool AddTileRenderPipelineFunctions(MTLTileRenderPipelineDescriptor descriptor, ref NSError error)
+        {
+            return ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_addTileRenderPipelineFunctionsWithDescriptorerror, descriptor, ref error.NativePtr);
+        }
+
+        public bool SerializeToURL(NSURL url, ref NSError error)
+        {
+            return ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_serializeToURLerror, url, ref error.NativePtr);
+        }
+
+        private static readonly Selector sel_addComputePipelineFunctionsWithDescriptorerror = "addComputePipelineFunctionsWithDescriptor:error:";
+        private static readonly Selector sel_addFunctionWithDescriptorlibraryerror = "addFunctionWithDescriptor:library:error:";
+        private static readonly Selector sel_addRenderPipelineFunctionsWithDescriptorerror = "addRenderPipelineFunctionsWithDescriptor:error:";
+        private static readonly Selector sel_addTileRenderPipelineFunctionsWithDescriptorerror = "addTileRenderPipelineFunctionsWithDescriptor:error:";
+        private static readonly Selector sel_device = "device";
+        private static readonly Selector sel_label = "label";
+        private static readonly Selector sel_serializeToURLerror = "serializeToURL:error:";
+        private static readonly Selector sel_setLabel = "setLabel:";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
     public struct MTLBinaryArchiveDescriptor : IDisposable
     {
         public IntPtr NativePtr;
@@ -38,64 +94,8 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setUrl, value);
         }
 
-        private static readonly Selector sel_url = "url";
         private static readonly Selector sel_setUrl = "setUrl:";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLBinaryArchive : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLBinaryArchive obj) => obj.NativePtr;
-        public MTLBinaryArchive(IntPtr ptr) => NativePtr = ptr;
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public NSString Label
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
-        }
-
-        public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
-
-        public bool AddComputePipelineFunctions(MTLComputePipelineDescriptor descriptor, ref NSError error)
-        {
-            return ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_addComputePipelineFunctionsWithDescriptorerror, descriptor, ref error.NativePtr);
-        }
-
-        public bool AddRenderPipelineFunctions(MTLRenderPipelineDescriptor descriptor, ref NSError error)
-        {
-            return ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_addRenderPipelineFunctionsWithDescriptorerror, descriptor, ref error.NativePtr);
-        }
-
-        public bool AddTileRenderPipelineFunctions(MTLTileRenderPipelineDescriptor descriptor, ref NSError error)
-        {
-            return ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_addTileRenderPipelineFunctionsWithDescriptorerror, descriptor, ref error.NativePtr);
-        }
-
-        public bool SerializeToURL(NSURL url, ref NSError error)
-        {
-            return ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_serializeToURLerror, url, ref error.NativePtr);
-        }
-
-        public bool AddFunction(MTLFunctionDescriptor descriptor, MTLLibrary library, ref NSError error)
-        {
-            return ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_addFunctionWithDescriptorlibraryerror, descriptor, library, ref error.NativePtr);
-        }
-
-        private static readonly Selector sel_label = "label";
-        private static readonly Selector sel_setLabel = "setLabel:";
-        private static readonly Selector sel_device = "device";
-        private static readonly Selector sel_addComputePipelineFunctionsWithDescriptorerror = "addComputePipelineFunctionsWithDescriptor:error:";
-        private static readonly Selector sel_addRenderPipelineFunctionsWithDescriptorerror = "addRenderPipelineFunctionsWithDescriptor:error:";
-        private static readonly Selector sel_addTileRenderPipelineFunctionsWithDescriptorerror = "addTileRenderPipelineFunctionsWithDescriptor:error:";
-        private static readonly Selector sel_serializeToURLerror = "serializeToURL:error:";
-        private static readonly Selector sel_addFunctionWithDescriptorlibraryerror = "addFunctionWithDescriptor:library:error:";
+        private static readonly Selector sel_url = "url";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLBlitCommandEncoder.cs
+++ b/src/SharpMetal/Metal/MTLBlitCommandEncoder.cs
@@ -35,21 +35,6 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
         }
 
-        public void SynchronizeResource(MTLResource resource)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_synchronizeResource, resource);
-        }
-
-        public void SynchronizeTexture(MTLTexture texture, ulong slice, ulong level)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_synchronizeTextureslicelevel, texture, slice, level);
-        }
-
-        public void CopyFromTexture(MTLTexture sourceTexture, ulong sourceSlice, ulong sourceLevel, MTLOrigin sourceOrigin, MTLSize sourceSize, MTLTexture destinationTexture, ulong destinationSlice, ulong destinationLevel, MTLOrigin destinationOrigin)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_copyFromTexturesourceSlicesourceLevelsourceOriginsourceSizetoTexturedestinationSlicedestinationLeveldestinationOrigin, sourceTexture, sourceSlice, sourceLevel, sourceOrigin, sourceSize, destinationTexture, destinationSlice, destinationLevel, destinationOrigin);
-        }
-
         public void CopyFromBuffer(MTLBuffer sourceBuffer, ulong sourceOffset, ulong sourceBytesPerRow, ulong sourceBytesPerImage, MTLSize sourceSize, MTLTexture destinationTexture, ulong destinationSlice, ulong destinationLevel, MTLOrigin destinationOrigin)
         {
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_copyFromBuffersourceOffsetsourceBytesPerRowsourceBytesPerImagesourceSizetoTexturedestinationSlicedestinationLeveldestinationOrigin, sourceBuffer, sourceOffset, sourceBytesPerRow, sourceBytesPerImage, sourceSize, destinationTexture, destinationSlice, destinationLevel, destinationOrigin);
@@ -58,6 +43,21 @@ namespace SharpMetal.Metal
         public void CopyFromBuffer(MTLBuffer sourceBuffer, ulong sourceOffset, ulong sourceBytesPerRow, ulong sourceBytesPerImage, MTLSize sourceSize, MTLTexture destinationTexture, ulong destinationSlice, ulong destinationLevel, MTLOrigin destinationOrigin, MTLBlitOption options)
         {
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_copyFromBuffersourceOffsetsourceBytesPerRowsourceBytesPerImagesourceSizetoTexturedestinationSlicedestinationLeveldestinationOriginoptions, sourceBuffer, sourceOffset, sourceBytesPerRow, sourceBytesPerImage, sourceSize, destinationTexture, destinationSlice, destinationLevel, destinationOrigin, (ulong)options);
+        }
+
+        public void CopyFromBuffer(MTLBuffer sourceBuffer, ulong sourceOffset, MTLBuffer destinationBuffer, ulong destinationOffset, ulong size)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_copyFromBuffersourceOffsettoBufferdestinationOffsetsize, sourceBuffer, sourceOffset, destinationBuffer, destinationOffset, size);
+        }
+
+        public void CopyFromTexture(MTLTexture sourceTexture, ulong sourceSlice, ulong sourceLevel, MTLTexture destinationTexture, ulong destinationSlice, ulong destinationLevel, ulong sliceCount, ulong levelCount)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_copyFromTexturesourceSlicesourceLeveltoTexturedestinationSlicedestinationLevelsliceCountlevelCount, sourceTexture, sourceSlice, sourceLevel, destinationTexture, destinationSlice, destinationLevel, sliceCount, levelCount);
+        }
+
+        public void CopyFromTexture(MTLTexture sourceTexture, ulong sourceSlice, ulong sourceLevel, MTLOrigin sourceOrigin, MTLSize sourceSize, MTLTexture destinationTexture, ulong destinationSlice, ulong destinationLevel, MTLOrigin destinationOrigin)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_copyFromTexturesourceSlicesourceLevelsourceOriginsourceSizetoTexturedestinationSlicedestinationLeveldestinationOrigin, sourceTexture, sourceSlice, sourceLevel, sourceOrigin, sourceSize, destinationTexture, destinationSlice, destinationLevel, destinationOrigin);
         }
 
         public void CopyFromTexture(MTLTexture sourceTexture, ulong sourceSlice, ulong sourceLevel, MTLOrigin sourceOrigin, MTLSize sourceSize, MTLBuffer destinationBuffer, ulong destinationOffset, ulong destinationBytesPerRow, ulong destinationBytesPerImage)
@@ -70,9 +70,19 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_copyFromTexturesourceSlicesourceLevelsourceOriginsourceSizetoBufferdestinationOffsetdestinationBytesPerRowdestinationBytesPerImageoptions, sourceTexture, sourceSlice, sourceLevel, sourceOrigin, sourceSize, destinationBuffer, destinationOffset, destinationBytesPerRow, destinationBytesPerImage, (ulong)options);
         }
 
-        public void GenerateMipmaps(MTLTexture texture)
+        public void CopyFromTexture(MTLTexture sourceTexture, MTLTexture destinationTexture)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_generateMipmapsForTexture, texture);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_copyFromTexturetoTexture, sourceTexture, destinationTexture);
+        }
+
+        public void CopyIndirectCommandBuffer(MTLIndirectCommandBuffer source, NSRange sourceRange, MTLIndirectCommandBuffer destination, ulong destinationIndex)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_copyIndirectCommandBuffersourceRangedestinationdestinationIndex, source, sourceRange, destination, destinationIndex);
+        }
+
+        public void EndEncoding()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_endEncoding);
         }
 
         public void FillBuffer(MTLBuffer buffer, NSRange range, byte value)
@@ -80,29 +90,9 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_fillBufferrangevalue, buffer, range, value);
         }
 
-        public void CopyFromTexture(MTLTexture sourceTexture, ulong sourceSlice, ulong sourceLevel, MTLTexture destinationTexture, ulong destinationSlice, ulong destinationLevel, ulong sliceCount, ulong levelCount)
+        public void GenerateMipmaps(MTLTexture texture)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_copyFromTexturesourceSlicesourceLeveltoTexturedestinationSlicedestinationLevelsliceCountlevelCount, sourceTexture, sourceSlice, sourceLevel, destinationTexture, destinationSlice, destinationLevel, sliceCount, levelCount);
-        }
-
-        public void CopyFromTexture(MTLTexture sourceTexture, MTLTexture destinationTexture)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_copyFromTexturetoTexture, sourceTexture, destinationTexture);
-        }
-
-        public void CopyFromBuffer(MTLBuffer sourceBuffer, ulong sourceOffset, MTLBuffer destinationBuffer, ulong destinationOffset, ulong size)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_copyFromBuffersourceOffsettoBufferdestinationOffsetsize, sourceBuffer, sourceOffset, destinationBuffer, destinationOffset, size);
-        }
-
-        public void UpdateFence(MTLFence fence)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_updateFence, fence);
-        }
-
-        public void WaitForFence(MTLFence fence)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_waitForFence, fence);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_generateMipmapsForTexture, texture);
         }
 
         public void GetTextureAccessCounters(MTLTexture texture, MTLRegion region, ulong mipLevel, ulong slice, bool resetCounters, MTLBuffer countersBuffer, ulong countersBufferOffset)
@@ -110,9 +100,19 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_getTextureAccessCountersregionmipLevelsliceresetCounterscountersBuffercountersBufferOffset, texture, region, mipLevel, slice, resetCounters, countersBuffer, countersBufferOffset);
         }
 
-        public void ResetTextureAccessCounters(MTLTexture texture, MTLRegion region, ulong mipLevel, ulong slice)
+        public void InsertDebugSignpost(NSString nsString)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_resetTextureAccessCountersregionmipLevelslice, texture, region, mipLevel, slice);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_insertDebugSignpost, nsString);
+        }
+
+        public void OptimizeContentsForCPUAccess(MTLTexture texture, ulong slice, ulong level)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_optimizeContentsForCPUAccessslicelevel, texture, slice, level);
+        }
+
+        public void OptimizeContentsForCPUAccess(MTLTexture texture)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_optimizeContentsForCPUAccess, texture);
         }
 
         public void OptimizeContentsForGPUAccess(MTLTexture texture)
@@ -125,54 +125,9 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_optimizeContentsForGPUAccessslicelevel, texture, slice, level);
         }
 
-        public void OptimizeContentsForCPUAccess(MTLTexture texture)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_optimizeContentsForCPUAccess, texture);
-        }
-
-        public void OptimizeContentsForCPUAccess(MTLTexture texture, ulong slice, ulong level)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_optimizeContentsForCPUAccessslicelevel, texture, slice, level);
-        }
-
-        public void ResetCommandsInBuffer(MTLIndirectCommandBuffer buffer, NSRange range)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_resetCommandsInBufferwithRange, buffer, range);
-        }
-
-        public void CopyIndirectCommandBuffer(MTLIndirectCommandBuffer source, NSRange sourceRange, MTLIndirectCommandBuffer destination, ulong destinationIndex)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_copyIndirectCommandBuffersourceRangedestinationdestinationIndex, source, sourceRange, destination, destinationIndex);
-        }
-
         public void OptimizeIndirectCommandBuffer(MTLIndirectCommandBuffer indirectCommandBuffer, NSRange range)
         {
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_optimizeIndirectCommandBufferwithRange, indirectCommandBuffer, range);
-        }
-
-        public void SampleCountersInBuffer(MTLCounterSampleBuffer sampleBuffer, ulong sampleIndex, bool barrier)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_sampleCountersInBufferatSampleIndexwithBarrier, sampleBuffer, sampleIndex, barrier);
-        }
-
-        public void ResolveCounters(MTLCounterSampleBuffer sampleBuffer, NSRange range, MTLBuffer destinationBuffer, ulong destinationOffset)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_resolveCountersinRangedestinationBufferdestinationOffset, sampleBuffer, range, destinationBuffer, destinationOffset);
-        }
-
-        public void EndEncoding()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_endEncoding);
-        }
-
-        public void InsertDebugSignpost(NSString nsString)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_insertDebugSignpost, nsString);
-        }
-
-        public void PushDebugGroup(NSString nsString)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_pushDebugGroup, nsString);
         }
 
         public void PopDebugGroup()
@@ -180,38 +135,83 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_popDebugGroup);
         }
 
-        private static readonly Selector sel_synchronizeResource = "synchronizeResource:";
-        private static readonly Selector sel_synchronizeTextureslicelevel = "synchronizeTexture:slice:level:";
-        private static readonly Selector sel_copyFromTexturesourceSlicesourceLevelsourceOriginsourceSizetoTexturedestinationSlicedestinationLeveldestinationOrigin = "copyFromTexture:sourceSlice:sourceLevel:sourceOrigin:sourceSize:toTexture:destinationSlice:destinationLevel:destinationOrigin:";
+        public void PushDebugGroup(NSString nsString)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_pushDebugGroup, nsString);
+        }
+
+        public void ResetCommandsInBuffer(MTLIndirectCommandBuffer buffer, NSRange range)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_resetCommandsInBufferwithRange, buffer, range);
+        }
+
+        public void ResetTextureAccessCounters(MTLTexture texture, MTLRegion region, ulong mipLevel, ulong slice)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_resetTextureAccessCountersregionmipLevelslice, texture, region, mipLevel, slice);
+        }
+
+        public void ResolveCounters(MTLCounterSampleBuffer sampleBuffer, NSRange range, MTLBuffer destinationBuffer, ulong destinationOffset)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_resolveCountersinRangedestinationBufferdestinationOffset, sampleBuffer, range, destinationBuffer, destinationOffset);
+        }
+
+        public void SampleCountersInBuffer(MTLCounterSampleBuffer sampleBuffer, ulong sampleIndex, bool barrier)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_sampleCountersInBufferatSampleIndexwithBarrier, sampleBuffer, sampleIndex, barrier);
+        }
+
+        public void SynchronizeResource(MTLResource resource)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_synchronizeResource, resource);
+        }
+
+        public void SynchronizeTexture(MTLTexture texture, ulong slice, ulong level)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_synchronizeTextureslicelevel, texture, slice, level);
+        }
+
+        public void UpdateFence(MTLFence fence)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_updateFence, fence);
+        }
+
+        public void WaitForFence(MTLFence fence)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_waitForFence, fence);
+        }
+
         private static readonly Selector sel_copyFromBuffersourceOffsetsourceBytesPerRowsourceBytesPerImagesourceSizetoTexturedestinationSlicedestinationLeveldestinationOrigin = "copyFromBuffer:sourceOffset:sourceBytesPerRow:sourceBytesPerImage:sourceSize:toTexture:destinationSlice:destinationLevel:destinationOrigin:";
         private static readonly Selector sel_copyFromBuffersourceOffsetsourceBytesPerRowsourceBytesPerImagesourceSizetoTexturedestinationSlicedestinationLeveldestinationOriginoptions = "copyFromBuffer:sourceOffset:sourceBytesPerRow:sourceBytesPerImage:sourceSize:toTexture:destinationSlice:destinationLevel:destinationOrigin:options:";
+        private static readonly Selector sel_copyFromBuffersourceOffsettoBufferdestinationOffsetsize = "copyFromBuffer:sourceOffset:toBuffer:destinationOffset:size:";
         private static readonly Selector sel_copyFromTexturesourceSlicesourceLevelsourceOriginsourceSizetoBufferdestinationOffsetdestinationBytesPerRowdestinationBytesPerImage = "copyFromTexture:sourceSlice:sourceLevel:sourceOrigin:sourceSize:toBuffer:destinationOffset:destinationBytesPerRow:destinationBytesPerImage:";
         private static readonly Selector sel_copyFromTexturesourceSlicesourceLevelsourceOriginsourceSizetoBufferdestinationOffsetdestinationBytesPerRowdestinationBytesPerImageoptions = "copyFromTexture:sourceSlice:sourceLevel:sourceOrigin:sourceSize:toBuffer:destinationOffset:destinationBytesPerRow:destinationBytesPerImage:options:";
-        private static readonly Selector sel_generateMipmapsForTexture = "generateMipmapsForTexture:";
-        private static readonly Selector sel_fillBufferrangevalue = "fillBuffer:range:value:";
+        private static readonly Selector sel_copyFromTexturesourceSlicesourceLevelsourceOriginsourceSizetoTexturedestinationSlicedestinationLeveldestinationOrigin = "copyFromTexture:sourceSlice:sourceLevel:sourceOrigin:sourceSize:toTexture:destinationSlice:destinationLevel:destinationOrigin:";
         private static readonly Selector sel_copyFromTexturesourceSlicesourceLeveltoTexturedestinationSlicedestinationLevelsliceCountlevelCount = "copyFromTexture:sourceSlice:sourceLevel:toTexture:destinationSlice:destinationLevel:sliceCount:levelCount:";
         private static readonly Selector sel_copyFromTexturetoTexture = "copyFromTexture:toTexture:";
-        private static readonly Selector sel_copyFromBuffersourceOffsettoBufferdestinationOffsetsize = "copyFromBuffer:sourceOffset:toBuffer:destinationOffset:size:";
-        private static readonly Selector sel_updateFence = "updateFence:";
-        private static readonly Selector sel_waitForFence = "waitForFence:";
+        private static readonly Selector sel_copyIndirectCommandBuffersourceRangedestinationdestinationIndex = "copyIndirectCommandBuffer:sourceRange:destination:destinationIndex:";
+        private static readonly Selector sel_device = "device";
+        private static readonly Selector sel_endEncoding = "endEncoding";
+        private static readonly Selector sel_fillBufferrangevalue = "fillBuffer:range:value:";
+        private static readonly Selector sel_generateMipmapsForTexture = "generateMipmapsForTexture:";
         private static readonly Selector sel_getTextureAccessCountersregionmipLevelsliceresetCounterscountersBuffercountersBufferOffset = "getTextureAccessCounters:region:mipLevel:slice:resetCounters:countersBuffer:countersBufferOffset:";
-        private static readonly Selector sel_resetTextureAccessCountersregionmipLevelslice = "resetTextureAccessCounters:region:mipLevel:slice:";
-        private static readonly Selector sel_optimizeContentsForGPUAccess = "optimizeContentsForGPUAccess:";
-        private static readonly Selector sel_optimizeContentsForGPUAccessslicelevel = "optimizeContentsForGPUAccess:slice:level:";
+        private static readonly Selector sel_insertDebugSignpost = "insertDebugSignpost:";
+        private static readonly Selector sel_label = "label";
         private static readonly Selector sel_optimizeContentsForCPUAccess = "optimizeContentsForCPUAccess:";
         private static readonly Selector sel_optimizeContentsForCPUAccessslicelevel = "optimizeContentsForCPUAccess:slice:level:";
-        private static readonly Selector sel_resetCommandsInBufferwithRange = "resetCommandsInBuffer:withRange:";
-        private static readonly Selector sel_copyIndirectCommandBuffersourceRangedestinationdestinationIndex = "copyIndirectCommandBuffer:sourceRange:destination:destinationIndex:";
+        private static readonly Selector sel_optimizeContentsForGPUAccess = "optimizeContentsForGPUAccess:";
+        private static readonly Selector sel_optimizeContentsForGPUAccessslicelevel = "optimizeContentsForGPUAccess:slice:level:";
         private static readonly Selector sel_optimizeIndirectCommandBufferwithRange = "optimizeIndirectCommandBuffer:withRange:";
-        private static readonly Selector sel_sampleCountersInBufferatSampleIndexwithBarrier = "sampleCountersInBuffer:atSampleIndex:withBarrier:";
-        private static readonly Selector sel_resolveCountersinRangedestinationBufferdestinationOffset = "resolveCounters:inRange:destinationBuffer:destinationOffset:";
-        private static readonly Selector sel_device = "device";
-        private static readonly Selector sel_label = "label";
-        private static readonly Selector sel_setLabel = "setLabel:";
-        private static readonly Selector sel_endEncoding = "endEncoding";
-        private static readonly Selector sel_insertDebugSignpost = "insertDebugSignpost:";
-        private static readonly Selector sel_pushDebugGroup = "pushDebugGroup:";
         private static readonly Selector sel_popDebugGroup = "popDebugGroup";
+        private static readonly Selector sel_pushDebugGroup = "pushDebugGroup:";
+        private static readonly Selector sel_resetCommandsInBufferwithRange = "resetCommandsInBuffer:withRange:";
+        private static readonly Selector sel_resetTextureAccessCountersregionmipLevelslice = "resetTextureAccessCounters:region:mipLevel:slice:";
+        private static readonly Selector sel_resolveCountersinRangedestinationBufferdestinationOffset = "resolveCounters:inRange:destinationBuffer:destinationOffset:";
+        private static readonly Selector sel_sampleCountersInBufferatSampleIndexwithBarrier = "sampleCountersInBuffer:atSampleIndex:withBarrier:";
+        private static readonly Selector sel_setLabel = "setLabel:";
+        private static readonly Selector sel_synchronizeResource = "synchronizeResource:";
+        private static readonly Selector sel_synchronizeTextureslicelevel = "synchronizeTexture:slice:level:";
+        private static readonly Selector sel_updateFence = "updateFence:";
+        private static readonly Selector sel_waitForFence = "waitForFence:";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLBlitPass.cs
+++ b/src/SharpMetal/Metal/MTLBlitPass.cs
@@ -5,6 +5,31 @@ using SharpMetal.Foundation;
 namespace SharpMetal.Metal
 {
     [SupportedOSPlatform("macos")]
+    public struct MTLBlitPassDescriptor : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLBlitPassDescriptor obj) => obj.NativePtr;
+        public MTLBlitPassDescriptor(IntPtr ptr) => NativePtr = ptr;
+
+        public MTLBlitPassDescriptor()
+        {
+            var cls = new ObjectiveCClass("MTLBlitPassDescriptor");
+            NativePtr = cls.AllocInit();
+        }
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public MTLBlitPassSampleBufferAttachmentDescriptorArray SampleBufferAttachments => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_sampleBufferAttachments));
+
+        private static readonly Selector sel_blitPassDescriptor = "blitPassDescriptor";
+        private static readonly Selector sel_sampleBufferAttachments = "sampleBufferAttachments";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
     public struct MTLBlitPassSampleBufferAttachmentDescriptor : IDisposable
     {
         public IntPtr NativePtr;
@@ -22,6 +47,12 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
+        public ulong EndOfEncoderSampleIndex
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_endOfEncoderSampleIndex);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setEndOfEncoderSampleIndex, value);
+        }
+
         public MTLCounterSampleBuffer SampleBuffer
         {
             get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_sampleBuffer));
@@ -34,18 +65,12 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStartOfEncoderSampleIndex, value);
         }
 
-        public ulong EndOfEncoderSampleIndex
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_endOfEncoderSampleIndex);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setEndOfEncoderSampleIndex, value);
-        }
-
-        private static readonly Selector sel_sampleBuffer = "sampleBuffer";
-        private static readonly Selector sel_setSampleBuffer = "setSampleBuffer:";
-        private static readonly Selector sel_startOfEncoderSampleIndex = "startOfEncoderSampleIndex";
-        private static readonly Selector sel_setStartOfEncoderSampleIndex = "setStartOfEncoderSampleIndex:";
         private static readonly Selector sel_endOfEncoderSampleIndex = "endOfEncoderSampleIndex";
+        private static readonly Selector sel_sampleBuffer = "sampleBuffer";
         private static readonly Selector sel_setEndOfEncoderSampleIndex = "setEndOfEncoderSampleIndex:";
+        private static readonly Selector sel_setSampleBuffer = "setSampleBuffer:";
+        private static readonly Selector sel_setStartOfEncoderSampleIndex = "setStartOfEncoderSampleIndex:";
+        private static readonly Selector sel_startOfEncoderSampleIndex = "startOfEncoderSampleIndex";
         private static readonly Selector sel_release = "release";
     }
 
@@ -79,31 +104,6 @@ namespace SharpMetal.Metal
 
         private static readonly Selector sel_objectAtIndexedSubscript = "objectAtIndexedSubscript:";
         private static readonly Selector sel_setObjectatIndexedSubscript = "setObject:atIndexedSubscript:";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLBlitPassDescriptor : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLBlitPassDescriptor obj) => obj.NativePtr;
-        public MTLBlitPassDescriptor(IntPtr ptr) => NativePtr = ptr;
-
-        public MTLBlitPassDescriptor()
-        {
-            var cls = new ObjectiveCClass("MTLBlitPassDescriptor");
-            NativePtr = cls.AllocInit();
-        }
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public MTLBlitPassSampleBufferAttachmentDescriptorArray SampleBufferAttachments => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_sampleBufferAttachments));
-
-        private static readonly Selector sel_blitPassDescriptor = "blitPassDescriptor";
-        private static readonly Selector sel_sampleBufferAttachments = "sampleBufferAttachments";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLBuffer.cs
+++ b/src/SharpMetal/Metal/MTLBuffer.cs
@@ -17,13 +17,23 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public ulong Length => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_length);
+        public ulong AllocatedSize => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_allocatedSize);
 
         public IntPtr Contents => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_contents));
 
-        public MTLBuffer RemoteStorageBuffer => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_remoteStorageBuffer));
+        public MTLCPUCacheMode CpuCacheMode => (MTLCPUCacheMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_cpuCacheMode);
+
+        public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
 
         public ulong GpuAddress => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_gpuAddress);
+
+        public MTLHazardTrackingMode HazardTrackingMode => (MTLHazardTrackingMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_hazardTrackingMode);
+
+        public MTLHeap Heap => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_heap));
+
+        public ulong HeapOffset => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_heapOffset);
+
+        public bool IsAliasable => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isAliasable);
 
         public NSString Label
         {
@@ -31,52 +41,22 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
         }
 
-        public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
+        public ulong Length => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_length);
 
-        public MTLCPUCacheMode CpuCacheMode => (MTLCPUCacheMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_cpuCacheMode);
-
-        public MTLStorageMode StorageMode => (MTLStorageMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_storageMode);
-
-        public MTLHazardTrackingMode HazardTrackingMode => (MTLHazardTrackingMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_hazardTrackingMode);
+        public MTLBuffer RemoteStorageBuffer => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_remoteStorageBuffer));
 
         public MTLResourceOptions ResourceOptions => (MTLResourceOptions)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_resourceOptions);
 
-        public MTLHeap Heap => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_heap));
-
-        public ulong HeapOffset => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_heapOffset);
-
-        public ulong AllocatedSize => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_allocatedSize);
-
-        public bool IsAliasable => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isAliasable);
-
-        public void DidModifyRange(NSRange range)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_didModifyRange, range);
-        }
-
-        public MTLTexture NewTexture(MTLTextureDescriptor descriptor, ulong offset, ulong bytesPerRow)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newTextureWithDescriptoroffsetbytesPerRow, descriptor, offset, bytesPerRow));
-        }
+        public MTLStorageMode StorageMode => (MTLStorageMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_storageMode);
 
         public void AddDebugMarker(NSString marker, NSRange range)
         {
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_addDebugMarkerrange, marker, range);
         }
 
-        public void RemoveAllDebugMarkers()
+        public void DidModifyRange(NSRange range)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_removeAllDebugMarkers);
-        }
-
-        public MTLBuffer NewRemoteBufferViewForDevice(MTLDevice device)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newRemoteBufferViewForDevice, device));
-        }
-
-        public MTLPurgeableState SetPurgeableState(MTLPurgeableState state)
-        {
-            return (MTLPurgeableState)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_setPurgeableState, (ulong)state);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_didModifyRange, range);
         }
 
         public void MakeAliasable()
@@ -84,28 +64,48 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_makeAliasable);
         }
 
-        private static readonly Selector sel_length = "length";
-        private static readonly Selector sel_contents = "contents";
-        private static readonly Selector sel_didModifyRange = "didModifyRange:";
-        private static readonly Selector sel_newTextureWithDescriptoroffsetbytesPerRow = "newTextureWithDescriptor:offset:bytesPerRow:";
+        public MTLBuffer NewRemoteBufferViewForDevice(MTLDevice device)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newRemoteBufferViewForDevice, device));
+        }
+
+        public MTLTexture NewTexture(MTLTextureDescriptor descriptor, ulong offset, ulong bytesPerRow)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newTextureWithDescriptoroffsetbytesPerRow, descriptor, offset, bytesPerRow));
+        }
+
+        public void RemoveAllDebugMarkers()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_removeAllDebugMarkers);
+        }
+
+        public MTLPurgeableState SetPurgeableState(MTLPurgeableState state)
+        {
+            return (MTLPurgeableState)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_setPurgeableState, (ulong)state);
+        }
+
         private static readonly Selector sel_addDebugMarkerrange = "addDebugMarker:range:";
-        private static readonly Selector sel_removeAllDebugMarkers = "removeAllDebugMarkers";
-        private static readonly Selector sel_remoteStorageBuffer = "remoteStorageBuffer";
-        private static readonly Selector sel_newRemoteBufferViewForDevice = "newRemoteBufferViewForDevice:";
-        private static readonly Selector sel_gpuAddress = "gpuAddress";
-        private static readonly Selector sel_label = "label";
-        private static readonly Selector sel_setLabel = "setLabel:";
-        private static readonly Selector sel_device = "device";
+        private static readonly Selector sel_allocatedSize = "allocatedSize";
+        private static readonly Selector sel_contents = "contents";
         private static readonly Selector sel_cpuCacheMode = "cpuCacheMode";
-        private static readonly Selector sel_storageMode = "storageMode";
+        private static readonly Selector sel_device = "device";
+        private static readonly Selector sel_didModifyRange = "didModifyRange:";
+        private static readonly Selector sel_gpuAddress = "gpuAddress";
         private static readonly Selector sel_hazardTrackingMode = "hazardTrackingMode";
-        private static readonly Selector sel_resourceOptions = "resourceOptions";
-        private static readonly Selector sel_setPurgeableState = "setPurgeableState:";
         private static readonly Selector sel_heap = "heap";
         private static readonly Selector sel_heapOffset = "heapOffset";
-        private static readonly Selector sel_allocatedSize = "allocatedSize";
-        private static readonly Selector sel_makeAliasable = "makeAliasable";
         private static readonly Selector sel_isAliasable = "isAliasable";
+        private static readonly Selector sel_label = "label";
+        private static readonly Selector sel_length = "length";
+        private static readonly Selector sel_makeAliasable = "makeAliasable";
+        private static readonly Selector sel_newRemoteBufferViewForDevice = "newRemoteBufferViewForDevice:";
+        private static readonly Selector sel_newTextureWithDescriptoroffsetbytesPerRow = "newTextureWithDescriptor:offset:bytesPerRow:";
+        private static readonly Selector sel_remoteStorageBuffer = "remoteStorageBuffer";
+        private static readonly Selector sel_removeAllDebugMarkers = "removeAllDebugMarkers";
+        private static readonly Selector sel_resourceOptions = "resourceOptions";
+        private static readonly Selector sel_setLabel = "setLabel:";
+        private static readonly Selector sel_setPurgeableState = "setPurgeableState:";
+        private static readonly Selector sel_storageMode = "storageMode";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLCaptureManager.cs
+++ b/src/SharpMetal/Metal/MTLCaptureManager.cs
@@ -5,18 +5,18 @@ using SharpMetal.Foundation;
 namespace SharpMetal.Metal
 {
     [SupportedOSPlatform("macos")]
+    public enum MTLCaptureDestination : long
+    {
+        DeveloperTools = 1,
+        GPUTraceDocument = 2,
+    }
+
+    [SupportedOSPlatform("macos")]
     public enum MTLCaptureError : long
     {
         NotSupported = 1,
         AlreadyCapturing = 2,
         InvalidDescriptor = 3,
-    }
-
-    [SupportedOSPlatform("macos")]
-    public enum MTLCaptureDestination : long
-    {
-        DeveloperTools = 1,
-        GPUTraceDocument = 2,
     }
 
     [SupportedOSPlatform("macos")]
@@ -56,10 +56,10 @@ namespace SharpMetal.Metal
         }
 
         private static readonly Selector sel_captureObject = "captureObject";
-        private static readonly Selector sel_setCaptureObject = "setCaptureObject:";
         private static readonly Selector sel_destination = "destination";
-        private static readonly Selector sel_setDestination = "setDestination:";
         private static readonly Selector sel_outputURL = "outputURL";
+        private static readonly Selector sel_setCaptureObject = "setCaptureObject:";
+        private static readonly Selector sel_setDestination = "setDestination:";
         private static readonly Selector sel_setOutputURL = "setOutputURL:";
         private static readonly Selector sel_release = "release";
     }
@@ -90,11 +90,6 @@ namespace SharpMetal.Metal
 
         public bool IsCapturing => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isCapturing);
 
-        public static MTLCaptureManager SharedCaptureManager()
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(new ObjectiveCClass("MTLCaptureManager"), sel_sharedCaptureManager));
-        }
-
         public MTLCaptureScope NewCaptureScope(MTLDevice device)
         {
             return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newCaptureScopeWithDevice, device));
@@ -105,9 +100,9 @@ namespace SharpMetal.Metal
             return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newCaptureScopeWithCommandQueue, commandQueue));
         }
 
-        public bool SupportsDestination(MTLCaptureDestination destination)
+        public static MTLCaptureManager SharedCaptureManager()
         {
-            return ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportsDestination, (long)destination);
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(new ObjectiveCClass("MTLCaptureManager"), sel_sharedCaptureManager));
         }
 
         public bool StartCapture(MTLCaptureDescriptor descriptor, ref NSError error)
@@ -135,18 +130,23 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_stopCapture);
         }
 
-        private static readonly Selector sel_sharedCaptureManager = "sharedCaptureManager";
-        private static readonly Selector sel_newCaptureScopeWithDevice = "newCaptureScopeWithDevice:";
+        public bool SupportsDestination(MTLCaptureDestination destination)
+        {
+            return ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportsDestination, (long)destination);
+        }
+
+        private static readonly Selector sel_defaultCaptureScope = "defaultCaptureScope";
+        private static readonly Selector sel_isCapturing = "isCapturing";
         private static readonly Selector sel_newCaptureScopeWithCommandQueue = "newCaptureScopeWithCommandQueue:";
-        private static readonly Selector sel_supportsDestination = "supportsDestination:";
+        private static readonly Selector sel_newCaptureScopeWithDevice = "newCaptureScopeWithDevice:";
+        private static readonly Selector sel_setDefaultCaptureScope = "setDefaultCaptureScope:";
+        private static readonly Selector sel_sharedCaptureManager = "sharedCaptureManager";
+        private static readonly Selector sel_startCaptureWithCommandQueue = "startCaptureWithCommandQueue:";
         private static readonly Selector sel_startCaptureWithDescriptorerror = "startCaptureWithDescriptor:error:";
         private static readonly Selector sel_startCaptureWithDevice = "startCaptureWithDevice:";
-        private static readonly Selector sel_startCaptureWithCommandQueue = "startCaptureWithCommandQueue:";
         private static readonly Selector sel_startCaptureWithScope = "startCaptureWithScope:";
         private static readonly Selector sel_stopCapture = "stopCapture";
-        private static readonly Selector sel_defaultCaptureScope = "defaultCaptureScope";
-        private static readonly Selector sel_setDefaultCaptureScope = "setDefaultCaptureScope:";
-        private static readonly Selector sel_isCapturing = "isCapturing";
+        private static readonly Selector sel_supportsDestination = "supportsDestination:";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLCaptureScope.cs
+++ b/src/SharpMetal/Metal/MTLCaptureScope.cs
@@ -16,6 +16,8 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
+        public MTLCommandQueue CommandQueue => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_commandQueue));
+
         public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
 
         public NSString Label
@@ -23,8 +25,6 @@ namespace SharpMetal.Metal
             get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
         }
-
-        public MTLCommandQueue CommandQueue => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_commandQueue));
 
         public void BeginScope()
         {
@@ -36,12 +36,12 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_endScope);
         }
 
+        private static readonly Selector sel_beginScope = "beginScope";
+        private static readonly Selector sel_commandQueue = "commandQueue";
         private static readonly Selector sel_device = "device";
+        private static readonly Selector sel_endScope = "endScope";
         private static readonly Selector sel_label = "label";
         private static readonly Selector sel_setLabel = "setLabel:";
-        private static readonly Selector sel_commandQueue = "commandQueue";
-        private static readonly Selector sel_beginScope = "beginScope";
-        private static readonly Selector sel_endScope = "endScope";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLCommandBuffer.cs
+++ b/src/SharpMetal/Metal/MTLCommandBuffer.cs
@@ -5,17 +5,6 @@ using SharpMetal.Foundation;
 namespace SharpMetal.Metal
 {
     [SupportedOSPlatform("macos")]
-    public enum MTLCommandBufferStatus : ulong
-    {
-        NotEnqueued = 0,
-        Enqueued = 1,
-        Committed = 2,
-        Scheduled = 3,
-        Completed = 4,
-        Error = 5,
-    }
-
-    [SupportedOSPlatform("macos")]
     public enum MTLCommandBufferError : ulong
     {
         None = 0,
@@ -41,6 +30,17 @@ namespace SharpMetal.Metal
     }
 
     [SupportedOSPlatform("macos")]
+    public enum MTLCommandBufferStatus : ulong
+    {
+        NotEnqueued = 0,
+        Enqueued = 1,
+        Committed = 2,
+        Scheduled = 3,
+        Completed = 4,
+        Error = 5,
+    }
+
+    [SupportedOSPlatform("macos")]
     public enum MTLCommandEncoderErrorState : long
     {
         Unknown = 0,
@@ -55,6 +55,194 @@ namespace SharpMetal.Metal
     {
         Serial = 0,
         Concurrent = 1,
+    }
+
+    [SupportedOSPlatform("macos")]
+    public struct MTLCommandBuffer : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLCommandBuffer obj) => obj.NativePtr;
+        public MTLCommandBuffer(IntPtr ptr) => NativePtr = ptr;
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public MTLCommandQueue CommandQueue => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_commandQueue));
+
+        public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
+
+        public NSError Error => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_error));
+
+        public MTLCommandBufferErrorOption ErrorOptions => (MTLCommandBufferErrorOption)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_errorOptions);
+
+        public IntPtr GPUEndTime => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_GPUEndTime));
+
+        public IntPtr GPUStartTime => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_GPUStartTime));
+
+        public IntPtr KernelEndTime => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_kernelEndTime));
+
+        public IntPtr KernelStartTime => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_kernelStartTime));
+
+        public NSString Label
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
+        }
+
+        public MTLLogContainer Logs => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_logs));
+
+        public bool RetainedReferences => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_retainedReferences);
+
+        public MTLCommandBufferStatus Status => (MTLCommandBufferStatus)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_status);
+
+        public MTLAccelerationStructureCommandEncoder AccelerationStructureCommandEncoder()
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_accelerationStructureCommandEncoderWithDescriptor));
+        }
+
+        public MTLAccelerationStructureCommandEncoder AccelerationStructureCommandEncoder(MTLAccelerationStructurePassDescriptor descriptor)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_accelerationStructureCommandEncoderWithDescriptor, descriptor));
+        }
+
+        public MTLBlitCommandEncoder BlitCommandEncoder()
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_blitCommandEncoderWithDescriptor));
+        }
+
+        public MTLBlitCommandEncoder BlitCommandEncoder(MTLBlitPassDescriptor blitPassDescriptor)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_blitCommandEncoderWithDescriptor, blitPassDescriptor));
+        }
+
+        public void Commit()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_commit);
+        }
+
+        public MTLComputeCommandEncoder ComputeCommandEncoder(MTLDispatchType dispatchType)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_computeCommandEncoderWithDispatchType, (ulong)dispatchType));
+        }
+
+        public MTLComputeCommandEncoder ComputeCommandEncoder(MTLComputePassDescriptor computePassDescriptor)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_computeCommandEncoderWithDescriptor, computePassDescriptor));
+        }
+
+        public MTLComputeCommandEncoder ComputeCommandEncoder()
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_computeCommandEncoder));
+        }
+
+        public void EncodeSignalEvent(MTLEvent mtlEvent, ulong value)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_encodeSignalEventvalue, mtlEvent, value);
+        }
+
+        public void EncodeWait(MTLEvent mtlEvent, ulong value)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_encodeWaitForEventvalue, mtlEvent, value);
+        }
+
+        public void Enqueue()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_enqueue);
+        }
+
+        public MTLParallelRenderCommandEncoder ParallelRenderCommandEncoder(MTLRenderPassDescriptor renderPassDescriptor)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_parallelRenderCommandEncoderWithDescriptor, renderPassDescriptor));
+        }
+
+        public void PopDebugGroup()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_popDebugGroup);
+        }
+
+        public void PresentDrawable(MTLDrawable drawable)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_presentDrawable, drawable);
+        }
+
+        public void PresentDrawableAfterMinimumDuration(MTLDrawable drawable, IntPtr duration)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_presentDrawableafterMinimumDuration, drawable, duration);
+        }
+
+        public void PresentDrawableAtTime(MTLDrawable drawable, IntPtr presentationTime)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_presentDrawableatTime, drawable, presentationTime);
+        }
+
+        public void PushDebugGroup(NSString nsString)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_pushDebugGroup, nsString);
+        }
+
+        public MTLRenderCommandEncoder RenderCommandEncoder(MTLRenderPassDescriptor renderPassDescriptor)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_renderCommandEncoderWithDescriptor, renderPassDescriptor));
+        }
+
+        public MTLResourceStateCommandEncoder ResourceStateCommandEncoder(MTLResourceStatePassDescriptor resourceStatePassDescriptor)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_resourceStateCommandEncoderWithDescriptor, resourceStatePassDescriptor));
+        }
+
+        public MTLResourceStateCommandEncoder ResourceStateCommandEncoder()
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_resourceStateCommandEncoderWithDescriptor));
+        }
+
+        public void WaitUntilCompleted()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_waitUntilCompleted);
+        }
+
+        public void WaitUntilScheduled()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_waitUntilScheduled);
+        }
+
+        private static readonly Selector sel_accelerationStructureCommandEncoder = "accelerationStructureCommandEncoder";
+        private static readonly Selector sel_accelerationStructureCommandEncoderWithDescriptor = "accelerationStructureCommandEncoderWithDescriptor:";
+        private static readonly Selector sel_blitCommandEncoder = "blitCommandEncoder";
+        private static readonly Selector sel_blitCommandEncoderWithDescriptor = "blitCommandEncoderWithDescriptor:";
+        private static readonly Selector sel_commandQueue = "commandQueue";
+        private static readonly Selector sel_commit = "commit";
+        private static readonly Selector sel_computeCommandEncoder = "computeCommandEncoder";
+        private static readonly Selector sel_computeCommandEncoderWithDescriptor = "computeCommandEncoderWithDescriptor:";
+        private static readonly Selector sel_computeCommandEncoderWithDispatchType = "computeCommandEncoderWithDispatchType:";
+        private static readonly Selector sel_device = "device";
+        private static readonly Selector sel_encodeSignalEventvalue = "encodeSignalEvent:value:";
+        private static readonly Selector sel_encodeWaitForEventvalue = "encodeWaitForEvent:value:";
+        private static readonly Selector sel_enqueue = "enqueue";
+        private static readonly Selector sel_error = "error";
+        private static readonly Selector sel_errorOptions = "errorOptions";
+        private static readonly Selector sel_GPUEndTime = "GPUEndTime";
+        private static readonly Selector sel_GPUStartTime = "GPUStartTime";
+        private static readonly Selector sel_kernelEndTime = "kernelEndTime";
+        private static readonly Selector sel_kernelStartTime = "kernelStartTime";
+        private static readonly Selector sel_label = "label";
+        private static readonly Selector sel_logs = "logs";
+        private static readonly Selector sel_parallelRenderCommandEncoderWithDescriptor = "parallelRenderCommandEncoderWithDescriptor:";
+        private static readonly Selector sel_popDebugGroup = "popDebugGroup";
+        private static readonly Selector sel_presentDrawable = "presentDrawable:";
+        private static readonly Selector sel_presentDrawableafterMinimumDuration = "presentDrawable:afterMinimumDuration:";
+        private static readonly Selector sel_presentDrawableatTime = "presentDrawable:atTime:";
+        private static readonly Selector sel_pushDebugGroup = "pushDebugGroup:";
+        private static readonly Selector sel_renderCommandEncoderWithDescriptor = "renderCommandEncoderWithDescriptor:";
+        private static readonly Selector sel_resourceStateCommandEncoder = "resourceStateCommandEncoder";
+        private static readonly Selector sel_resourceStateCommandEncoderWithDescriptor = "resourceStateCommandEncoderWithDescriptor:";
+        private static readonly Selector sel_retainedReferences = "retainedReferences";
+        private static readonly Selector sel_setLabel = "setLabel:";
+        private static readonly Selector sel_status = "status";
+        private static readonly Selector sel_waitUntilCompleted = "waitUntilCompleted";
+        private static readonly Selector sel_waitUntilScheduled = "waitUntilScheduled";
+        private static readonly Selector sel_release = "release";
     }
 
     [SupportedOSPlatform("macos")]
@@ -75,22 +263,22 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public bool RetainedReferences
-        {
-            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_retainedReferences);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRetainedReferences, value);
-        }
-
         public MTLCommandBufferErrorOption ErrorOptions
         {
             get => (MTLCommandBufferErrorOption)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_errorOptions);
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setErrorOptions, (ulong)value);
         }
 
-        private static readonly Selector sel_retainedReferences = "retainedReferences";
-        private static readonly Selector sel_setRetainedReferences = "setRetainedReferences:";
+        public bool RetainedReferences
+        {
+            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_retainedReferences);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRetainedReferences, value);
+        }
+
         private static readonly Selector sel_errorOptions = "errorOptions";
+        private static readonly Selector sel_retainedReferences = "retainedReferences";
         private static readonly Selector sel_setErrorOptions = "setErrorOptions:";
+        private static readonly Selector sel_setRetainedReferences = "setRetainedReferences:";
         private static readonly Selector sel_release = "release";
     }
 
@@ -106,203 +294,15 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public NSString Label => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
-
         public NSArray DebugSignposts => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_debugSignposts));
 
         public MTLCommandEncoderErrorState ErrorState => (MTLCommandEncoderErrorState)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_errorState);
 
-        private static readonly Selector sel_label = "label";
+        public NSString Label => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
+
         private static readonly Selector sel_debugSignposts = "debugSignposts";
         private static readonly Selector sel_errorState = "errorState";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLCommandBuffer : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLCommandBuffer obj) => obj.NativePtr;
-        public MTLCommandBuffer(IntPtr ptr) => NativePtr = ptr;
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
-
-        public MTLCommandQueue CommandQueue => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_commandQueue));
-
-        public bool RetainedReferences => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_retainedReferences);
-
-        public MTLCommandBufferErrorOption ErrorOptions => (MTLCommandBufferErrorOption)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_errorOptions);
-
-        public NSString Label
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
-        }
-
-        public IntPtr KernelStartTime => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_kernelStartTime));
-
-        public IntPtr KernelEndTime => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_kernelEndTime));
-
-        public MTLLogContainer Logs => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_logs));
-
-        public IntPtr GPUStartTime => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_GPUStartTime));
-
-        public IntPtr GPUEndTime => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_GPUEndTime));
-
-        public MTLCommandBufferStatus Status => (MTLCommandBufferStatus)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_status);
-
-        public NSError Error => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_error));
-
-        public void Enqueue()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_enqueue);
-        }
-
-        public void Commit()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_commit);
-        }
-
-        public void PresentDrawable(MTLDrawable drawable)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_presentDrawable, drawable);
-        }
-
-        public void PresentDrawableAtTime(MTLDrawable drawable, IntPtr presentationTime)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_presentDrawableatTime, drawable, presentationTime);
-        }
-
-        public void PresentDrawableAfterMinimumDuration(MTLDrawable drawable, IntPtr duration)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_presentDrawableafterMinimumDuration, drawable, duration);
-        }
-
-        public void WaitUntilScheduled()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_waitUntilScheduled);
-        }
-
-        public void WaitUntilCompleted()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_waitUntilCompleted);
-        }
-
-        public MTLRenderCommandEncoder RenderCommandEncoder(MTLRenderPassDescriptor renderPassDescriptor)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_renderCommandEncoderWithDescriptor, renderPassDescriptor));
-        }
-
-        public MTLComputeCommandEncoder ComputeCommandEncoder(MTLComputePassDescriptor computePassDescriptor)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_computeCommandEncoderWithDescriptor, computePassDescriptor));
-        }
-
-        public MTLBlitCommandEncoder BlitCommandEncoder(MTLBlitPassDescriptor blitPassDescriptor)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_blitCommandEncoderWithDescriptor, blitPassDescriptor));
-        }
-
-        public MTLBlitCommandEncoder BlitCommandEncoder()
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_blitCommandEncoderWithDescriptor));
-        }
-
-        public MTLComputeCommandEncoder ComputeCommandEncoder()
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_computeCommandEncoder));
-        }
-
-        public MTLComputeCommandEncoder ComputeCommandEncoder(MTLDispatchType dispatchType)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_computeCommandEncoderWithDispatchType, (ulong)dispatchType));
-        }
-
-        public void EncodeWait(MTLEvent mtlEvent, ulong value)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_encodeWaitForEventvalue, mtlEvent, value);
-        }
-
-        public void EncodeSignalEvent(MTLEvent mtlEvent, ulong value)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_encodeSignalEventvalue, mtlEvent, value);
-        }
-
-        public MTLParallelRenderCommandEncoder ParallelRenderCommandEncoder(MTLRenderPassDescriptor renderPassDescriptor)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_parallelRenderCommandEncoderWithDescriptor, renderPassDescriptor));
-        }
-
-        public MTLResourceStateCommandEncoder ResourceStateCommandEncoder(MTLResourceStatePassDescriptor resourceStatePassDescriptor)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_resourceStateCommandEncoderWithDescriptor, resourceStatePassDescriptor));
-        }
-
-        public MTLResourceStateCommandEncoder ResourceStateCommandEncoder()
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_resourceStateCommandEncoderWithDescriptor));
-        }
-
-        public MTLAccelerationStructureCommandEncoder AccelerationStructureCommandEncoder(MTLAccelerationStructurePassDescriptor descriptor)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_accelerationStructureCommandEncoderWithDescriptor, descriptor));
-        }
-
-        public MTLAccelerationStructureCommandEncoder AccelerationStructureCommandEncoder()
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_accelerationStructureCommandEncoderWithDescriptor));
-        }
-
-        public void PushDebugGroup(NSString nsString)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_pushDebugGroup, nsString);
-        }
-
-        public void PopDebugGroup()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_popDebugGroup);
-        }
-
-        private static readonly Selector sel_device = "device";
-        private static readonly Selector sel_commandQueue = "commandQueue";
-        private static readonly Selector sel_retainedReferences = "retainedReferences";
-        private static readonly Selector sel_errorOptions = "errorOptions";
         private static readonly Selector sel_label = "label";
-        private static readonly Selector sel_setLabel = "setLabel:";
-        private static readonly Selector sel_kernelStartTime = "kernelStartTime";
-        private static readonly Selector sel_kernelEndTime = "kernelEndTime";
-        private static readonly Selector sel_logs = "logs";
-        private static readonly Selector sel_GPUStartTime = "GPUStartTime";
-        private static readonly Selector sel_GPUEndTime = "GPUEndTime";
-        private static readonly Selector sel_enqueue = "enqueue";
-        private static readonly Selector sel_commit = "commit";
-        private static readonly Selector sel_presentDrawable = "presentDrawable:";
-        private static readonly Selector sel_presentDrawableatTime = "presentDrawable:atTime:";
-        private static readonly Selector sel_presentDrawableafterMinimumDuration = "presentDrawable:afterMinimumDuration:";
-        private static readonly Selector sel_waitUntilScheduled = "waitUntilScheduled";
-        private static readonly Selector sel_waitUntilCompleted = "waitUntilCompleted";
-        private static readonly Selector sel_status = "status";
-        private static readonly Selector sel_error = "error";
-        private static readonly Selector sel_blitCommandEncoder = "blitCommandEncoder";
-        private static readonly Selector sel_renderCommandEncoderWithDescriptor = "renderCommandEncoderWithDescriptor:";
-        private static readonly Selector sel_computeCommandEncoderWithDescriptor = "computeCommandEncoderWithDescriptor:";
-        private static readonly Selector sel_blitCommandEncoderWithDescriptor = "blitCommandEncoderWithDescriptor:";
-        private static readonly Selector sel_computeCommandEncoder = "computeCommandEncoder";
-        private static readonly Selector sel_computeCommandEncoderWithDispatchType = "computeCommandEncoderWithDispatchType:";
-        private static readonly Selector sel_encodeWaitForEventvalue = "encodeWaitForEvent:value:";
-        private static readonly Selector sel_encodeSignalEventvalue = "encodeSignalEvent:value:";
-        private static readonly Selector sel_parallelRenderCommandEncoderWithDescriptor = "parallelRenderCommandEncoderWithDescriptor:";
-        private static readonly Selector sel_resourceStateCommandEncoder = "resourceStateCommandEncoder";
-        private static readonly Selector sel_resourceStateCommandEncoderWithDescriptor = "resourceStateCommandEncoderWithDescriptor:";
-        private static readonly Selector sel_accelerationStructureCommandEncoder = "accelerationStructureCommandEncoder";
-        private static readonly Selector sel_accelerationStructureCommandEncoderWithDescriptor = "accelerationStructureCommandEncoderWithDescriptor:";
-        private static readonly Selector sel_pushDebugGroup = "pushDebugGroup:";
-        private static readonly Selector sel_popDebugGroup = "popDebugGroup";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLCommandEncoder.cs
+++ b/src/SharpMetal/Metal/MTLCommandEncoder.cs
@@ -6,20 +6,20 @@ namespace SharpMetal.Metal
 {
     [SupportedOSPlatform("macos")]
     [Flags]
-    public enum MTLResourceUsage : ulong
-    {
-        Read = 1,
-        Write = 2,
-        Sample = 4,
-    }
-
-    [SupportedOSPlatform("macos")]
-    [Flags]
     public enum MTLBarrierScope : ulong
     {
         Buffers = 1,
         Textures = 2,
         RenderTargets = 4,
+    }
+
+    [SupportedOSPlatform("macos")]
+    [Flags]
+    public enum MTLResourceUsage : ulong
+    {
+        Read = 1,
+        Write = 2,
+        Sample = 4,
     }
 
     [SupportedOSPlatform("macos")]
@@ -52,23 +52,23 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_insertDebugSignpost, nsString);
         }
 
-        public void PushDebugGroup(NSString nsString)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_pushDebugGroup, nsString);
-        }
-
         public void PopDebugGroup()
         {
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_popDebugGroup);
         }
 
+        public void PushDebugGroup(NSString nsString)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_pushDebugGroup, nsString);
+        }
+
         private static readonly Selector sel_device = "device";
-        private static readonly Selector sel_label = "label";
-        private static readonly Selector sel_setLabel = "setLabel:";
         private static readonly Selector sel_endEncoding = "endEncoding";
         private static readonly Selector sel_insertDebugSignpost = "insertDebugSignpost:";
-        private static readonly Selector sel_pushDebugGroup = "pushDebugGroup:";
+        private static readonly Selector sel_label = "label";
         private static readonly Selector sel_popDebugGroup = "popDebugGroup";
+        private static readonly Selector sel_pushDebugGroup = "pushDebugGroup:";
+        private static readonly Selector sel_setLabel = "setLabel:";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLCommandQueue.cs
+++ b/src/SharpMetal/Metal/MTLCommandQueue.cs
@@ -16,15 +16,15 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
+        public MTLCommandBuffer CommandBufferWithUnretainedReferences => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_commandBufferWithUnretainedReferences));
+
+        public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
+
         public NSString Label
         {
             get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
         }
-
-        public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
-
-        public MTLCommandBuffer CommandBufferWithUnretainedReferences => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_commandBufferWithUnretainedReferences));
 
         public MTLCommandBuffer CommandBuffer(MTLCommandBufferDescriptor descriptor)
         {
@@ -41,13 +41,13 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_insertDebugCaptureBoundary);
         }
 
-        private static readonly Selector sel_label = "label";
-        private static readonly Selector sel_setLabel = "setLabel:";
-        private static readonly Selector sel_device = "device";
         private static readonly Selector sel_commandBuffer = "commandBuffer";
         private static readonly Selector sel_commandBufferWithDescriptor = "commandBufferWithDescriptor:";
         private static readonly Selector sel_commandBufferWithUnretainedReferences = "commandBufferWithUnretainedReferences";
+        private static readonly Selector sel_device = "device";
         private static readonly Selector sel_insertDebugCaptureBoundary = "insertDebugCaptureBoundary";
+        private static readonly Selector sel_label = "label";
+        private static readonly Selector sel_setLabel = "setLabel:";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLComputeCommandEncoder.cs
+++ b/src/SharpMetal/Metal/MTLComputeCommandEncoder.cs
@@ -33,9 +33,9 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public MTLDispatchType DispatchType => (MTLDispatchType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_dispatchType);
-
         public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
+
+        public MTLDispatchType DispatchType => (MTLDispatchType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_dispatchType);
 
         public NSString Label
         {
@@ -43,124 +43,9 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
         }
 
-        public void SetComputePipelineState(MTLComputePipelineState state)
+        public void DispatchThreadgroups(MTLBuffer indirectBuffer, ulong indirectBufferOffset, MTLSize threadsPerThreadgroup)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setComputePipelineState, state);
-        }
-
-        public void SetBytes(IntPtr bytes, ulong length, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setByteslengthatIndex, bytes, length, index);
-        }
-
-        public void SetBuffer(MTLBuffer buffer, ulong offset, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBufferoffsetatIndex, buffer, offset, index);
-        }
-
-        public void SetBufferOffset(ulong offset, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBufferOffsetatIndex, offset, index);
-        }
-
-        public void SetBuffers(MTLBuffer[] buffers, ulong[] offsets, NSRange range)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void SetBuffer(MTLBuffer buffer, ulong offset, ulong stride, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBufferoffsetattributeStrideatIndex, buffer, offset, stride, index);
-        }
-
-        public void SetBuffers(MTLBuffer[] buffers, ulong offsets, ulong strides, NSRange range)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void SetBufferOffset(ulong offset, ulong stride, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBufferOffsetattributeStrideatIndex, offset, stride, index);
-        }
-
-        public void SetBytes(IntPtr bytes, ulong length, ulong stride, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setByteslengthattributeStrideatIndex, bytes, length, stride, index);
-        }
-
-        public void SetVisibleFunctionTable(MTLVisibleFunctionTable visibleFunctionTable, ulong bufferIndex)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVisibleFunctionTableatBufferIndex, visibleFunctionTable, bufferIndex);
-        }
-
-        public void SetVisibleFunctionTables(MTLVisibleFunctionTable[] visibleFunctionTables, NSRange range)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void SetIntersectionFunctionTable(MTLIntersectionFunctionTable intersectionFunctionTable, ulong bufferIndex)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIntersectionFunctionTableatBufferIndex, intersectionFunctionTable, bufferIndex);
-        }
-
-        public void SetIntersectionFunctionTables(MTLIntersectionFunctionTable[] intersectionFunctionTables, NSRange range)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void SetAccelerationStructure(MTLAccelerationStructure accelerationStructure, ulong bufferIndex)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setAccelerationStructureatBufferIndex, accelerationStructure, bufferIndex);
-        }
-
-        public void SetTexture(MTLTexture texture, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTextureatIndex, texture, index);
-        }
-
-        public void SetTextures(MTLTexture[] textures, NSRange range)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void SetSamplerState(MTLSamplerState sampler, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSamplerStateatIndex, sampler, index);
-        }
-
-        public void SetSamplerStates(MTLSamplerState[] samplers, NSRange range)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void SetSamplerState(MTLSamplerState sampler, float lodMinClamp, float lodMaxClamp, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSamplerStatelodMinClamplodMaxClampatIndex, sampler, lodMinClamp, lodMaxClamp, index);
-        }
-
-        public void SetSamplerStates(MTLSamplerState[] samplers, float[] lodMinClamps, float[] lodMaxClamps, NSRange range)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void SetThreadgroupMemoryLength(ulong length, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setThreadgroupMemoryLengthatIndex, length, index);
-        }
-
-        public void SetImageblockWidth(ulong width, ulong height)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setImageblockWidthheight, width, height);
-        }
-
-        public void SetStageInRegion(MTLRegion region)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStageInRegion, region);
-        }
-
-        public void SetStageInRegion(MTLBuffer indirectBuffer, ulong indirectBufferOffset)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStageInRegionWithIndirectBufferindirectBufferOffset, indirectBuffer, indirectBufferOffset);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_dispatchThreadgroupsWithIndirectBufferindirectBufferOffsetthreadsPerThreadgroup, indirectBuffer, indirectBufferOffset, threadsPerThreadgroup);
         }
 
         public void DispatchThreadgroups(MTLSize threadgroupsPerGrid, MTLSize threadsPerThreadgroup)
@@ -168,44 +53,14 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_dispatchThreadgroupsthreadsPerThreadgroup, threadgroupsPerGrid, threadsPerThreadgroup);
         }
 
-        public void DispatchThreadgroups(MTLBuffer indirectBuffer, ulong indirectBufferOffset, MTLSize threadsPerThreadgroup)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_dispatchThreadgroupsWithIndirectBufferindirectBufferOffsetthreadsPerThreadgroup, indirectBuffer, indirectBufferOffset, threadsPerThreadgroup);
-        }
-
         public void DispatchThreads(MTLSize threadsPerGrid, MTLSize threadsPerThreadgroup)
         {
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_dispatchThreadsthreadsPerThreadgroup, threadsPerGrid, threadsPerThreadgroup);
         }
 
-        public void UpdateFence(MTLFence fence)
+        public void EndEncoding()
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_updateFence, fence);
-        }
-
-        public void WaitForFence(MTLFence fence)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_waitForFence, fence);
-        }
-
-        public void UseResource(MTLResource resource, MTLResourceUsage usage)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_useResourceusage, resource, (ulong)usage);
-        }
-
-        public void UseResources(MTLResource[] resources, ulong count, MTLResourceUsage usage)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void UseHeap(MTLHeap heap)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_useHeap, heap);
-        }
-
-        public void UseHeaps(MTLHeap[] heaps, ulong count)
-        {
-            throw new NotImplementedException();
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_endEncoding);
         }
 
         public void ExecuteCommandsInBuffer(MTLIndirectCommandBuffer indirectCommandBuffer, NSRange executionRange)
@@ -218,6 +73,11 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_executeCommandsInBufferindirectBufferindirectBufferOffset, indirectCommandbuffer, indirectRangeBuffer, indirectBufferOffset);
         }
 
+        public void InsertDebugSignpost(NSString nsString)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_insertDebugSignpost, nsString);
+        }
+
         public void MemoryBarrier(MTLBarrierScope scope)
         {
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_memoryBarrierWithScope, (ulong)scope);
@@ -228,19 +88,9 @@ namespace SharpMetal.Metal
             throw new NotImplementedException();
         }
 
-        public void SampleCountersInBuffer(MTLCounterSampleBuffer sampleBuffer, ulong sampleIndex, bool barrier)
+        public void PopDebugGroup()
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_sampleCountersInBufferatSampleIndexwithBarrier, sampleBuffer, sampleIndex, barrier);
-        }
-
-        public void EndEncoding()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_endEncoding);
-        }
-
-        public void InsertDebugSignpost(NSString nsString)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_insertDebugSignpost, nsString);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_popDebugGroup);
         }
 
         public void PushDebugGroup(NSString nsString)
@@ -248,57 +98,207 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_pushDebugGroup, nsString);
         }
 
-        public void PopDebugGroup()
+        public void SampleCountersInBuffer(MTLCounterSampleBuffer sampleBuffer, ulong sampleIndex, bool barrier)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_popDebugGroup);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_sampleCountersInBufferatSampleIndexwithBarrier, sampleBuffer, sampleIndex, barrier);
         }
 
-        private static readonly Selector sel_dispatchType = "dispatchType";
-        private static readonly Selector sel_setComputePipelineState = "setComputePipelineState:";
-        private static readonly Selector sel_setByteslengthatIndex = "setBytes:length:atIndex:";
-        private static readonly Selector sel_setBufferoffsetatIndex = "setBuffer:offset:atIndex:";
-        private static readonly Selector sel_setBufferOffsetatIndex = "setBufferOffset:atIndex:";
-        private static readonly Selector sel_setBuffersoffsetswithRange = "setBuffers:offsets:withRange:";
-        private static readonly Selector sel_setBufferoffsetattributeStrideatIndex = "setBuffer:offset:attributeStride:atIndex:";
-        private static readonly Selector sel_setBuffersoffsetsattributeStrideswithRange = "setBuffers:offsets:attributeStrides:withRange:";
-        private static readonly Selector sel_setBufferOffsetattributeStrideatIndex = "setBufferOffset:attributeStride:atIndex:";
-        private static readonly Selector sel_setByteslengthattributeStrideatIndex = "setBytes:length:attributeStride:atIndex:";
-        private static readonly Selector sel_setVisibleFunctionTableatBufferIndex = "setVisibleFunctionTable:atBufferIndex:";
-        private static readonly Selector sel_setVisibleFunctionTableswithBufferRange = "setVisibleFunctionTables:withBufferRange:";
-        private static readonly Selector sel_setIntersectionFunctionTableatBufferIndex = "setIntersectionFunctionTable:atBufferIndex:";
-        private static readonly Selector sel_setIntersectionFunctionTableswithBufferRange = "setIntersectionFunctionTables:withBufferRange:";
-        private static readonly Selector sel_setAccelerationStructureatBufferIndex = "setAccelerationStructure:atBufferIndex:";
-        private static readonly Selector sel_setTextureatIndex = "setTexture:atIndex:";
-        private static readonly Selector sel_setTextureswithRange = "setTextures:withRange:";
-        private static readonly Selector sel_setSamplerStateatIndex = "setSamplerState:atIndex:";
-        private static readonly Selector sel_setSamplerStateswithRange = "setSamplerStates:withRange:";
-        private static readonly Selector sel_setSamplerStatelodMinClamplodMaxClampatIndex = "setSamplerState:lodMinClamp:lodMaxClamp:atIndex:";
-        private static readonly Selector sel_setSamplerStateslodMinClampslodMaxClampswithRange = "setSamplerStates:lodMinClamps:lodMaxClamps:withRange:";
-        private static readonly Selector sel_setThreadgroupMemoryLengthatIndex = "setThreadgroupMemoryLength:atIndex:";
-        private static readonly Selector sel_setImageblockWidthheight = "setImageblockWidth:height:";
-        private static readonly Selector sel_setStageInRegion = "setStageInRegion:";
-        private static readonly Selector sel_setStageInRegionWithIndirectBufferindirectBufferOffset = "setStageInRegionWithIndirectBuffer:indirectBufferOffset:";
+        public void SetAccelerationStructure(MTLAccelerationStructure accelerationStructure, ulong bufferIndex)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setAccelerationStructureatBufferIndex, accelerationStructure, bufferIndex);
+        }
+
+        public void SetBuffer(MTLBuffer buffer, ulong offset, ulong stride, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBufferoffsetattributeStrideatIndex, buffer, offset, stride, index);
+        }
+
+        public void SetBuffer(MTLBuffer buffer, ulong offset, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBufferoffsetatIndex, buffer, offset, index);
+        }
+
+        public void SetBufferOffset(ulong offset, ulong stride, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBufferOffsetattributeStrideatIndex, offset, stride, index);
+        }
+
+        public void SetBufferOffset(ulong offset, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBufferOffsetatIndex, offset, index);
+        }
+
+        public void SetBuffers(MTLBuffer[] buffers, ulong offsets, ulong strides, NSRange range)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SetBuffers(MTLBuffer[] buffers, ulong[] offsets, NSRange range)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SetBytes(IntPtr bytes, ulong length, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setByteslengthatIndex, bytes, length, index);
+        }
+
+        public void SetBytes(IntPtr bytes, ulong length, ulong stride, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setByteslengthattributeStrideatIndex, bytes, length, stride, index);
+        }
+
+        public void SetComputePipelineState(MTLComputePipelineState state)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setComputePipelineState, state);
+        }
+
+        public void SetImageblockWidth(ulong width, ulong height)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setImageblockWidthheight, width, height);
+        }
+
+        public void SetIntersectionFunctionTable(MTLIntersectionFunctionTable intersectionFunctionTable, ulong bufferIndex)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIntersectionFunctionTableatBufferIndex, intersectionFunctionTable, bufferIndex);
+        }
+
+        public void SetIntersectionFunctionTables(MTLIntersectionFunctionTable[] intersectionFunctionTables, NSRange range)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SetSamplerState(MTLSamplerState sampler, float lodMinClamp, float lodMaxClamp, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSamplerStatelodMinClamplodMaxClampatIndex, sampler, lodMinClamp, lodMaxClamp, index);
+        }
+
+        public void SetSamplerState(MTLSamplerState sampler, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSamplerStateatIndex, sampler, index);
+        }
+
+        public void SetSamplerStates(MTLSamplerState[] samplers, float[] lodMinClamps, float[] lodMaxClamps, NSRange range)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SetSamplerStates(MTLSamplerState[] samplers, NSRange range)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SetStageInRegion(MTLRegion region)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStageInRegion, region);
+        }
+
+        public void SetStageInRegion(MTLBuffer indirectBuffer, ulong indirectBufferOffset)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStageInRegionWithIndirectBufferindirectBufferOffset, indirectBuffer, indirectBufferOffset);
+        }
+
+        public void SetTexture(MTLTexture texture, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTextureatIndex, texture, index);
+        }
+
+        public void SetTextures(MTLTexture[] textures, NSRange range)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SetThreadgroupMemoryLength(ulong length, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setThreadgroupMemoryLengthatIndex, length, index);
+        }
+
+        public void SetVisibleFunctionTable(MTLVisibleFunctionTable visibleFunctionTable, ulong bufferIndex)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVisibleFunctionTableatBufferIndex, visibleFunctionTable, bufferIndex);
+        }
+
+        public void SetVisibleFunctionTables(MTLVisibleFunctionTable[] visibleFunctionTables, NSRange range)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void UpdateFence(MTLFence fence)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_updateFence, fence);
+        }
+
+        public void UseHeap(MTLHeap heap)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_useHeap, heap);
+        }
+
+        public void UseHeaps(MTLHeap[] heaps, ulong count)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void UseResource(MTLResource resource, MTLResourceUsage usage)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_useResourceusage, resource, (ulong)usage);
+        }
+
+        public void UseResources(MTLResource[] resources, ulong count, MTLResourceUsage usage)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WaitForFence(MTLFence fence)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_waitForFence, fence);
+        }
+
+        private static readonly Selector sel_device = "device";
         private static readonly Selector sel_dispatchThreadgroupsthreadsPerThreadgroup = "dispatchThreadgroups:threadsPerThreadgroup:";
         private static readonly Selector sel_dispatchThreadgroupsWithIndirectBufferindirectBufferOffsetthreadsPerThreadgroup = "dispatchThreadgroupsWithIndirectBuffer:indirectBufferOffset:threadsPerThreadgroup:";
         private static readonly Selector sel_dispatchThreadsthreadsPerThreadgroup = "dispatchThreads:threadsPerThreadgroup:";
+        private static readonly Selector sel_dispatchType = "dispatchType";
+        private static readonly Selector sel_endEncoding = "endEncoding";
+        private static readonly Selector sel_executeCommandsInBufferindirectBufferindirectBufferOffset = "executeCommandsInBuffer:indirectBuffer:indirectBufferOffset:";
+        private static readonly Selector sel_executeCommandsInBufferwithRange = "executeCommandsInBuffer:withRange:";
+        private static readonly Selector sel_insertDebugSignpost = "insertDebugSignpost:";
+        private static readonly Selector sel_label = "label";
+        private static readonly Selector sel_memoryBarrierWithResourcescount = "memoryBarrierWithResources:count:";
+        private static readonly Selector sel_memoryBarrierWithScope = "memoryBarrierWithScope:";
+        private static readonly Selector sel_popDebugGroup = "popDebugGroup";
+        private static readonly Selector sel_pushDebugGroup = "pushDebugGroup:";
+        private static readonly Selector sel_sampleCountersInBufferatSampleIndexwithBarrier = "sampleCountersInBuffer:atSampleIndex:withBarrier:";
+        private static readonly Selector sel_setAccelerationStructureatBufferIndex = "setAccelerationStructure:atBufferIndex:";
+        private static readonly Selector sel_setBufferOffsetatIndex = "setBufferOffset:atIndex:";
+        private static readonly Selector sel_setBufferoffsetatIndex = "setBuffer:offset:atIndex:";
+        private static readonly Selector sel_setBufferOffsetattributeStrideatIndex = "setBufferOffset:attributeStride:atIndex:";
+        private static readonly Selector sel_setBufferoffsetattributeStrideatIndex = "setBuffer:offset:attributeStride:atIndex:";
+        private static readonly Selector sel_setBuffersoffsetsattributeStrideswithRange = "setBuffers:offsets:attributeStrides:withRange:";
+        private static readonly Selector sel_setBuffersoffsetswithRange = "setBuffers:offsets:withRange:";
+        private static readonly Selector sel_setByteslengthatIndex = "setBytes:length:atIndex:";
+        private static readonly Selector sel_setByteslengthattributeStrideatIndex = "setBytes:length:attributeStride:atIndex:";
+        private static readonly Selector sel_setComputePipelineState = "setComputePipelineState:";
+        private static readonly Selector sel_setImageblockWidthheight = "setImageblockWidth:height:";
+        private static readonly Selector sel_setIntersectionFunctionTableatBufferIndex = "setIntersectionFunctionTable:atBufferIndex:";
+        private static readonly Selector sel_setIntersectionFunctionTableswithBufferRange = "setIntersectionFunctionTables:withBufferRange:";
+        private static readonly Selector sel_setLabel = "setLabel:";
+        private static readonly Selector sel_setSamplerStateatIndex = "setSamplerState:atIndex:";
+        private static readonly Selector sel_setSamplerStatelodMinClamplodMaxClampatIndex = "setSamplerState:lodMinClamp:lodMaxClamp:atIndex:";
+        private static readonly Selector sel_setSamplerStateslodMinClampslodMaxClampswithRange = "setSamplerStates:lodMinClamps:lodMaxClamps:withRange:";
+        private static readonly Selector sel_setSamplerStateswithRange = "setSamplerStates:withRange:";
+        private static readonly Selector sel_setStageInRegion = "setStageInRegion:";
+        private static readonly Selector sel_setStageInRegionWithIndirectBufferindirectBufferOffset = "setStageInRegionWithIndirectBuffer:indirectBufferOffset:";
+        private static readonly Selector sel_setTextureatIndex = "setTexture:atIndex:";
+        private static readonly Selector sel_setTextureswithRange = "setTextures:withRange:";
+        private static readonly Selector sel_setThreadgroupMemoryLengthatIndex = "setThreadgroupMemoryLength:atIndex:";
+        private static readonly Selector sel_setVisibleFunctionTableatBufferIndex = "setVisibleFunctionTable:atBufferIndex:";
+        private static readonly Selector sel_setVisibleFunctionTableswithBufferRange = "setVisibleFunctionTables:withBufferRange:";
         private static readonly Selector sel_updateFence = "updateFence:";
-        private static readonly Selector sel_waitForFence = "waitForFence:";
-        private static readonly Selector sel_useResourceusage = "useResource:usage:";
-        private static readonly Selector sel_useResourcescountusage = "useResources:count:usage:";
         private static readonly Selector sel_useHeap = "useHeap:";
         private static readonly Selector sel_useHeapscount = "useHeaps:count:";
-        private static readonly Selector sel_executeCommandsInBufferwithRange = "executeCommandsInBuffer:withRange:";
-        private static readonly Selector sel_executeCommandsInBufferindirectBufferindirectBufferOffset = "executeCommandsInBuffer:indirectBuffer:indirectBufferOffset:";
-        private static readonly Selector sel_memoryBarrierWithScope = "memoryBarrierWithScope:";
-        private static readonly Selector sel_memoryBarrierWithResourcescount = "memoryBarrierWithResources:count:";
-        private static readonly Selector sel_sampleCountersInBufferatSampleIndexwithBarrier = "sampleCountersInBuffer:atSampleIndex:withBarrier:";
-        private static readonly Selector sel_device = "device";
-        private static readonly Selector sel_label = "label";
-        private static readonly Selector sel_setLabel = "setLabel:";
-        private static readonly Selector sel_endEncoding = "endEncoding";
-        private static readonly Selector sel_insertDebugSignpost = "insertDebugSignpost:";
-        private static readonly Selector sel_pushDebugGroup = "pushDebugGroup:";
-        private static readonly Selector sel_popDebugGroup = "popDebugGroup";
+        private static readonly Selector sel_useResourcescountusage = "useResources:count:usage:";
+        private static readonly Selector sel_useResourceusage = "useResource:usage:";
+        private static readonly Selector sel_waitForFence = "waitForFence:";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLComputePass.cs
+++ b/src/SharpMetal/Metal/MTLComputePass.cs
@@ -5,6 +5,39 @@ using SharpMetal.Foundation;
 namespace SharpMetal.Metal
 {
     [SupportedOSPlatform("macos")]
+    public struct MTLComputePassDescriptor : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLComputePassDescriptor obj) => obj.NativePtr;
+        public MTLComputePassDescriptor(IntPtr ptr) => NativePtr = ptr;
+
+        public MTLComputePassDescriptor()
+        {
+            var cls = new ObjectiveCClass("MTLComputePassDescriptor");
+            NativePtr = cls.AllocInit();
+        }
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public MTLDispatchType DispatchType
+        {
+            get => (MTLDispatchType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_dispatchType);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDispatchType, (ulong)value);
+        }
+
+        public MTLComputePassSampleBufferAttachmentDescriptorArray SampleBufferAttachments => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_sampleBufferAttachments));
+
+        private static readonly Selector sel_computePassDescriptor = "computePassDescriptor";
+        private static readonly Selector sel_dispatchType = "dispatchType";
+        private static readonly Selector sel_sampleBufferAttachments = "sampleBufferAttachments";
+        private static readonly Selector sel_setDispatchType = "setDispatchType:";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
     public struct MTLComputePassSampleBufferAttachmentDescriptor : IDisposable
     {
         public IntPtr NativePtr;
@@ -22,6 +55,12 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
+        public ulong EndOfEncoderSampleIndex
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_endOfEncoderSampleIndex);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setEndOfEncoderSampleIndex, value);
+        }
+
         public MTLCounterSampleBuffer SampleBuffer
         {
             get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_sampleBuffer));
@@ -34,18 +73,12 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStartOfEncoderSampleIndex, value);
         }
 
-        public ulong EndOfEncoderSampleIndex
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_endOfEncoderSampleIndex);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setEndOfEncoderSampleIndex, value);
-        }
-
-        private static readonly Selector sel_sampleBuffer = "sampleBuffer";
-        private static readonly Selector sel_setSampleBuffer = "setSampleBuffer:";
-        private static readonly Selector sel_startOfEncoderSampleIndex = "startOfEncoderSampleIndex";
-        private static readonly Selector sel_setStartOfEncoderSampleIndex = "setStartOfEncoderSampleIndex:";
         private static readonly Selector sel_endOfEncoderSampleIndex = "endOfEncoderSampleIndex";
+        private static readonly Selector sel_sampleBuffer = "sampleBuffer";
         private static readonly Selector sel_setEndOfEncoderSampleIndex = "setEndOfEncoderSampleIndex:";
+        private static readonly Selector sel_setSampleBuffer = "setSampleBuffer:";
+        private static readonly Selector sel_setStartOfEncoderSampleIndex = "setStartOfEncoderSampleIndex:";
+        private static readonly Selector sel_startOfEncoderSampleIndex = "startOfEncoderSampleIndex";
         private static readonly Selector sel_release = "release";
     }
 
@@ -79,39 +112,6 @@ namespace SharpMetal.Metal
 
         private static readonly Selector sel_objectAtIndexedSubscript = "objectAtIndexedSubscript:";
         private static readonly Selector sel_setObjectatIndexedSubscript = "setObject:atIndexedSubscript:";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLComputePassDescriptor : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLComputePassDescriptor obj) => obj.NativePtr;
-        public MTLComputePassDescriptor(IntPtr ptr) => NativePtr = ptr;
-
-        public MTLComputePassDescriptor()
-        {
-            var cls = new ObjectiveCClass("MTLComputePassDescriptor");
-            NativePtr = cls.AllocInit();
-        }
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public MTLDispatchType DispatchType
-        {
-            get => (MTLDispatchType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_dispatchType);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDispatchType, (ulong)value);
-        }
-
-        public MTLComputePassSampleBufferAttachmentDescriptorArray SampleBufferAttachments => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_sampleBufferAttachments));
-
-        private static readonly Selector sel_computePassDescriptor = "computePassDescriptor";
-        private static readonly Selector sel_dispatchType = "dispatchType";
-        private static readonly Selector sel_setDispatchType = "setDispatchType:";
-        private static readonly Selector sel_sampleBufferAttachments = "sampleBufferAttachments";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLComputePipeline.cs
+++ b/src/SharpMetal/Metal/MTLComputePipeline.cs
@@ -5,33 +5,6 @@ using SharpMetal.Foundation;
 namespace SharpMetal.Metal
 {
     [SupportedOSPlatform("macos")]
-    public struct MTLComputePipelineReflection : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLComputePipelineReflection obj) => obj.NativePtr;
-        public MTLComputePipelineReflection(IntPtr ptr) => NativePtr = ptr;
-
-        public MTLComputePipelineReflection()
-        {
-            var cls = new ObjectiveCClass("MTLComputePipelineReflection");
-            NativePtr = cls.AllocInit();
-        }
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public NSArray Bindings => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_bindings));
-
-        public NSArray Arguments => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_arguments));
-
-        private static readonly Selector sel_bindings = "bindings";
-        private static readonly Selector sel_arguments = "arguments";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
     public struct MTLComputePipelineDescriptor : IDisposable
     {
         public IntPtr NativePtr;
@@ -49,42 +22,18 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public NSString Label
+        public NSArray BinaryArchives
         {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_binaryArchives));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBinaryArchives, value);
         }
+
+        public MTLPipelineBufferDescriptorArray Buffers => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_buffers));
 
         public MTLFunction ComputeFunction
         {
             get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_computeFunction));
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setComputeFunction, value);
-        }
-
-        public bool ThreadGroupSizeIsMultipleOfThreadExecutionWidth
-        {
-            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_threadGroupSizeIsMultipleOfThreadExecutionWidth);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setThreadGroupSizeIsMultipleOfThreadExecutionWidth, value);
-        }
-
-        public ulong MaxTotalThreadsPerThreadgroup
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxTotalThreadsPerThreadgroup);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxTotalThreadsPerThreadgroup, value);
-        }
-
-        public MTLStageInputOutputDescriptor StageInputDescriptor
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_stageInputDescriptor));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStageInputDescriptor, value);
-        }
-
-        public MTLPipelineBufferDescriptorArray Buffers => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_buffers));
-
-        public bool SupportIndirectCommandBuffers
-        {
-            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportIndirectCommandBuffers);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSupportIndirectCommandBuffers, value);
         }
 
         public NSArray InsertLibraries
@@ -93,16 +42,10 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setInsertLibraries, value);
         }
 
-        public NSArray PreloadedLibraries
+        public NSString Label
         {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_preloadedLibraries));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPreloadedLibraries, value);
-        }
-
-        public NSArray BinaryArchives
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_binaryArchives));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBinaryArchives, value);
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
         }
 
         public MTLLinkedFunctions LinkedFunctions
@@ -111,16 +54,46 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLinkedFunctions, value);
         }
 
+        public ulong MaxCallStackDepth
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxCallStackDepth);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxCallStackDepth, value);
+        }
+
+        public ulong MaxTotalThreadsPerThreadgroup
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxTotalThreadsPerThreadgroup);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxTotalThreadsPerThreadgroup, value);
+        }
+
+        public NSArray PreloadedLibraries
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_preloadedLibraries));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPreloadedLibraries, value);
+        }
+
+        public MTLStageInputOutputDescriptor StageInputDescriptor
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_stageInputDescriptor));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStageInputDescriptor, value);
+        }
+
         public bool SupportAddingBinaryFunctions
         {
             get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportAddingBinaryFunctions);
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSupportAddingBinaryFunctions, value);
         }
 
-        public ulong MaxCallStackDepth
+        public bool SupportIndirectCommandBuffers
         {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxCallStackDepth);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxCallStackDepth, value);
+            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportIndirectCommandBuffers);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSupportIndirectCommandBuffers, value);
+        }
+
+        public bool ThreadGroupSizeIsMultipleOfThreadExecutionWidth
+        {
+            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_threadGroupSizeIsMultipleOfThreadExecutionWidth);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setThreadGroupSizeIsMultipleOfThreadExecutionWidth, value);
         }
 
         public void Reset()
@@ -128,32 +101,59 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_reset);
         }
 
-        private static readonly Selector sel_label = "label";
-        private static readonly Selector sel_setLabel = "setLabel:";
-        private static readonly Selector sel_computeFunction = "computeFunction";
-        private static readonly Selector sel_setComputeFunction = "setComputeFunction:";
-        private static readonly Selector sel_threadGroupSizeIsMultipleOfThreadExecutionWidth = "threadGroupSizeIsMultipleOfThreadExecutionWidth";
-        private static readonly Selector sel_setThreadGroupSizeIsMultipleOfThreadExecutionWidth = "setThreadGroupSizeIsMultipleOfThreadExecutionWidth:";
-        private static readonly Selector sel_maxTotalThreadsPerThreadgroup = "maxTotalThreadsPerThreadgroup";
-        private static readonly Selector sel_setMaxTotalThreadsPerThreadgroup = "setMaxTotalThreadsPerThreadgroup:";
-        private static readonly Selector sel_stageInputDescriptor = "stageInputDescriptor";
-        private static readonly Selector sel_setStageInputDescriptor = "setStageInputDescriptor:";
-        private static readonly Selector sel_buffers = "buffers";
-        private static readonly Selector sel_supportIndirectCommandBuffers = "supportIndirectCommandBuffers";
-        private static readonly Selector sel_setSupportIndirectCommandBuffers = "setSupportIndirectCommandBuffers:";
-        private static readonly Selector sel_insertLibraries = "insertLibraries";
-        private static readonly Selector sel_setInsertLibraries = "setInsertLibraries:";
-        private static readonly Selector sel_preloadedLibraries = "preloadedLibraries";
-        private static readonly Selector sel_setPreloadedLibraries = "setPreloadedLibraries:";
         private static readonly Selector sel_binaryArchives = "binaryArchives";
-        private static readonly Selector sel_setBinaryArchives = "setBinaryArchives:";
-        private static readonly Selector sel_reset = "reset";
+        private static readonly Selector sel_buffers = "buffers";
+        private static readonly Selector sel_computeFunction = "computeFunction";
+        private static readonly Selector sel_insertLibraries = "insertLibraries";
+        private static readonly Selector sel_label = "label";
         private static readonly Selector sel_linkedFunctions = "linkedFunctions";
-        private static readonly Selector sel_setLinkedFunctions = "setLinkedFunctions:";
-        private static readonly Selector sel_supportAddingBinaryFunctions = "supportAddingBinaryFunctions";
-        private static readonly Selector sel_setSupportAddingBinaryFunctions = "setSupportAddingBinaryFunctions:";
         private static readonly Selector sel_maxCallStackDepth = "maxCallStackDepth";
+        private static readonly Selector sel_maxTotalThreadsPerThreadgroup = "maxTotalThreadsPerThreadgroup";
+        private static readonly Selector sel_preloadedLibraries = "preloadedLibraries";
+        private static readonly Selector sel_reset = "reset";
+        private static readonly Selector sel_setBinaryArchives = "setBinaryArchives:";
+        private static readonly Selector sel_setComputeFunction = "setComputeFunction:";
+        private static readonly Selector sel_setInsertLibraries = "setInsertLibraries:";
+        private static readonly Selector sel_setLabel = "setLabel:";
+        private static readonly Selector sel_setLinkedFunctions = "setLinkedFunctions:";
         private static readonly Selector sel_setMaxCallStackDepth = "setMaxCallStackDepth:";
+        private static readonly Selector sel_setMaxTotalThreadsPerThreadgroup = "setMaxTotalThreadsPerThreadgroup:";
+        private static readonly Selector sel_setPreloadedLibraries = "setPreloadedLibraries:";
+        private static readonly Selector sel_setStageInputDescriptor = "setStageInputDescriptor:";
+        private static readonly Selector sel_setSupportAddingBinaryFunctions = "setSupportAddingBinaryFunctions:";
+        private static readonly Selector sel_setSupportIndirectCommandBuffers = "setSupportIndirectCommandBuffers:";
+        private static readonly Selector sel_setThreadGroupSizeIsMultipleOfThreadExecutionWidth = "setThreadGroupSizeIsMultipleOfThreadExecutionWidth:";
+        private static readonly Selector sel_stageInputDescriptor = "stageInputDescriptor";
+        private static readonly Selector sel_supportAddingBinaryFunctions = "supportAddingBinaryFunctions";
+        private static readonly Selector sel_supportIndirectCommandBuffers = "supportIndirectCommandBuffers";
+        private static readonly Selector sel_threadGroupSizeIsMultipleOfThreadExecutionWidth = "threadGroupSizeIsMultipleOfThreadExecutionWidth";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
+    public struct MTLComputePipelineReflection : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLComputePipelineReflection obj) => obj.NativePtr;
+        public MTLComputePipelineReflection(IntPtr ptr) => NativePtr = ptr;
+
+        public MTLComputePipelineReflection()
+        {
+            var cls = new ObjectiveCClass("MTLComputePipelineReflection");
+            NativePtr = cls.AllocInit();
+        }
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public NSArray Arguments => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_arguments));
+
+        public NSArray Bindings => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_bindings));
+
+        private static readonly Selector sel_arguments = "arguments";
+        private static readonly Selector sel_bindings = "bindings";
         private static readonly Selector sel_release = "release";
     }
 
@@ -169,28 +169,28 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public NSString Label => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
-
         public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
 
-        public ulong MaxTotalThreadsPerThreadgroup => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxTotalThreadsPerThreadgroup);
+        public MTLResourceID GpuResourceID => ObjectiveCRuntime.MTLResourceID_objc_msgSend(NativePtr, sel_gpuResourceID);
 
-        public ulong ThreadExecutionWidth => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_threadExecutionWidth);
+        public NSString Label => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
+
+        public ulong MaxTotalThreadsPerThreadgroup => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxTotalThreadsPerThreadgroup);
 
         public ulong StaticThreadgroupMemoryLength => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_staticThreadgroupMemoryLength);
 
         public bool SupportIndirectCommandBuffers => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportIndirectCommandBuffers);
 
-        public MTLResourceID GpuResourceID => ObjectiveCRuntime.MTLResourceID_objc_msgSend(NativePtr, sel_gpuResourceID);
-
-        public ulong ImageblockMemoryLength(MTLSize imageblockDimensions)
-        {
-            return ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_imageblockMemoryLengthForDimensions, imageblockDimensions);
-        }
+        public ulong ThreadExecutionWidth => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_threadExecutionWidth);
 
         public MTLFunctionHandle FunctionHandle(MTLFunction function)
         {
             return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_functionHandleWithFunction, function));
+        }
+
+        public ulong ImageblockMemoryLength(MTLSize imageblockDimensions)
+        {
+            return ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_imageblockMemoryLengthForDimensions, imageblockDimensions);
         }
 
         public MTLComputePipelineState NewComputePipelineState(NSArray functions, ref NSError error)
@@ -198,28 +198,28 @@ namespace SharpMetal.Metal
             return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newComputePipelineStateWithAdditionalBinaryFunctionserror, functions, ref error.NativePtr));
         }
 
-        public MTLVisibleFunctionTable NewVisibleFunctionTable(MTLVisibleFunctionTableDescriptor descriptor)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newVisibleFunctionTableWithDescriptor, descriptor));
-        }
-
         public MTLIntersectionFunctionTable NewIntersectionFunctionTable(MTLIntersectionFunctionTableDescriptor descriptor)
         {
             return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newIntersectionFunctionTableWithDescriptor, descriptor));
         }
 
-        private static readonly Selector sel_label = "label";
+        public MTLVisibleFunctionTable NewVisibleFunctionTable(MTLVisibleFunctionTableDescriptor descriptor)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newVisibleFunctionTableWithDescriptor, descriptor));
+        }
+
         private static readonly Selector sel_device = "device";
-        private static readonly Selector sel_maxTotalThreadsPerThreadgroup = "maxTotalThreadsPerThreadgroup";
-        private static readonly Selector sel_threadExecutionWidth = "threadExecutionWidth";
-        private static readonly Selector sel_staticThreadgroupMemoryLength = "staticThreadgroupMemoryLength";
-        private static readonly Selector sel_imageblockMemoryLengthForDimensions = "imageblockMemoryLengthForDimensions:";
-        private static readonly Selector sel_supportIndirectCommandBuffers = "supportIndirectCommandBuffers";
-        private static readonly Selector sel_gpuResourceID = "gpuResourceID";
         private static readonly Selector sel_functionHandleWithFunction = "functionHandleWithFunction:";
+        private static readonly Selector sel_gpuResourceID = "gpuResourceID";
+        private static readonly Selector sel_imageblockMemoryLengthForDimensions = "imageblockMemoryLengthForDimensions:";
+        private static readonly Selector sel_label = "label";
+        private static readonly Selector sel_maxTotalThreadsPerThreadgroup = "maxTotalThreadsPerThreadgroup";
         private static readonly Selector sel_newComputePipelineStateWithAdditionalBinaryFunctionserror = "newComputePipelineStateWithAdditionalBinaryFunctions:error:";
-        private static readonly Selector sel_newVisibleFunctionTableWithDescriptor = "newVisibleFunctionTableWithDescriptor:";
         private static readonly Selector sel_newIntersectionFunctionTableWithDescriptor = "newIntersectionFunctionTableWithDescriptor:";
+        private static readonly Selector sel_newVisibleFunctionTableWithDescriptor = "newVisibleFunctionTableWithDescriptor:";
+        private static readonly Selector sel_staticThreadgroupMemoryLength = "staticThreadgroupMemoryLength";
+        private static readonly Selector sel_supportIndirectCommandBuffers = "supportIndirectCommandBuffers";
+        private static readonly Selector sel_threadExecutionWidth = "threadExecutionWidth";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLCounters.cs
+++ b/src/SharpMetal/Metal/MTLCounters.cs
@@ -15,13 +15,6 @@ namespace SharpMetal.Metal
 
     [SupportedOSPlatform("macos")]
     [StructLayout(LayoutKind.Sequential)]
-    public struct MTLCounterResultTimestamp
-    {
-        public ulong timestamp;
-    }
-
-    [SupportedOSPlatform("macos")]
-    [StructLayout(LayoutKind.Sequential)]
     public struct MTLCounterResultStageUtilization
     {
         public ulong totalCycles;
@@ -47,6 +40,13 @@ namespace SharpMetal.Metal
     }
 
     [SupportedOSPlatform("macos")]
+    [StructLayout(LayoutKind.Sequential)]
+    public struct MTLCounterResultTimestamp
+    {
+        public ulong timestamp;
+    }
+
+    [SupportedOSPlatform("macos")]
     public struct MTLCounter : IDisposable
     {
         public IntPtr NativePtr;
@@ -65,23 +65,32 @@ namespace SharpMetal.Metal
     }
 
     [SupportedOSPlatform("macos")]
-    public struct MTLCounterSet : IDisposable
+    public struct MTLCounterSampleBuffer : IDisposable
     {
         public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLCounterSet obj) => obj.NativePtr;
-        public MTLCounterSet(IntPtr ptr) => NativePtr = ptr;
+        public static implicit operator IntPtr(MTLCounterSampleBuffer obj) => obj.NativePtr;
+        public MTLCounterSampleBuffer(IntPtr ptr) => NativePtr = ptr;
 
         public void Dispose()
         {
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public NSString Name => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_name));
+        public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
 
-        public NSArray Counters => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_counters));
+        public NSString Label => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
 
-        private static readonly Selector sel_name = "name";
-        private static readonly Selector sel_counters = "counters";
+        public ulong SampleCount => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_sampleCount);
+
+        public NSData ResolveCounterRange(NSRange range)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_resolveCounterRange, range));
+        }
+
+        private static readonly Selector sel_device = "device";
+        private static readonly Selector sel_label = "label";
+        private static readonly Selector sel_resolveCounterRange = "resolveCounterRange:";
+        private static readonly Selector sel_sampleCount = "sampleCount";
         private static readonly Selector sel_release = "release";
     }
 
@@ -115,56 +124,47 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
         }
 
-        public MTLStorageMode StorageMode
-        {
-            get => (MTLStorageMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_storageMode);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStorageMode, (ulong)value);
-        }
-
         public ulong SampleCount
         {
             get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_sampleCount);
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSampleCount, value);
         }
 
+        public MTLStorageMode StorageMode
+        {
+            get => (MTLStorageMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_storageMode);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStorageMode, (ulong)value);
+        }
+
         private static readonly Selector sel_counterSet = "counterSet";
-        private static readonly Selector sel_setCounterSet = "setCounterSet:";
         private static readonly Selector sel_label = "label";
-        private static readonly Selector sel_setLabel = "setLabel:";
-        private static readonly Selector sel_storageMode = "storageMode";
-        private static readonly Selector sel_setStorageMode = "setStorageMode:";
         private static readonly Selector sel_sampleCount = "sampleCount";
+        private static readonly Selector sel_setCounterSet = "setCounterSet:";
+        private static readonly Selector sel_setLabel = "setLabel:";
         private static readonly Selector sel_setSampleCount = "setSampleCount:";
+        private static readonly Selector sel_setStorageMode = "setStorageMode:";
+        private static readonly Selector sel_storageMode = "storageMode";
         private static readonly Selector sel_release = "release";
     }
 
     [SupportedOSPlatform("macos")]
-    public struct MTLCounterSampleBuffer : IDisposable
+    public struct MTLCounterSet : IDisposable
     {
         public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLCounterSampleBuffer obj) => obj.NativePtr;
-        public MTLCounterSampleBuffer(IntPtr ptr) => NativePtr = ptr;
+        public static implicit operator IntPtr(MTLCounterSet obj) => obj.NativePtr;
+        public MTLCounterSet(IntPtr ptr) => NativePtr = ptr;
 
         public void Dispose()
         {
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
+        public NSArray Counters => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_counters));
 
-        public NSString Label => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
+        public NSString Name => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_name));
 
-        public ulong SampleCount => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_sampleCount);
-
-        public NSData ResolveCounterRange(NSRange range)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_resolveCounterRange, range));
-        }
-
-        private static readonly Selector sel_device = "device";
-        private static readonly Selector sel_label = "label";
-        private static readonly Selector sel_sampleCount = "sampleCount";
-        private static readonly Selector sel_resolveCounterRange = "resolveCounterRange:";
+        private static readonly Selector sel_counters = "counters";
+        private static readonly Selector sel_name = "name";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLDepthStencil.cs
+++ b/src/SharpMetal/Metal/MTLDepthStencil.cs
@@ -31,75 +31,6 @@ namespace SharpMetal.Metal
     }
 
     [SupportedOSPlatform("macos")]
-    public struct MTLStencilDescriptor : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLStencilDescriptor obj) => obj.NativePtr;
-        public MTLStencilDescriptor(IntPtr ptr) => NativePtr = ptr;
-
-        public MTLStencilDescriptor()
-        {
-            var cls = new ObjectiveCClass("MTLStencilDescriptor");
-            NativePtr = cls.AllocInit();
-        }
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public MTLCompareFunction StencilCompareFunction
-        {
-            get => (MTLCompareFunction)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_stencilCompareFunction);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStencilCompareFunction, (ulong)value);
-        }
-
-        public MTLStencilOperation StencilFailureOperation
-        {
-            get => (MTLStencilOperation)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_stencilFailureOperation);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStencilFailureOperation, (ulong)value);
-        }
-
-        public MTLStencilOperation DepthFailureOperation
-        {
-            get => (MTLStencilOperation)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_depthFailureOperation);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDepthFailureOperation, (ulong)value);
-        }
-
-        public MTLStencilOperation DepthStencilPassOperation
-        {
-            get => (MTLStencilOperation)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_depthStencilPassOperation);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDepthStencilPassOperation, (ulong)value);
-        }
-
-        public uint ReadMask
-        {
-            get => ObjectiveCRuntime.uint_objc_msgSend(NativePtr, sel_readMask);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setReadMask, value);
-        }
-
-        public uint WriteMask
-        {
-            get => ObjectiveCRuntime.uint_objc_msgSend(NativePtr, sel_writeMask);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setWriteMask, value);
-        }
-
-        private static readonly Selector sel_stencilCompareFunction = "stencilCompareFunction";
-        private static readonly Selector sel_setStencilCompareFunction = "setStencilCompareFunction:";
-        private static readonly Selector sel_stencilFailureOperation = "stencilFailureOperation";
-        private static readonly Selector sel_setStencilFailureOperation = "setStencilFailureOperation:";
-        private static readonly Selector sel_depthFailureOperation = "depthFailureOperation";
-        private static readonly Selector sel_setDepthFailureOperation = "setDepthFailureOperation:";
-        private static readonly Selector sel_depthStencilPassOperation = "depthStencilPassOperation";
-        private static readonly Selector sel_setDepthStencilPassOperation = "setDepthStencilPassOperation:";
-        private static readonly Selector sel_readMask = "readMask";
-        private static readonly Selector sel_setReadMask = "setReadMask:";
-        private static readonly Selector sel_writeMask = "writeMask";
-        private static readonly Selector sel_setWriteMask = "setWriteMask:";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
     public struct MTLDepthStencilDescriptor : IDisposable
     {
         public IntPtr NativePtr;
@@ -115,6 +46,12 @@ namespace SharpMetal.Metal
         public void Dispose()
         {
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public MTLStencilDescriptor BackFaceStencil
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_backFaceStencil));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBackFaceStencil, value);
         }
 
         public MTLCompareFunction DepthCompareFunction
@@ -135,12 +72,6 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFrontFaceStencil, value);
         }
 
-        public MTLStencilDescriptor BackFaceStencil
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_backFaceStencil));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBackFaceStencil, value);
-        }
-
         public NSString Label
         {
             get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
@@ -152,15 +83,15 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDepthWriteEnabled, depthWriteEnabled);
         }
 
-        private static readonly Selector sel_depthCompareFunction = "depthCompareFunction";
-        private static readonly Selector sel_setDepthCompareFunction = "setDepthCompareFunction:";
-        private static readonly Selector sel_isDepthWriteEnabled = "isDepthWriteEnabled";
-        private static readonly Selector sel_setDepthWriteEnabled = "setDepthWriteEnabled:";
-        private static readonly Selector sel_frontFaceStencil = "frontFaceStencil";
-        private static readonly Selector sel_setFrontFaceStencil = "setFrontFaceStencil:";
         private static readonly Selector sel_backFaceStencil = "backFaceStencil";
-        private static readonly Selector sel_setBackFaceStencil = "setBackFaceStencil:";
+        private static readonly Selector sel_depthCompareFunction = "depthCompareFunction";
+        private static readonly Selector sel_frontFaceStencil = "frontFaceStencil";
+        private static readonly Selector sel_isDepthWriteEnabled = "isDepthWriteEnabled";
         private static readonly Selector sel_label = "label";
+        private static readonly Selector sel_setBackFaceStencil = "setBackFaceStencil:";
+        private static readonly Selector sel_setDepthCompareFunction = "setDepthCompareFunction:";
+        private static readonly Selector sel_setDepthWriteEnabled = "setDepthWriteEnabled:";
+        private static readonly Selector sel_setFrontFaceStencil = "setFrontFaceStencil:";
         private static readonly Selector sel_setLabel = "setLabel:";
         private static readonly Selector sel_release = "release";
     }
@@ -177,12 +108,81 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public NSString Label => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
-
         public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
 
-        private static readonly Selector sel_label = "label";
+        public NSString Label => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
+
         private static readonly Selector sel_device = "device";
+        private static readonly Selector sel_label = "label";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
+    public struct MTLStencilDescriptor : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLStencilDescriptor obj) => obj.NativePtr;
+        public MTLStencilDescriptor(IntPtr ptr) => NativePtr = ptr;
+
+        public MTLStencilDescriptor()
+        {
+            var cls = new ObjectiveCClass("MTLStencilDescriptor");
+            NativePtr = cls.AllocInit();
+        }
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public MTLStencilOperation DepthFailureOperation
+        {
+            get => (MTLStencilOperation)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_depthFailureOperation);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDepthFailureOperation, (ulong)value);
+        }
+
+        public MTLStencilOperation DepthStencilPassOperation
+        {
+            get => (MTLStencilOperation)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_depthStencilPassOperation);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDepthStencilPassOperation, (ulong)value);
+        }
+
+        public uint ReadMask
+        {
+            get => ObjectiveCRuntime.uint_objc_msgSend(NativePtr, sel_readMask);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setReadMask, value);
+        }
+
+        public MTLCompareFunction StencilCompareFunction
+        {
+            get => (MTLCompareFunction)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_stencilCompareFunction);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStencilCompareFunction, (ulong)value);
+        }
+
+        public MTLStencilOperation StencilFailureOperation
+        {
+            get => (MTLStencilOperation)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_stencilFailureOperation);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStencilFailureOperation, (ulong)value);
+        }
+
+        public uint WriteMask
+        {
+            get => ObjectiveCRuntime.uint_objc_msgSend(NativePtr, sel_writeMask);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setWriteMask, value);
+        }
+
+        private static readonly Selector sel_depthFailureOperation = "depthFailureOperation";
+        private static readonly Selector sel_depthStencilPassOperation = "depthStencilPassOperation";
+        private static readonly Selector sel_readMask = "readMask";
+        private static readonly Selector sel_setDepthFailureOperation = "setDepthFailureOperation:";
+        private static readonly Selector sel_setDepthStencilPassOperation = "setDepthStencilPassOperation:";
+        private static readonly Selector sel_setReadMask = "setReadMask:";
+        private static readonly Selector sel_setStencilCompareFunction = "setStencilCompareFunction:";
+        private static readonly Selector sel_setStencilFailureOperation = "setStencilFailureOperation:";
+        private static readonly Selector sel_setWriteMask = "setWriteMask:";
+        private static readonly Selector sel_stencilCompareFunction = "stencilCompareFunction";
+        private static readonly Selector sel_stencilFailureOperation = "stencilFailureOperation";
+        private static readonly Selector sel_writeMask = "writeMask";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLDevice.cs
+++ b/src/SharpMetal/Metal/MTLDevice.cs
@@ -6,13 +6,29 @@ using SharpMetal.Foundation;
 namespace SharpMetal.Metal
 {
     [SupportedOSPlatform("macos")]
-    public enum MTLIOCompressionMethod : long
+    public enum MTLArgumentBuffersTier : ulong
     {
-        Zlib = 0,
-        LZFSE = 1,
-        LZ4 = 2,
-        LZMA = 3,
-        LZBitmap = 4,
+        Tier1 = 0,
+        Tier2 = 1,
+    }
+
+    [SupportedOSPlatform("macos")]
+    public enum MTLCounterSamplingPoint : ulong
+    {
+        AtStageBoundary = 0,
+        AtDrawBoundary = 1,
+        AtDispatchBoundary = 2,
+        AtTileDispatchBoundary = 3,
+        AtBlitBoundary = 4,
+    }
+
+    [SupportedOSPlatform("macos")]
+    public enum MTLDeviceLocation : ulong
+    {
+        BuiltIn = 0,
+        Slot = 1,
+        External = 2,
+        Unspecified = UInt64.MaxValue,
     }
 
     [SupportedOSPlatform("macos")]
@@ -80,12 +96,13 @@ namespace SharpMetal.Metal
     }
 
     [SupportedOSPlatform("macos")]
-    public enum MTLDeviceLocation : ulong
+    public enum MTLIOCompressionMethod : long
     {
-        BuiltIn = 0,
-        Slot = 1,
-        External = 2,
-        Unspecified = UInt64.MaxValue,
+        Zlib = 0,
+        LZFSE = 1,
+        LZ4 = 2,
+        LZMA = 3,
+        LZBitmap = 4,
     }
 
     [SupportedOSPlatform("macos")]
@@ -107,20 +124,6 @@ namespace SharpMetal.Metal
     }
 
     [SupportedOSPlatform("macos")]
-    public enum MTLArgumentBuffersTier : ulong
-    {
-        Tier1 = 0,
-        Tier2 = 1,
-    }
-
-    [SupportedOSPlatform("macos")]
-    public enum MTLSparseTextureRegionAlignmentMode : ulong
-    {
-        Outward = 0,
-        Inward = 1,
-    }
-
-    [SupportedOSPlatform("macos")]
     public enum MTLSparsePageSize : long
     {
         Size16 = 101,
@@ -129,13 +132,10 @@ namespace SharpMetal.Metal
     }
 
     [SupportedOSPlatform("macos")]
-    public enum MTLCounterSamplingPoint : ulong
+    public enum MTLSparseTextureRegionAlignmentMode : ulong
     {
-        AtStageBoundary = 0,
-        AtDrawBoundary = 1,
-        AtDispatchBoundary = 2,
-        AtTileDispatchBoundary = 3,
-        AtBlitBoundary = 4,
+        Outward = 0,
+        Inward = 1,
     }
 
     [SupportedOSPlatform("macos")]
@@ -153,76 +153,6 @@ namespace SharpMetal.Metal
     {
         public ulong size;
         public ulong align;
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLArgumentDescriptor : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLArgumentDescriptor obj) => obj.NativePtr;
-        public MTLArgumentDescriptor(IntPtr ptr) => NativePtr = ptr;
-
-        public MTLArgumentDescriptor()
-        {
-            var cls = new ObjectiveCClass("MTLArgumentDescriptor");
-            NativePtr = cls.AllocInit();
-        }
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public MTLDataType DataType
-        {
-            get => (MTLDataType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_dataType);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDataType, (ulong)value);
-        }
-
-        public ulong Index
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_index);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIndex, value);
-        }
-
-        public ulong ArrayLength
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_arrayLength);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setArrayLength, value);
-        }
-
-        public MTLBindingAccess Access
-        {
-            get => (MTLBindingAccess)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_access);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setAccess, (ulong)value);
-        }
-
-        public MTLTextureType TextureType
-        {
-            get => (MTLTextureType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_textureType);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTextureType, (ulong)value);
-        }
-
-        public ulong ConstantBlockAlignment
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_constantBlockAlignment);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setConstantBlockAlignment, value);
-        }
-
-        private static readonly Selector sel_argumentDescriptor = "argumentDescriptor";
-        private static readonly Selector sel_dataType = "dataType";
-        private static readonly Selector sel_setDataType = "setDataType:";
-        private static readonly Selector sel_index = "index";
-        private static readonly Selector sel_setIndex = "setIndex:";
-        private static readonly Selector sel_arrayLength = "arrayLength";
-        private static readonly Selector sel_setArrayLength = "setArrayLength:";
-        private static readonly Selector sel_access = "access";
-        private static readonly Selector sel_setAccess = "setAccess:";
-        private static readonly Selector sel_textureType = "textureType";
-        private static readonly Selector sel_setTextureType = "setTextureType:";
-        private static readonly Selector sel_constantBlockAlignment = "constantBlockAlignment";
-        private static readonly Selector sel_setConstantBlockAlignment = "setConstantBlockAlignment:";
-        private static readonly Selector sel_release = "release";
     }
 
     [SupportedOSPlatform("macos")]
@@ -250,6 +180,76 @@ namespace SharpMetal.Metal
     }
 
     [SupportedOSPlatform("macos")]
+    public struct MTLArgumentDescriptor : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLArgumentDescriptor obj) => obj.NativePtr;
+        public MTLArgumentDescriptor(IntPtr ptr) => NativePtr = ptr;
+
+        public MTLArgumentDescriptor()
+        {
+            var cls = new ObjectiveCClass("MTLArgumentDescriptor");
+            NativePtr = cls.AllocInit();
+        }
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public MTLBindingAccess Access
+        {
+            get => (MTLBindingAccess)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_access);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setAccess, (ulong)value);
+        }
+
+        public ulong ArrayLength
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_arrayLength);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setArrayLength, value);
+        }
+
+        public ulong ConstantBlockAlignment
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_constantBlockAlignment);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setConstantBlockAlignment, value);
+        }
+
+        public MTLDataType DataType
+        {
+            get => (MTLDataType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_dataType);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDataType, (ulong)value);
+        }
+
+        public ulong Index
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_index);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIndex, value);
+        }
+
+        public MTLTextureType TextureType
+        {
+            get => (MTLTextureType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_textureType);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTextureType, (ulong)value);
+        }
+
+        private static readonly Selector sel_access = "access";
+        private static readonly Selector sel_argumentDescriptor = "argumentDescriptor";
+        private static readonly Selector sel_arrayLength = "arrayLength";
+        private static readonly Selector sel_constantBlockAlignment = "constantBlockAlignment";
+        private static readonly Selector sel_dataType = "dataType";
+        private static readonly Selector sel_index = "index";
+        private static readonly Selector sel_setAccess = "setAccess:";
+        private static readonly Selector sel_setArrayLength = "setArrayLength:";
+        private static readonly Selector sel_setConstantBlockAlignment = "setConstantBlockAlignment:";
+        private static readonly Selector sel_setDataType = "setDataType:";
+        private static readonly Selector sel_setIndex = "setIndex:";
+        private static readonly Selector sel_setTextureType = "setTextureType:";
+        private static readonly Selector sel_textureType = "textureType";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
     public partial struct MTLDevice : IDisposable
     {
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -264,88 +264,64 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public bool IsHeadless => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isHeadless);
-
-        public NSString Name => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_name));
-
-        public ulong RegistryID => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_registryID);
-
         public MTLArchitecture Architecture => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_architecture));
 
-        public MTLSize MaxThreadsPerThreadgroup => ObjectiveCRuntime.MTLSize_objc_msgSend(NativePtr, sel_maxThreadsPerThreadgroup);
+        public MTLArgumentBuffersTier ArgumentBuffersSupport => (MTLArgumentBuffersTier)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_argumentBuffersSupport);
 
-        public bool LowPower => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isLowPower);
+        public bool BarycentricCoordsSupported => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_areBarycentricCoordsSupported);
 
+        public NSArray CounterSets => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_counterSets));
 
-        public bool Removable => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isRemovable);
+        public ulong CurrentAllocatedSize => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_currentAllocatedSize);
+
+        public bool Depth24Stencil8PixelFormatSupported => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isDepth24Stencil8PixelFormatSupported);
 
         public bool HasUnifiedMemory => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_hasUnifiedMemory);
 
-        public ulong RecommendedMaxWorkingSetSize => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_recommendedMaxWorkingSetSize);
+        public bool Headless => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isHeadless);
+
 
         public MTLDeviceLocation Location => (MTLDeviceLocation)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_location);
 
         public ulong LocationNumber => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_locationNumber);
 
-        public ulong MaxTransferRate => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxTransferRate);
-
-        public bool Depth24Stencil8PixelFormatSupported => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isDepth24Stencil8PixelFormatSupported);
-
-        public MTLReadWriteTextureTier ReadWriteTextureSupport => (MTLReadWriteTextureTier)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_readWriteTextureSupport);
-
-        public MTLArgumentBuffersTier ArgumentBuffersSupport => (MTLArgumentBuffersTier)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_argumentBuffersSupport);
-
-        public bool RasterOrderGroupsSupported => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_areRasterOrderGroupsSupported);
-
-        public bool Supports32BitFloatFiltering => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supports32BitFloatFiltering);
-
-        public bool Supports32BitMSAA => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supports32BitMSAA);
-
-        public bool SupportsQueryTextureLOD => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportsQueryTextureLOD);
-
-        public bool SupportsBCTextureCompression => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportsBCTextureCompression);
-
-        public bool SupportsPullModelInterpolation => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportsPullModelInterpolation);
-
-        public bool BarycentricCoordsSupported => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_areBarycentricCoordsSupported);
-
-        public bool SupportsShaderBarycentricCoordinates => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportsShaderBarycentricCoordinates);
-
-        public ulong CurrentAllocatedSize => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_currentAllocatedSize);
-
-        public MTLFence NewFence => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newFence));
-
-        public ulong MaxThreadgroupMemoryLength => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxThreadgroupMemoryLength);
+        public bool LowPower => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isLowPower);
 
         public ulong MaxArgumentBufferSamplerCount => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxArgumentBufferSamplerCount);
 
-        public bool ProgrammableSamplePositionsSupported => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_areProgrammableSamplePositionsSupported);
+        public ulong MaxBufferLength => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxBufferLength);
+
+        public ulong MaximumConcurrentCompilationTaskCount => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maximumConcurrentCompilationTaskCount);
+
+        public ulong MaxThreadgroupMemoryLength => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxThreadgroupMemoryLength);
+
+        public MTLSize MaxThreadsPerThreadgroup => ObjectiveCRuntime.MTLSize_objc_msgSend(NativePtr, sel_maxThreadsPerThreadgroup);
+
+        public ulong MaxTransferRate => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxTransferRate);
+
+        public NSString Name => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_name));
 
         public MTLEvent NewEvent => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newEvent));
+
+        public MTLFence NewFence => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newFence));
+
+        public uint PeerCount => ObjectiveCRuntime.uint_objc_msgSend(NativePtr, sel_peerCount);
 
         public ulong PeerGroupID => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_peerGroupID);
 
         public uint PeerIndex => ObjectiveCRuntime.uint_objc_msgSend(NativePtr, sel_peerIndex);
 
-        public uint PeerCount => ObjectiveCRuntime.uint_objc_msgSend(NativePtr, sel_peerCount);
+        public bool ProgrammableSamplePositionsSupported => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_areProgrammableSamplePositionsSupported);
 
-        public ulong MaxBufferLength => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxBufferLength);
+        public bool RasterOrderGroupsSupported => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_areRasterOrderGroupsSupported);
 
-        public NSArray CounterSets => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_counterSets));
+        public MTLReadWriteTextureTier ReadWriteTextureSupport => (MTLReadWriteTextureTier)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_readWriteTextureSupport);
 
-        public bool SupportsDynamicLibraries => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportsDynamicLibraries);
+        public ulong RecommendedMaxWorkingSetSize => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_recommendedMaxWorkingSetSize);
 
-        public bool SupportsRenderDynamicLibraries => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportsRenderDynamicLibraries);
+        public ulong RegistryID => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_registryID);
 
-        public bool SupportsRaytracing => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportsRaytracing);
-
-        public bool SupportsFunctionPointers => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportsFunctionPointers);
-
-        public bool SupportsFunctionPointersFromRender => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportsFunctionPointersFromRender);
-
-        public bool SupportsRaytracingFromRender => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportsRaytracingFromRender);
-
-        public bool SupportsPrimitiveMotionBlur => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportsPrimitiveMotionBlur);
+        public bool Removable => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isRemovable);
 
         public bool ShouldMaximizeConcurrentCompilation
         {
@@ -353,14 +329,45 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setShouldMaximizeConcurrentCompilation, value);
         }
 
-        public ulong MaximumConcurrentCompilationTaskCount => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maximumConcurrentCompilationTaskCount);
+        public bool Supports32BitFloatFiltering => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supports32BitFloatFiltering);
 
-        [LibraryImport(ObjectiveC.MetalFramework)]
-        private static partial IntPtr MTLCreateSystemDefaultDevice();
+        public bool Supports32BitMSAA => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supports32BitMSAA);
 
-        public static MTLDevice CreateSystemDefaultDevice()
+        public bool SupportsBCTextureCompression => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportsBCTextureCompression);
+
+        public bool SupportsDynamicLibraries => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportsDynamicLibraries);
+
+        public bool SupportsFunctionPointers => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportsFunctionPointers);
+
+        public bool SupportsFunctionPointersFromRender => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportsFunctionPointersFromRender);
+
+        public bool SupportsPrimitiveMotionBlur => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportsPrimitiveMotionBlur);
+
+        public bool SupportsPullModelInterpolation => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportsPullModelInterpolation);
+
+        public bool SupportsQueryTextureLOD => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportsQueryTextureLOD);
+
+        public bool SupportsRaytracing => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportsRaytracing);
+
+        public bool SupportsRaytracingFromRender => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportsRaytracingFromRender);
+
+        public bool SupportsRenderDynamicLibraries => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportsRenderDynamicLibraries);
+
+        public bool SupportsShaderBarycentricCoordinates => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportsShaderBarycentricCoordinates);
+
+        public MTLAccelerationStructureSizes AccelerationStructureSizes(MTLAccelerationStructureDescriptor descriptor)
         {
-            return new(MTLCreateSystemDefaultDevice());
+            return ObjectiveCRuntime.MTLAccelerationStructureSizes_objc_msgSend(NativePtr, sel_accelerationStructureSizesWithDescriptor, descriptor);
+        }
+
+        public void ConvertSparsePixelRegions(MTLRegion pixelRegions, MTLRegion tileRegions, MTLSize tileSize, MTLSparseTextureRegionAlignmentMode mode, ulong numRegions)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_convertSparsePixelRegionstoTileRegionswithTileSizealignmentModenumRegions, pixelRegions, tileRegions, tileSize, (ulong)mode, numRegions);
+        }
+
+        public void ConvertSparseTileRegions(MTLRegion tileRegions, MTLRegion pixelRegions, MTLSize tileSize, ulong numRegions)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_convertSparseTileRegionstoPixelRegionswithTileSizenumRegions, tileRegions, pixelRegions, tileSize, numRegions);
         }
 
         [LibraryImport(ObjectiveC.MetalFramework)]
@@ -371,6 +378,84 @@ namespace SharpMetal.Metal
             return new(MTLCopyAllDevices());
         }
 
+        [LibraryImport(ObjectiveC.MetalFramework)]
+        private static partial IntPtr MTLCreateSystemDefaultDevice();
+
+        public static MTLDevice CreateSystemDefaultDevice()
+        {
+            return new(MTLCreateSystemDefaultDevice());
+        }
+
+        public void GetDefaultSamplePositions(MTLSamplePosition positions, ulong count)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_getDefaultSamplePositionscount, positions, count);
+        }
+
+        public MTLSizeAndAlign HeapAccelerationStructureSizeAndAlign(MTLAccelerationStructureDescriptor descriptor)
+        {
+            return ObjectiveCRuntime.MTLSizeAndAlign_objc_msgSend(NativePtr, sel_heapAccelerationStructureSizeAndAlignWithDescriptor, descriptor);
+        }
+
+        public MTLSizeAndAlign HeapAccelerationStructureSizeAndAlign(ulong size)
+        {
+            return ObjectiveCRuntime.MTLSizeAndAlign_objc_msgSend(NativePtr, sel_heapAccelerationStructureSizeAndAlignWithSize, size);
+        }
+
+        public MTLSizeAndAlign HeapBufferSizeAndAlign(ulong length, MTLResourceOptions options)
+        {
+            return ObjectiveCRuntime.MTLSizeAndAlign_objc_msgSend(NativePtr, sel_heapBufferSizeAndAlignWithLengthoptions, length, (ulong)options);
+        }
+
+        public MTLSizeAndAlign HeapTextureSizeAndAlign(MTLTextureDescriptor desc)
+        {
+            return ObjectiveCRuntime.MTLSizeAndAlign_objc_msgSend(NativePtr, sel_heapTextureSizeAndAlignWithDescriptor, desc);
+        }
+
+        public ulong MinimumLinearTextureAlignmentForPixelFormat(MTLPixelFormat format)
+        {
+            return ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_minimumLinearTextureAlignmentForPixelFormat, (ulong)format);
+        }
+
+        public ulong MinimumTextureBufferAlignmentForPixelFormat(MTLPixelFormat format)
+        {
+            return ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_minimumTextureBufferAlignmentForPixelFormat, (ulong)format);
+        }
+
+        public MTLAccelerationStructure NewAccelerationStructure(ulong size)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newAccelerationStructureWithSize, size));
+        }
+
+        public MTLAccelerationStructure NewAccelerationStructure(MTLAccelerationStructureDescriptor descriptor)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newAccelerationStructureWithDescriptor, descriptor));
+        }
+
+        public MTLArgumentEncoder NewArgumentEncoder(MTLBufferBinding bufferBinding)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newArgumentEncoderWithBufferBinding, bufferBinding));
+        }
+
+        public MTLArgumentEncoder NewArgumentEncoder(NSArray arguments)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newArgumentEncoderWithArguments, arguments));
+        }
+
+        public MTLBinaryArchive NewBinaryArchive(MTLBinaryArchiveDescriptor descriptor, ref NSError error)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newBinaryArchiveWithDescriptorerror, descriptor, ref error.NativePtr));
+        }
+
+        public MTLBuffer NewBuffer(IntPtr pointer, ulong length, MTLResourceOptions options)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newBufferWithByteslengthoptions, pointer, length, (ulong)options));
+        }
+
+        public MTLBuffer NewBuffer(ulong length, MTLResourceOptions options)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newBufferWithLengthoptions, length, (ulong)options));
+        }
+
         public MTLCommandQueue NewCommandQueue(ulong maxCommandBufferCount)
         {
             return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newCommandQueueWithMaxCommandBufferCount, maxCommandBufferCount));
@@ -379,118 +464,6 @@ namespace SharpMetal.Metal
         public MTLCommandQueue NewCommandQueue()
         {
             return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newCommandQueueWithMaxCommandBufferCount));
-        }
-
-        public MTLSizeAndAlign HeapTextureSizeAndAlign(MTLTextureDescriptor desc)
-        {
-            return ObjectiveCRuntime.MTLSizeAndAlign_objc_msgSend(NativePtr, sel_heapTextureSizeAndAlignWithDescriptor, desc);
-        }
-
-        public MTLSizeAndAlign HeapBufferSizeAndAlign(ulong length, MTLResourceOptions options)
-        {
-            return ObjectiveCRuntime.MTLSizeAndAlign_objc_msgSend(NativePtr, sel_heapBufferSizeAndAlignWithLengthoptions, length, (ulong)options);
-        }
-
-        public MTLHeap NewHeap(MTLHeapDescriptor descriptor)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newHeapWithDescriptor, descriptor));
-        }
-
-        public MTLBuffer NewBuffer(ulong length, MTLResourceOptions options)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newBufferWithLengthoptions, length, (ulong)options));
-        }
-
-        public MTLBuffer NewBuffer(IntPtr pointer, ulong length, MTLResourceOptions options)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newBufferWithByteslengthoptions, pointer, length, (ulong)options));
-        }
-
-        public MTLDepthStencilState NewDepthStencilState(MTLDepthStencilDescriptor descriptor)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newDepthStencilStateWithDescriptor, descriptor));
-        }
-
-        public MTLTexture NewTexture(MTLTextureDescriptor descriptor)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newTextureWithDescriptor, descriptor));
-        }
-
-        public MTLTexture NewTexture(MTLTextureDescriptor descriptor, IntPtr iosurface, ulong plane)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newTextureWithDescriptoriosurfaceplane, descriptor, iosurface, plane));
-        }
-
-        public MTLTexture NewSharedTexture(MTLTextureDescriptor descriptor)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newSharedTextureWithDescriptor, descriptor));
-        }
-
-        public MTLTexture NewSharedTexture(MTLSharedTextureHandle sharedHandle)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newSharedTextureWithHandle, sharedHandle));
-        }
-
-        public MTLSamplerState NewSamplerState(MTLSamplerDescriptor descriptor)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newSamplerStateWithDescriptor, descriptor));
-        }
-
-        public MTLLibrary NewDefaultLibrary(NSBundle bundle, ref NSError error)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newDefaultLibraryWithBundleerror, bundle, ref error.NativePtr));
-        }
-
-        public MTLLibrary NewDefaultLibrary()
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newDefaultLibraryWithBundleerror));
-        }
-
-        public MTLLibrary NewLibrary(NSString filepath, ref NSError error)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newLibraryWithFileerror, filepath, ref error.NativePtr));
-        }
-
-        public MTLLibrary NewLibrary(NSURL url, ref NSError error)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newLibraryWithURLerror, url, ref error.NativePtr));
-        }
-
-        public MTLLibrary NewLibrary(IntPtr data, ref NSError error)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newLibraryWithDataerror, data, ref error.NativePtr));
-        }
-
-        public MTLLibrary NewLibrary(NSString source, MTLCompileOptions options, ref NSError error)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newLibraryWithSourceoptionserror, source, options, ref error.NativePtr));
-        }
-
-        public GCHandle NewLibrary(NSString source, MTLCompileOptions options, Action<MTLLibrary, NSError> callback)
-        {
-            NewLibraryCompletionHandler handler = (_, library, error) => callback(new MTLLibrary(library), new NSError(error));
-            var gcHandle = GCHandle.Alloc(handler);
-
-            var block = Block.GetBlockForDelegate(handler);
-
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_newLibraryWithSourceoptionscompletionHandler, source, options, block);
-
-            return gcHandle;
-        }
-
-        public MTLLibrary NewLibrary(MTLStitchedLibraryDescriptor descriptor, ref NSError error)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newLibraryWithStitchedDescriptorerror, descriptor, ref error.NativePtr));
-        }
-
-        public MTLRenderPipelineState NewRenderPipelineState(MTLRenderPipelineDescriptor descriptor, ref NSError error)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newRenderPipelineStateWithDescriptorerror, descriptor, ref error.NativePtr));
-        }
-
-        public MTLRenderPipelineState NewRenderPipelineState(MTLRenderPipelineDescriptor descriptor, MTLPipelineOption options, IntPtr reflection, ref NSError error)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newRenderPipelineStateWithDescriptoroptionsreflectionerror, descriptor, (ulong)options, reflection, ref error.NativePtr));
         }
 
         public MTLComputePipelineState NewComputePipelineState(MTLFunction computeFunction, ref NSError error)
@@ -508,29 +481,108 @@ namespace SharpMetal.Metal
             return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newComputePipelineStateWithDescriptoroptionsreflectionerror, descriptor, (ulong)options, reflection, ref error.NativePtr));
         }
 
-        public bool SupportsFeatureSet(MTLFeatureSet featureSet)
+        public MTLCounterSampleBuffer NewCounterSampleBuffer(MTLCounterSampleBufferDescriptor descriptor, ref NSError error)
         {
-            return ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportsFeatureSet, (ulong)featureSet);
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newCounterSampleBufferWithDescriptorerror, descriptor, ref error.NativePtr));
         }
 
-        public bool SupportsFamily(MTLGPUFamily gpuFamily)
+        public MTLLibrary NewDefaultLibrary()
         {
-            return ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportsFamily, (long)gpuFamily);
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newDefaultLibraryWithBundleerror));
         }
 
-        public bool SupportsTextureSampleCount(ulong sampleCount)
+        public MTLLibrary NewDefaultLibrary(NSBundle bundle, ref NSError error)
         {
-            return ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportsTextureSampleCount, sampleCount);
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newDefaultLibraryWithBundleerror, bundle, ref error.NativePtr));
         }
 
-        public ulong MinimumLinearTextureAlignmentForPixelFormat(MTLPixelFormat format)
+        public MTLDepthStencilState NewDepthStencilState(MTLDepthStencilDescriptor descriptor)
         {
-            return ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_minimumLinearTextureAlignmentForPixelFormat, (ulong)format);
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newDepthStencilStateWithDescriptor, descriptor));
         }
 
-        public ulong MinimumTextureBufferAlignmentForPixelFormat(MTLPixelFormat format)
+        public MTLDynamicLibrary NewDynamicLibrary(NSURL url, ref NSError error)
         {
-            return ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_minimumTextureBufferAlignmentForPixelFormat, (ulong)format);
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newDynamicLibraryWithURLerror, url, ref error.NativePtr));
+        }
+
+        public MTLDynamicLibrary NewDynamicLibrary(MTLLibrary library, ref NSError error)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newDynamicLibraryerror, library, ref error.NativePtr));
+        }
+
+        public MTLHeap NewHeap(MTLHeapDescriptor descriptor)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newHeapWithDescriptor, descriptor));
+        }
+
+        public MTLIndirectCommandBuffer NewIndirectCommandBuffer(MTLIndirectCommandBufferDescriptor descriptor, ulong maxCount, MTLResourceOptions options)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newIndirectCommandBufferWithDescriptormaxCommandCountoptions, descriptor, maxCount, (ulong)options));
+        }
+
+        public IntPtr NewIOCommandQueue(IntPtr descriptor, ref NSError error)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newIOCommandQueueWithDescriptorerror, descriptor, ref error.NativePtr));
+        }
+
+        public IntPtr NewIOFileHandle(NSURL url, MTLIOCompressionMethod compressionMethod, ref NSError error)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newIOFileHandleWithURLcompressionMethoderror, url, (long)compressionMethod, ref error.NativePtr));
+        }
+
+        public IntPtr NewIOFileHandle(NSURL url, ref NSError error)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newIOFileHandleWithURLerror, url, ref error.NativePtr));
+        }
+
+        public IntPtr NewIOHandle(NSURL url, MTLIOCompressionMethod compressionMethod, ref NSError error)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newIOHandleWithURLcompressionMethoderror, url, (long)compressionMethod, ref error.NativePtr));
+        }
+
+        public IntPtr NewIOHandle(NSURL url, ref NSError error)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newIOHandleWithURLerror, url, ref error.NativePtr));
+        }
+
+        public MTLLibrary NewLibrary(NSString source, MTLCompileOptions options, ref NSError error)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newLibraryWithSourceoptionserror, source, options, ref error.NativePtr));
+        }
+
+        public GCHandle NewLibrary(NSString source, MTLCompileOptions options, Action<MTLLibrary, NSError> callback)
+        {
+            NewLibraryCompletionHandler handler = (_, library, error) => callback(new MTLLibrary(library), new NSError(error));
+            var gcHandle = GCHandle.Alloc(handler);
+            var block = Block.GetBlockForDelegate(handler);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_newLibraryWithSourceoptionscompletionHandler, source, options, block);
+            return gcHandle;
+        }
+
+        public MTLLibrary NewLibrary(IntPtr data, ref NSError error)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newLibraryWithDataerror, data, ref error.NativePtr));
+        }
+
+        public MTLLibrary NewLibrary(NSURL url, ref NSError error)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newLibraryWithURLerror, url, ref error.NativePtr));
+        }
+
+        public MTLLibrary NewLibrary(NSString filepath, ref NSError error)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newLibraryWithFileerror, filepath, ref error.NativePtr));
+        }
+
+        public MTLLibrary NewLibrary(MTLStitchedLibraryDescriptor descriptor, ref NSError error)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newLibraryWithStitchedDescriptorerror, descriptor, ref error.NativePtr));
+        }
+
+        public MTLRasterizationRateMap NewRasterizationRateMap(MTLRasterizationRateMapDescriptor descriptor)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newRasterizationRateMapWithDescriptor, descriptor));
         }
 
         public MTLRenderPipelineState NewRenderPipelineState(MTLTileRenderPipelineDescriptor descriptor, MTLPipelineOption options, IntPtr reflection, ref NSError error)
@@ -543,29 +595,19 @@ namespace SharpMetal.Metal
             return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newRenderPipelineStateWithMeshDescriptoroptionsreflectionerror, descriptor, (ulong)options, reflection, ref error.NativePtr));
         }
 
-        public void GetDefaultSamplePositions(MTLSamplePosition positions, ulong count)
+        public MTLRenderPipelineState NewRenderPipelineState(MTLRenderPipelineDescriptor descriptor, ref NSError error)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_getDefaultSamplePositionscount, positions, count);
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newRenderPipelineStateWithDescriptorerror, descriptor, ref error.NativePtr));
         }
 
-        public MTLArgumentEncoder NewArgumentEncoder(NSArray arguments)
+        public MTLRenderPipelineState NewRenderPipelineState(MTLRenderPipelineDescriptor descriptor, MTLPipelineOption options, IntPtr reflection, ref NSError error)
         {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newArgumentEncoderWithArguments, arguments));
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newRenderPipelineStateWithDescriptoroptionsreflectionerror, descriptor, (ulong)options, reflection, ref error.NativePtr));
         }
 
-        public bool SupportsRasterizationRateMap(ulong layerCount)
+        public MTLSamplerState NewSamplerState(MTLSamplerDescriptor descriptor)
         {
-            return ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportsRasterizationRateMapWithLayerCount, layerCount);
-        }
-
-        public MTLRasterizationRateMap NewRasterizationRateMap(MTLRasterizationRateMapDescriptor descriptor)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newRasterizationRateMapWithDescriptor, descriptor));
-        }
-
-        public MTLIndirectCommandBuffer NewIndirectCommandBuffer(MTLIndirectCommandBufferDescriptor descriptor, ulong maxCount, MTLResourceOptions options)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newIndirectCommandBufferWithDescriptormaxCommandCountoptions, descriptor, maxCount, (ulong)options));
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newSamplerStateWithDescriptor, descriptor));
         }
 
         public MTLSharedEvent NewSharedEvent(MTLSharedEventHandle sharedEventHandle)
@@ -578,64 +620,24 @@ namespace SharpMetal.Metal
             return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newSharedEventWithHandle));
         }
 
-        public IntPtr NewIOHandle(NSURL url, ref NSError error)
+        public MTLTexture NewSharedTexture(MTLTextureDescriptor descriptor)
         {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newIOHandleWithURLerror, url, ref error.NativePtr));
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newSharedTextureWithDescriptor, descriptor));
         }
 
-        public IntPtr NewIOCommandQueue(IntPtr descriptor, ref NSError error)
+        public MTLTexture NewSharedTexture(MTLSharedTextureHandle sharedHandle)
         {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newIOCommandQueueWithDescriptorerror, descriptor, ref error.NativePtr));
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newSharedTextureWithHandle, sharedHandle));
         }
 
-        public IntPtr NewIOHandle(NSURL url, MTLIOCompressionMethod compressionMethod, ref NSError error)
+        public MTLTexture NewTexture(MTLTextureDescriptor descriptor)
         {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newIOHandleWithURLcompressionMethoderror, url, (long)compressionMethod, ref error.NativePtr));
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newTextureWithDescriptor, descriptor));
         }
 
-        public IntPtr NewIOFileHandle(NSURL url, ref NSError error)
+        public MTLTexture NewTexture(MTLTextureDescriptor descriptor, IntPtr iosurface, ulong plane)
         {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newIOFileHandleWithURLerror, url, ref error.NativePtr));
-        }
-
-        public IntPtr NewIOFileHandle(NSURL url, MTLIOCompressionMethod compressionMethod, ref NSError error)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newIOFileHandleWithURLcompressionMethoderror, url, (long)compressionMethod, ref error.NativePtr));
-        }
-
-        public MTLSize SparseTileSize(MTLTextureType textureType, MTLPixelFormat pixelFormat, ulong sampleCount)
-        {
-            return ObjectiveCRuntime.MTLSize_objc_msgSend(NativePtr, sel_sparseTileSizeWithTextureTypepixelFormatsampleCount, (ulong)textureType, (ulong)pixelFormat, sampleCount);
-        }
-
-        public void ConvertSparsePixelRegions(MTLRegion pixelRegions, MTLRegion tileRegions, MTLSize tileSize, MTLSparseTextureRegionAlignmentMode mode, ulong numRegions)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_convertSparsePixelRegionstoTileRegionswithTileSizealignmentModenumRegions, pixelRegions, tileRegions, tileSize, (ulong)mode, numRegions);
-        }
-
-        public void ConvertSparseTileRegions(MTLRegion tileRegions, MTLRegion pixelRegions, MTLSize tileSize, ulong numRegions)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_convertSparseTileRegionstoPixelRegionswithTileSizenumRegions, tileRegions, pixelRegions, tileSize, numRegions);
-        }
-
-        public ulong SparseTileSizeInBytes(MTLSparsePageSize sparsePageSize)
-        {
-            return ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_sparseTileSizeInBytesForSparsePageSize, (long)sparsePageSize);
-        }
-
-        public ulong SparseTileSizeInBytes()
-        {
-            return ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_sparseTileSizeInBytesForSparsePageSize);
-        }
-
-        public MTLSize SparseTileSize(MTLTextureType textureType, MTLPixelFormat pixelFormat, ulong sampleCount, MTLSparsePageSize sparsePageSize)
-        {
-            return ObjectiveCRuntime.MTLSize_objc_msgSend(NativePtr, sel_sparseTileSizeWithTextureTypepixelFormatsampleCountsparsePageSize, (ulong)textureType, (ulong)pixelFormat, sampleCount, (long)sparsePageSize);
-        }
-
-        public MTLCounterSampleBuffer NewCounterSampleBuffer(MTLCounterSampleBufferDescriptor descriptor, ref NSError error)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newCounterSampleBufferWithDescriptorerror, descriptor, ref error.NativePtr));
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newTextureWithDescriptoriosurfaceplane, descriptor, iosurface, plane));
         }
 
         public void SampleTimestamps(ulong cpuTimestamp, ulong gpuTimestamp)
@@ -643,9 +645,24 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_sampleTimestampsgpuTimestamp, cpuTimestamp, gpuTimestamp);
         }
 
-        public MTLArgumentEncoder NewArgumentEncoder(MTLBufferBinding bufferBinding)
+        public MTLSize SparseTileSize(MTLTextureType textureType, MTLPixelFormat pixelFormat, ulong sampleCount, MTLSparsePageSize sparsePageSize)
         {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newArgumentEncoderWithBufferBinding, bufferBinding));
+            return ObjectiveCRuntime.MTLSize_objc_msgSend(NativePtr, sel_sparseTileSizeWithTextureTypepixelFormatsampleCountsparsePageSize, (ulong)textureType, (ulong)pixelFormat, sampleCount, (long)sparsePageSize);
+        }
+
+        public MTLSize SparseTileSize(MTLTextureType textureType, MTLPixelFormat pixelFormat, ulong sampleCount)
+        {
+            return ObjectiveCRuntime.MTLSize_objc_msgSend(NativePtr, sel_sparseTileSizeWithTextureTypepixelFormatsampleCount, (ulong)textureType, (ulong)pixelFormat, sampleCount);
+        }
+
+        public ulong SparseTileSizeInBytes()
+        {
+            return ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_sparseTileSizeInBytesForSparsePageSize);
+        }
+
+        public ulong SparseTileSizeInBytes(MTLSparsePageSize sparsePageSize)
+        {
+            return ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_sparseTileSizeInBytesForSparsePageSize, (long)sparsePageSize);
         }
 
         public bool SupportsCounterSampling(MTLCounterSamplingPoint samplingPoint)
@@ -653,160 +670,140 @@ namespace SharpMetal.Metal
             return ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportsCounterSampling, (ulong)samplingPoint);
         }
 
+        public bool SupportsFamily(MTLGPUFamily gpuFamily)
+        {
+            return ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportsFamily, (long)gpuFamily);
+        }
+
+        public bool SupportsFeatureSet(MTLFeatureSet featureSet)
+        {
+            return ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportsFeatureSet, (ulong)featureSet);
+        }
+
+        public bool SupportsRasterizationRateMap(ulong layerCount)
+        {
+            return ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportsRasterizationRateMapWithLayerCount, layerCount);
+        }
+
+        public bool SupportsTextureSampleCount(ulong sampleCount)
+        {
+            return ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportsTextureSampleCount, sampleCount);
+        }
+
         public bool SupportsVertexAmplificationCount(ulong count)
         {
             return ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportsVertexAmplificationCount, count);
         }
 
-        public MTLDynamicLibrary NewDynamicLibrary(MTLLibrary library, ref NSError error)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newDynamicLibraryerror, library, ref error.NativePtr));
-        }
-
-        public MTLDynamicLibrary NewDynamicLibrary(NSURL url, ref NSError error)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newDynamicLibraryWithURLerror, url, ref error.NativePtr));
-        }
-
-        public MTLBinaryArchive NewBinaryArchive(MTLBinaryArchiveDescriptor descriptor, ref NSError error)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newBinaryArchiveWithDescriptorerror, descriptor, ref error.NativePtr));
-        }
-
-        public MTLAccelerationStructureSizes AccelerationStructureSizes(MTLAccelerationStructureDescriptor descriptor)
-        {
-            return ObjectiveCRuntime.MTLAccelerationStructureSizes_objc_msgSend(NativePtr, sel_accelerationStructureSizesWithDescriptor, descriptor);
-        }
-
-        public MTLAccelerationStructure NewAccelerationStructure(ulong size)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newAccelerationStructureWithSize, size));
-        }
-
-        public MTLAccelerationStructure NewAccelerationStructure(MTLAccelerationStructureDescriptor descriptor)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newAccelerationStructureWithDescriptor, descriptor));
-        }
-
-        public MTLSizeAndAlign HeapAccelerationStructureSizeAndAlign(ulong size)
-        {
-            return ObjectiveCRuntime.MTLSizeAndAlign_objc_msgSend(NativePtr, sel_heapAccelerationStructureSizeAndAlignWithSize, size);
-        }
-
-        public MTLSizeAndAlign HeapAccelerationStructureSizeAndAlign(MTLAccelerationStructureDescriptor descriptor)
-        {
-            return ObjectiveCRuntime.MTLSizeAndAlign_objc_msgSend(NativePtr, sel_heapAccelerationStructureSizeAndAlignWithDescriptor, descriptor);
-        }
-
-        private static readonly Selector sel_name = "name";
-        private static readonly Selector sel_registryID = "registryID";
+        private static readonly Selector sel_accelerationStructureSizesWithDescriptor = "accelerationStructureSizesWithDescriptor:";
         private static readonly Selector sel_architecture = "architecture";
-        private static readonly Selector sel_maxThreadsPerThreadgroup = "maxThreadsPerThreadgroup";
-        private static readonly Selector sel_isLowPower = "isLowPower";
-        private static readonly Selector sel_isHeadless = "isHeadless";
-        private static readonly Selector sel_isRemovable = "isRemovable";
-        private static readonly Selector sel_hasUnifiedMemory = "hasUnifiedMemory";
-        private static readonly Selector sel_recommendedMaxWorkingSetSize = "recommendedMaxWorkingSetSize";
-        private static readonly Selector sel_location = "location";
-        private static readonly Selector sel_locationNumber = "locationNumber";
-        private static readonly Selector sel_maxTransferRate = "maxTransferRate";
-        private static readonly Selector sel_isDepth24Stencil8PixelFormatSupported = "isDepth24Stencil8PixelFormatSupported";
-        private static readonly Selector sel_readWriteTextureSupport = "readWriteTextureSupport";
-        private static readonly Selector sel_argumentBuffersSupport = "argumentBuffersSupport";
-        private static readonly Selector sel_areRasterOrderGroupsSupported = "areRasterOrderGroupsSupported";
-        private static readonly Selector sel_supports32BitFloatFiltering = "supports32BitFloatFiltering";
-        private static readonly Selector sel_supports32BitMSAA = "supports32BitMSAA";
-        private static readonly Selector sel_supportsQueryTextureLOD = "supportsQueryTextureLOD";
-        private static readonly Selector sel_supportsBCTextureCompression = "supportsBCTextureCompression";
-        private static readonly Selector sel_supportsPullModelInterpolation = "supportsPullModelInterpolation";
         private static readonly Selector sel_areBarycentricCoordsSupported = "areBarycentricCoordsSupported";
-        private static readonly Selector sel_supportsShaderBarycentricCoordinates = "supportsShaderBarycentricCoordinates";
-        private static readonly Selector sel_currentAllocatedSize = "currentAllocatedSize";
-        private static readonly Selector sel_newCommandQueue = "newCommandQueue";
-        private static readonly Selector sel_newCommandQueueWithMaxCommandBufferCount = "newCommandQueueWithMaxCommandBufferCount:";
-        private static readonly Selector sel_heapTextureSizeAndAlignWithDescriptor = "heapTextureSizeAndAlignWithDescriptor:";
-        private static readonly Selector sel_heapBufferSizeAndAlignWithLengthoptions = "heapBufferSizeAndAlignWithLength:options:";
-        private static readonly Selector sel_newHeapWithDescriptor = "newHeapWithDescriptor:";
-        private static readonly Selector sel_newBufferWithLengthoptions = "newBufferWithLength:options:";
-        private static readonly Selector sel_newBufferWithByteslengthoptions = "newBufferWithBytes:length:options:";
-        private static readonly Selector sel_newBufferWithBytesNoCopylengthoptionsdeallocator = "newBufferWithBytesNoCopy:length:options:deallocator:";
-        private static readonly Selector sel_newDepthStencilStateWithDescriptor = "newDepthStencilStateWithDescriptor:";
-        private static readonly Selector sel_newTextureWithDescriptor = "newTextureWithDescriptor:";
-        private static readonly Selector sel_newTextureWithDescriptoriosurfaceplane = "newTextureWithDescriptor:iosurface:plane:";
-        private static readonly Selector sel_newSharedTextureWithDescriptor = "newSharedTextureWithDescriptor:";
-        private static readonly Selector sel_newSharedTextureWithHandle = "newSharedTextureWithHandle:";
-        private static readonly Selector sel_newSamplerStateWithDescriptor = "newSamplerStateWithDescriptor:";
-        private static readonly Selector sel_newDefaultLibrary = "newDefaultLibrary";
-        private static readonly Selector sel_newDefaultLibraryWithBundleerror = "newDefaultLibraryWithBundle:error:";
-        private static readonly Selector sel_newLibraryWithFileerror = "newLibraryWithFile:error:";
-        private static readonly Selector sel_newLibraryWithURLerror = "newLibraryWithURL:error:";
-        private static readonly Selector sel_newLibraryWithDataerror = "newLibraryWithData:error:";
-        private static readonly Selector sel_newLibraryWithSourceoptionserror = "newLibraryWithSource:options:error:";
-        private static readonly Selector sel_newLibraryWithSourceoptionscompletionHandler = "newLibraryWithSource:options:completionHandler:";
-        private static readonly Selector sel_newLibraryWithStitchedDescriptorerror = "newLibraryWithStitchedDescriptor:error:";
-        private static readonly Selector sel_newRenderPipelineStateWithDescriptorerror = "newRenderPipelineStateWithDescriptor:error:";
-        private static readonly Selector sel_newRenderPipelineStateWithDescriptoroptionsreflectionerror = "newRenderPipelineStateWithDescriptor:options:reflection:error:";
-        private static readonly Selector sel_newComputePipelineStateWithFunctionerror = "newComputePipelineStateWithFunction:error:";
-        private static readonly Selector sel_newComputePipelineStateWithFunctionoptionsreflectionerror = "newComputePipelineStateWithFunction:options:reflection:error:";
-        private static readonly Selector sel_newComputePipelineStateWithDescriptoroptionsreflectionerror = "newComputePipelineStateWithDescriptor:options:reflection:error:";
-        private static readonly Selector sel_newFence = "newFence";
-        private static readonly Selector sel_supportsFeatureSet = "supportsFeatureSet:";
-        private static readonly Selector sel_supportsFamily = "supportsFamily:";
-        private static readonly Selector sel_supportsTextureSampleCount = "supportsTextureSampleCount:";
-        private static readonly Selector sel_minimumLinearTextureAlignmentForPixelFormat = "minimumLinearTextureAlignmentForPixelFormat:";
-        private static readonly Selector sel_minimumTextureBufferAlignmentForPixelFormat = "minimumTextureBufferAlignmentForPixelFormat:";
-        private static readonly Selector sel_newRenderPipelineStateWithTileDescriptoroptionsreflectionerror = "newRenderPipelineStateWithTileDescriptor:options:reflection:error:";
-        private static readonly Selector sel_newRenderPipelineStateWithMeshDescriptoroptionsreflectionerror = "newRenderPipelineStateWithMeshDescriptor:options:reflection:error:";
-        private static readonly Selector sel_maxThreadgroupMemoryLength = "maxThreadgroupMemoryLength";
-        private static readonly Selector sel_maxArgumentBufferSamplerCount = "maxArgumentBufferSamplerCount";
         private static readonly Selector sel_areProgrammableSamplePositionsSupported = "areProgrammableSamplePositionsSupported";
-        private static readonly Selector sel_getDefaultSamplePositionscount = "getDefaultSamplePositions:count:";
-        private static readonly Selector sel_newArgumentEncoderWithArguments = "newArgumentEncoderWithArguments:";
-        private static readonly Selector sel_supportsRasterizationRateMapWithLayerCount = "supportsRasterizationRateMapWithLayerCount:";
-        private static readonly Selector sel_newRasterizationRateMapWithDescriptor = "newRasterizationRateMapWithDescriptor:";
-        private static readonly Selector sel_newIndirectCommandBufferWithDescriptormaxCommandCountoptions = "newIndirectCommandBufferWithDescriptor:maxCommandCount:options:";
-        private static readonly Selector sel_newEvent = "newEvent";
-        private static readonly Selector sel_newSharedEvent = "newSharedEvent";
-        private static readonly Selector sel_newSharedEventWithHandle = "newSharedEventWithHandle:";
-        private static readonly Selector sel_peerGroupID = "peerGroupID";
-        private static readonly Selector sel_peerIndex = "peerIndex";
-        private static readonly Selector sel_peerCount = "peerCount";
-        private static readonly Selector sel_newIOHandleWithURLerror = "newIOHandleWithURL:error:";
-        private static readonly Selector sel_newIOCommandQueueWithDescriptorerror = "newIOCommandQueueWithDescriptor:error:";
-        private static readonly Selector sel_newIOHandleWithURLcompressionMethoderror = "newIOHandleWithURL:compressionMethod:error:";
-        private static readonly Selector sel_newIOFileHandleWithURLerror = "newIOFileHandleWithURL:error:";
-        private static readonly Selector sel_newIOFileHandleWithURLcompressionMethoderror = "newIOFileHandleWithURL:compressionMethod:error:";
-        private static readonly Selector sel_sparseTileSizeWithTextureTypepixelFormatsampleCount = "sparseTileSizeWithTextureType:pixelFormat:sampleCount:";
-        private static readonly Selector sel_sparseTileSizeInBytes = "sparseTileSizeInBytes";
+        private static readonly Selector sel_areRasterOrderGroupsSupported = "areRasterOrderGroupsSupported";
+        private static readonly Selector sel_argumentBuffersSupport = "argumentBuffersSupport";
         private static readonly Selector sel_convertSparsePixelRegionstoTileRegionswithTileSizealignmentModenumRegions = "convertSparsePixelRegions:toTileRegions:withTileSize:alignmentMode:numRegions:";
         private static readonly Selector sel_convertSparseTileRegionstoPixelRegionswithTileSizenumRegions = "convertSparseTileRegions:toPixelRegions:withTileSize:numRegions:";
-        private static readonly Selector sel_sparseTileSizeInBytesForSparsePageSize = "sparseTileSizeInBytesForSparsePageSize:";
-        private static readonly Selector sel_sparseTileSizeWithTextureTypepixelFormatsampleCountsparsePageSize = "sparseTileSizeWithTextureType:pixelFormat:sampleCount:sparsePageSize:";
-        private static readonly Selector sel_maxBufferLength = "maxBufferLength";
         private static readonly Selector sel_counterSets = "counterSets";
-        private static readonly Selector sel_newCounterSampleBufferWithDescriptorerror = "newCounterSampleBufferWithDescriptor:error:";
-        private static readonly Selector sel_sampleTimestampsgpuTimestamp = "sampleTimestamps:gpuTimestamp:";
+        private static readonly Selector sel_currentAllocatedSize = "currentAllocatedSize";
+        private static readonly Selector sel_getDefaultSamplePositionscount = "getDefaultSamplePositions:count:";
+        private static readonly Selector sel_hasUnifiedMemory = "hasUnifiedMemory";
+        private static readonly Selector sel_heapAccelerationStructureSizeAndAlignWithDescriptor = "heapAccelerationStructureSizeAndAlignWithDescriptor:";
+        private static readonly Selector sel_heapAccelerationStructureSizeAndAlignWithSize = "heapAccelerationStructureSizeAndAlignWithSize:";
+        private static readonly Selector sel_heapBufferSizeAndAlignWithLengthoptions = "heapBufferSizeAndAlignWithLength:options:";
+        private static readonly Selector sel_heapTextureSizeAndAlignWithDescriptor = "heapTextureSizeAndAlignWithDescriptor:";
+        private static readonly Selector sel_isDepth24Stencil8PixelFormatSupported = "isDepth24Stencil8PixelFormatSupported";
+        private static readonly Selector sel_isHeadless = "isHeadless";
+        private static readonly Selector sel_isLowPower = "isLowPower";
+        private static readonly Selector sel_isRemovable = "isRemovable";
+        private static readonly Selector sel_location = "location";
+        private static readonly Selector sel_locationNumber = "locationNumber";
+        private static readonly Selector sel_maxArgumentBufferSamplerCount = "maxArgumentBufferSamplerCount";
+        private static readonly Selector sel_maxBufferLength = "maxBufferLength";
+        private static readonly Selector sel_maximumConcurrentCompilationTaskCount = "maximumConcurrentCompilationTaskCount";
+        private static readonly Selector sel_maxThreadgroupMemoryLength = "maxThreadgroupMemoryLength";
+        private static readonly Selector sel_maxThreadsPerThreadgroup = "maxThreadsPerThreadgroup";
+        private static readonly Selector sel_maxTransferRate = "maxTransferRate";
+        private static readonly Selector sel_minimumLinearTextureAlignmentForPixelFormat = "minimumLinearTextureAlignmentForPixelFormat:";
+        private static readonly Selector sel_minimumTextureBufferAlignmentForPixelFormat = "minimumTextureBufferAlignmentForPixelFormat:";
+        private static readonly Selector sel_name = "name";
+        private static readonly Selector sel_newAccelerationStructureWithDescriptor = "newAccelerationStructureWithDescriptor:";
+        private static readonly Selector sel_newAccelerationStructureWithSize = "newAccelerationStructureWithSize:";
+        private static readonly Selector sel_newArgumentEncoderWithArguments = "newArgumentEncoderWithArguments:";
         private static readonly Selector sel_newArgumentEncoderWithBufferBinding = "newArgumentEncoderWithBufferBinding:";
-        private static readonly Selector sel_supportsCounterSampling = "supportsCounterSampling:";
-        private static readonly Selector sel_supportsVertexAmplificationCount = "supportsVertexAmplificationCount:";
-        private static readonly Selector sel_supportsDynamicLibraries = "supportsDynamicLibraries";
-        private static readonly Selector sel_supportsRenderDynamicLibraries = "supportsRenderDynamicLibraries";
+        private static readonly Selector sel_newBinaryArchiveWithDescriptorerror = "newBinaryArchiveWithDescriptor:error:";
+        private static readonly Selector sel_newBufferWithByteslengthoptions = "newBufferWithBytes:length:options:";
+        private static readonly Selector sel_newBufferWithBytesNoCopylengthoptionsdeallocator = "newBufferWithBytesNoCopy:length:options:deallocator:";
+        private static readonly Selector sel_newBufferWithLengthoptions = "newBufferWithLength:options:";
+        private static readonly Selector sel_newCommandQueue = "newCommandQueue";
+        private static readonly Selector sel_newCommandQueueWithMaxCommandBufferCount = "newCommandQueueWithMaxCommandBufferCount:";
+        private static readonly Selector sel_newComputePipelineStateWithDescriptoroptionsreflectionerror = "newComputePipelineStateWithDescriptor:options:reflection:error:";
+        private static readonly Selector sel_newComputePipelineStateWithFunctionerror = "newComputePipelineStateWithFunction:error:";
+        private static readonly Selector sel_newComputePipelineStateWithFunctionoptionsreflectionerror = "newComputePipelineStateWithFunction:options:reflection:error:";
+        private static readonly Selector sel_newCounterSampleBufferWithDescriptorerror = "newCounterSampleBufferWithDescriptor:error:";
+        private static readonly Selector sel_newDefaultLibrary = "newDefaultLibrary";
+        private static readonly Selector sel_newDefaultLibraryWithBundleerror = "newDefaultLibraryWithBundle:error:";
+        private static readonly Selector sel_newDepthStencilStateWithDescriptor = "newDepthStencilStateWithDescriptor:";
         private static readonly Selector sel_newDynamicLibraryerror = "newDynamicLibrary:error:";
         private static readonly Selector sel_newDynamicLibraryWithURLerror = "newDynamicLibraryWithURL:error:";
-        private static readonly Selector sel_newBinaryArchiveWithDescriptorerror = "newBinaryArchiveWithDescriptor:error:";
-        private static readonly Selector sel_supportsRaytracing = "supportsRaytracing";
-        private static readonly Selector sel_accelerationStructureSizesWithDescriptor = "accelerationStructureSizesWithDescriptor:";
-        private static readonly Selector sel_newAccelerationStructureWithSize = "newAccelerationStructureWithSize:";
-        private static readonly Selector sel_newAccelerationStructureWithDescriptor = "newAccelerationStructureWithDescriptor:";
-        private static readonly Selector sel_heapAccelerationStructureSizeAndAlignWithSize = "heapAccelerationStructureSizeAndAlignWithSize:";
-        private static readonly Selector sel_heapAccelerationStructureSizeAndAlignWithDescriptor = "heapAccelerationStructureSizeAndAlignWithDescriptor:";
+        private static readonly Selector sel_newEvent = "newEvent";
+        private static readonly Selector sel_newFence = "newFence";
+        private static readonly Selector sel_newHeapWithDescriptor = "newHeapWithDescriptor:";
+        private static readonly Selector sel_newIndirectCommandBufferWithDescriptormaxCommandCountoptions = "newIndirectCommandBufferWithDescriptor:maxCommandCount:options:";
+        private static readonly Selector sel_newIOCommandQueueWithDescriptorerror = "newIOCommandQueueWithDescriptor:error:";
+        private static readonly Selector sel_newIOFileHandleWithURLcompressionMethoderror = "newIOFileHandleWithURL:compressionMethod:error:";
+        private static readonly Selector sel_newIOFileHandleWithURLerror = "newIOFileHandleWithURL:error:";
+        private static readonly Selector sel_newIOHandleWithURLcompressionMethoderror = "newIOHandleWithURL:compressionMethod:error:";
+        private static readonly Selector sel_newIOHandleWithURLerror = "newIOHandleWithURL:error:";
+        private static readonly Selector sel_newLibraryWithDataerror = "newLibraryWithData:error:";
+        private static readonly Selector sel_newLibraryWithFileerror = "newLibraryWithFile:error:";
+        private static readonly Selector sel_newLibraryWithSourceoptionscompletionHandler = "newLibraryWithSource:options:completionHandler:";
+        private static readonly Selector sel_newLibraryWithSourceoptionserror = "newLibraryWithSource:options:error:";
+        private static readonly Selector sel_newLibraryWithStitchedDescriptorerror = "newLibraryWithStitchedDescriptor:error:";
+        private static readonly Selector sel_newLibraryWithURLerror = "newLibraryWithURL:error:";
+        private static readonly Selector sel_newRasterizationRateMapWithDescriptor = "newRasterizationRateMapWithDescriptor:";
+        private static readonly Selector sel_newRenderPipelineStateWithDescriptorerror = "newRenderPipelineStateWithDescriptor:error:";
+        private static readonly Selector sel_newRenderPipelineStateWithDescriptoroptionsreflectionerror = "newRenderPipelineStateWithDescriptor:options:reflection:error:";
+        private static readonly Selector sel_newRenderPipelineStateWithMeshDescriptoroptionsreflectionerror = "newRenderPipelineStateWithMeshDescriptor:options:reflection:error:";
+        private static readonly Selector sel_newRenderPipelineStateWithTileDescriptoroptionsreflectionerror = "newRenderPipelineStateWithTileDescriptor:options:reflection:error:";
+        private static readonly Selector sel_newSamplerStateWithDescriptor = "newSamplerStateWithDescriptor:";
+        private static readonly Selector sel_newSharedEvent = "newSharedEvent";
+        private static readonly Selector sel_newSharedEventWithHandle = "newSharedEventWithHandle:";
+        private static readonly Selector sel_newSharedTextureWithDescriptor = "newSharedTextureWithDescriptor:";
+        private static readonly Selector sel_newSharedTextureWithHandle = "newSharedTextureWithHandle:";
+        private static readonly Selector sel_newTextureWithDescriptor = "newTextureWithDescriptor:";
+        private static readonly Selector sel_newTextureWithDescriptoriosurfaceplane = "newTextureWithDescriptor:iosurface:plane:";
+        private static readonly Selector sel_peerCount = "peerCount";
+        private static readonly Selector sel_peerGroupID = "peerGroupID";
+        private static readonly Selector sel_peerIndex = "peerIndex";
+        private static readonly Selector sel_readWriteTextureSupport = "readWriteTextureSupport";
+        private static readonly Selector sel_recommendedMaxWorkingSetSize = "recommendedMaxWorkingSetSize";
+        private static readonly Selector sel_registryID = "registryID";
+        private static readonly Selector sel_sampleTimestampsgpuTimestamp = "sampleTimestamps:gpuTimestamp:";
+        private static readonly Selector sel_setShouldMaximizeConcurrentCompilation = "setShouldMaximizeConcurrentCompilation:";
+        private static readonly Selector sel_shouldMaximizeConcurrentCompilation = "shouldMaximizeConcurrentCompilation";
+        private static readonly Selector sel_sparseTileSizeInBytes = "sparseTileSizeInBytes";
+        private static readonly Selector sel_sparseTileSizeInBytesForSparsePageSize = "sparseTileSizeInBytesForSparsePageSize:";
+        private static readonly Selector sel_sparseTileSizeWithTextureTypepixelFormatsampleCount = "sparseTileSizeWithTextureType:pixelFormat:sampleCount:";
+        private static readonly Selector sel_sparseTileSizeWithTextureTypepixelFormatsampleCountsparsePageSize = "sparseTileSizeWithTextureType:pixelFormat:sampleCount:sparsePageSize:";
+        private static readonly Selector sel_supports32BitFloatFiltering = "supports32BitFloatFiltering";
+        private static readonly Selector sel_supports32BitMSAA = "supports32BitMSAA";
+        private static readonly Selector sel_supportsBCTextureCompression = "supportsBCTextureCompression";
+        private static readonly Selector sel_supportsCounterSampling = "supportsCounterSampling:";
+        private static readonly Selector sel_supportsDynamicLibraries = "supportsDynamicLibraries";
+        private static readonly Selector sel_supportsFamily = "supportsFamily:";
+        private static readonly Selector sel_supportsFeatureSet = "supportsFeatureSet:";
         private static readonly Selector sel_supportsFunctionPointers = "supportsFunctionPointers";
         private static readonly Selector sel_supportsFunctionPointersFromRender = "supportsFunctionPointersFromRender";
-        private static readonly Selector sel_supportsRaytracingFromRender = "supportsRaytracingFromRender";
         private static readonly Selector sel_supportsPrimitiveMotionBlur = "supportsPrimitiveMotionBlur";
-        private static readonly Selector sel_shouldMaximizeConcurrentCompilation = "shouldMaximizeConcurrentCompilation";
-        private static readonly Selector sel_setShouldMaximizeConcurrentCompilation = "setShouldMaximizeConcurrentCompilation:";
-        private static readonly Selector sel_maximumConcurrentCompilationTaskCount = "maximumConcurrentCompilationTaskCount";
+        private static readonly Selector sel_supportsPullModelInterpolation = "supportsPullModelInterpolation";
+        private static readonly Selector sel_supportsQueryTextureLOD = "supportsQueryTextureLOD";
+        private static readonly Selector sel_supportsRasterizationRateMapWithLayerCount = "supportsRasterizationRateMapWithLayerCount:";
+        private static readonly Selector sel_supportsRaytracing = "supportsRaytracing";
+        private static readonly Selector sel_supportsRaytracingFromRender = "supportsRaytracingFromRender";
+        private static readonly Selector sel_supportsRenderDynamicLibraries = "supportsRenderDynamicLibraries";
+        private static readonly Selector sel_supportsShaderBarycentricCoordinates = "supportsShaderBarycentricCoordinates";
+        private static readonly Selector sel_supportsTextureSampleCount = "supportsTextureSampleCount:";
+        private static readonly Selector sel_supportsVertexAmplificationCount = "supportsVertexAmplificationCount:";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLDrawable.cs
+++ b/src/SharpMetal/Metal/MTLDrawable.cs
@@ -16,18 +16,13 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public IntPtr PresentedTime => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_presentedTime));
-
         public ulong DrawableID => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_drawableID);
+
+        public IntPtr PresentedTime => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_presentedTime));
 
         public void Present()
         {
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_present);
-        }
-
-        public void PresentAtTime(IntPtr presentationTime)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_presentAtTime, presentationTime);
         }
 
         public void PresentAfterMinimumDuration(IntPtr duration)
@@ -35,11 +30,16 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_presentAfterMinimumDuration, duration);
         }
 
-        private static readonly Selector sel_present = "present";
-        private static readonly Selector sel_presentAtTime = "presentAtTime:";
-        private static readonly Selector sel_presentAfterMinimumDuration = "presentAfterMinimumDuration:";
-        private static readonly Selector sel_presentedTime = "presentedTime";
+        public void PresentAtTime(IntPtr presentationTime)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_presentAtTime, presentationTime);
+        }
+
         private static readonly Selector sel_drawableID = "drawableID";
+        private static readonly Selector sel_present = "present";
+        private static readonly Selector sel_presentAfterMinimumDuration = "presentAfterMinimumDuration:";
+        private static readonly Selector sel_presentAtTime = "presentAtTime:";
+        private static readonly Selector sel_presentedTime = "presentedTime";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLDynamicLibrary.cs
+++ b/src/SharpMetal/Metal/MTLDynamicLibrary.cs
@@ -27,26 +27,26 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
+        public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
+
+        public NSString InstallName => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_installName));
+
         public NSString Label
         {
             get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
         }
 
-        public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
-
-        public NSString InstallName => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_installName));
-
         public bool SerializeToURL(NSURL url, ref NSError error)
         {
             return ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_serializeToURLerror, url, ref error.NativePtr);
         }
 
-        private static readonly Selector sel_label = "label";
-        private static readonly Selector sel_setLabel = "setLabel:";
         private static readonly Selector sel_device = "device";
         private static readonly Selector sel_installName = "installName";
+        private static readonly Selector sel_label = "label";
         private static readonly Selector sel_serializeToURLerror = "serializeToURL:error:";
+        private static readonly Selector sel_setLabel = "setLabel:";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLEvent.cs
+++ b/src/SharpMetal/Metal/MTLEvent.cs
@@ -31,36 +31,6 @@ namespace SharpMetal.Metal
     }
 
     [SupportedOSPlatform("macos")]
-    public struct MTLSharedEventListener : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLSharedEventListener obj) => obj.NativePtr;
-        public MTLSharedEventListener(IntPtr ptr) => NativePtr = ptr;
-
-        public MTLSharedEventListener()
-        {
-            var cls = new ObjectiveCClass("MTLSharedEventListener");
-            NativePtr = cls.AllocInit();
-        }
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public IntPtr DispatchQueue => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_dispatchQueue));
-
-        public MTLSharedEventListener Init(IntPtr dispatchQueue)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithDispatchQueue, dispatchQueue));
-        }
-
-        private static readonly Selector sel_initWithDispatchQueue = "initWithDispatchQueue:";
-        private static readonly Selector sel_dispatchQueue = "dispatchQueue";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
     public struct MTLSharedEvent : IDisposable
     {
         public IntPtr NativePtr;
@@ -73,14 +43,6 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public MTLSharedEventHandle NewSharedEventHandle => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newSharedEventHandle));
-
-        public ulong SignaledValue
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_signaledValue);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSignaledValue, value);
-        }
-
         public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
 
         public NSString Label
@@ -89,18 +51,26 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
         }
 
+        public MTLSharedEventHandle NewSharedEventHandle => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newSharedEventHandle));
+
+        public ulong SignaledValue
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_signaledValue);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSignaledValue, value);
+        }
+
         public void NotifyListener(MTLSharedEventListener listener, ulong value, IntPtr block)
         {
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_notifyListeneratValueblock, listener, value, block);
         }
 
-        private static readonly Selector sel_notifyListeneratValueblock = "notifyListener:atValue:block:";
-        private static readonly Selector sel_newSharedEventHandle = "newSharedEventHandle";
-        private static readonly Selector sel_signaledValue = "signaledValue";
-        private static readonly Selector sel_setSignaledValue = "setSignaledValue:";
         private static readonly Selector sel_device = "device";
         private static readonly Selector sel_label = "label";
+        private static readonly Selector sel_newSharedEventHandle = "newSharedEventHandle";
+        private static readonly Selector sel_notifyListeneratValueblock = "notifyListener:atValue:block:";
         private static readonly Selector sel_setLabel = "setLabel:";
+        private static readonly Selector sel_setSignaledValue = "setSignaledValue:";
+        private static readonly Selector sel_signaledValue = "signaledValue";
         private static readonly Selector sel_release = "release";
     }
 
@@ -125,6 +95,36 @@ namespace SharpMetal.Metal
         public NSString Label => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
 
         private static readonly Selector sel_label = "label";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
+    public struct MTLSharedEventListener : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLSharedEventListener obj) => obj.NativePtr;
+        public MTLSharedEventListener(IntPtr ptr) => NativePtr = ptr;
+
+        public MTLSharedEventListener()
+        {
+            var cls = new ObjectiveCClass("MTLSharedEventListener");
+            NativePtr = cls.AllocInit();
+        }
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public IntPtr DispatchQueue => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_dispatchQueue));
+
+        public MTLSharedEventListener Init(IntPtr dispatchQueue)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithDispatchQueue, dispatchQueue));
+        }
+
+        private static readonly Selector sel_dispatchQueue = "dispatchQueue";
+        private static readonly Selector sel_initWithDispatchQueue = "initWithDispatchQueue:";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLFunctionConstantValues.cs
+++ b/src/SharpMetal/Metal/MTLFunctionConstantValues.cs
@@ -22,14 +22,14 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
+        public void Reset()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_reset);
+        }
+
         public void SetConstantValue(IntPtr value, MTLDataType type, ulong index)
         {
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setConstantValuetypeatIndex, value, (ulong)type, index);
-        }
-
-        public void SetConstantValues(IntPtr values, MTLDataType type, NSRange range)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setConstantValuestypewithRange, values, (ulong)type, range);
         }
 
         public void SetConstantValue(IntPtr value, MTLDataType type, NSString name)
@@ -37,15 +37,15 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setConstantValuetypewithName, value, (ulong)type, name);
         }
 
-        public void Reset()
+        public void SetConstantValues(IntPtr values, MTLDataType type, NSRange range)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_reset);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setConstantValuestypewithRange, values, (ulong)type, range);
         }
 
-        private static readonly Selector sel_setConstantValuetypeatIndex = "setConstantValue:type:atIndex:";
-        private static readonly Selector sel_setConstantValuestypewithRange = "setConstantValues:type:withRange:";
-        private static readonly Selector sel_setConstantValuetypewithName = "setConstantValue:type:withName:";
         private static readonly Selector sel_reset = "reset";
+        private static readonly Selector sel_setConstantValuestypewithRange = "setConstantValues:type:withRange:";
+        private static readonly Selector sel_setConstantValuetypeatIndex = "setConstantValue:type:atIndex:";
+        private static readonly Selector sel_setConstantValuetypewithName = "setConstantValue:type:withName:";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLFunctionDescriptor.cs
+++ b/src/SharpMetal/Metal/MTLFunctionDescriptor.cs
@@ -31,16 +31,10 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public NSString Name
+        public NSArray BinaryArchives
         {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_name));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setName, value);
-        }
-
-        public NSString SpecializedName
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_specializedName));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSpecializedName, value);
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_binaryArchives));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBinaryArchives, value);
         }
 
         public MTLFunctionConstantValues ConstantValues
@@ -49,29 +43,35 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setConstantValues, value);
         }
 
+        public NSString Name
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_name));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setName, value);
+        }
+
         public MTLFunctionOptions Options
         {
             get => (MTLFunctionOptions)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_options);
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setOptions, (ulong)value);
         }
 
-        public NSArray BinaryArchives
+        public NSString SpecializedName
         {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_binaryArchives));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBinaryArchives, value);
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_specializedName));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSpecializedName, value);
         }
 
+        private static readonly Selector sel_binaryArchives = "binaryArchives";
+        private static readonly Selector sel_constantValues = "constantValues";
         private static readonly Selector sel_functionDescriptor = "functionDescriptor";
         private static readonly Selector sel_name = "name";
-        private static readonly Selector sel_setName = "setName:";
-        private static readonly Selector sel_specializedName = "specializedName";
-        private static readonly Selector sel_setSpecializedName = "setSpecializedName:";
-        private static readonly Selector sel_constantValues = "constantValues";
-        private static readonly Selector sel_setConstantValues = "setConstantValues:";
         private static readonly Selector sel_options = "options";
-        private static readonly Selector sel_setOptions = "setOptions:";
-        private static readonly Selector sel_binaryArchives = "binaryArchives";
         private static readonly Selector sel_setBinaryArchives = "setBinaryArchives:";
+        private static readonly Selector sel_setConstantValues = "setConstantValues:";
+        private static readonly Selector sel_setName = "setName:";
+        private static readonly Selector sel_setOptions = "setOptions:";
+        private static readonly Selector sel_setSpecializedName = "setSpecializedName:";
+        private static readonly Selector sel_specializedName = "specializedName";
         private static readonly Selector sel_release = "release";
     }
 
@@ -94,16 +94,10 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public NSString Name
+        public NSArray BinaryArchives
         {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_name));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setName, value);
-        }
-
-        public NSString SpecializedName
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_specializedName));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSpecializedName, value);
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_binaryArchives));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBinaryArchives, value);
         }
 
         public MTLFunctionConstantValues ConstantValues
@@ -112,29 +106,35 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setConstantValues, value);
         }
 
+        public NSString Name
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_name));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setName, value);
+        }
+
         public MTLFunctionOptions Options
         {
             get => (MTLFunctionOptions)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_options);
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setOptions, (ulong)value);
         }
 
-        public NSArray BinaryArchives
+        public NSString SpecializedName
         {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_binaryArchives));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBinaryArchives, value);
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_specializedName));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSpecializedName, value);
         }
 
+        private static readonly Selector sel_binaryArchives = "binaryArchives";
+        private static readonly Selector sel_constantValues = "constantValues";
         private static readonly Selector sel_functionDescriptor = "functionDescriptor";
         private static readonly Selector sel_name = "name";
-        private static readonly Selector sel_setName = "setName:";
-        private static readonly Selector sel_specializedName = "specializedName";
-        private static readonly Selector sel_setSpecializedName = "setSpecializedName:";
-        private static readonly Selector sel_constantValues = "constantValues";
-        private static readonly Selector sel_setConstantValues = "setConstantValues:";
         private static readonly Selector sel_options = "options";
-        private static readonly Selector sel_setOptions = "setOptions:";
-        private static readonly Selector sel_binaryArchives = "binaryArchives";
         private static readonly Selector sel_setBinaryArchives = "setBinaryArchives:";
+        private static readonly Selector sel_setConstantValues = "setConstantValues:";
+        private static readonly Selector sel_setName = "setName:";
+        private static readonly Selector sel_setOptions = "setOptions:";
+        private static readonly Selector sel_setSpecializedName = "setSpecializedName:";
+        private static readonly Selector sel_specializedName = "specializedName";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLFunctionHandle.cs
+++ b/src/SharpMetal/Metal/MTLFunctionHandle.cs
@@ -16,15 +16,15 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
+        public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
+
         public MTLFunctionType FunctionType => (MTLFunctionType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_functionType);
 
         public NSString Name => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_name));
 
-        public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
-
+        private static readonly Selector sel_device = "device";
         private static readonly Selector sel_functionType = "functionType";
         private static readonly Selector sel_name = "name";
-        private static readonly Selector sel_device = "device";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLFunctionLog.cs
+++ b/src/SharpMetal/Metal/MTLFunctionLog.cs
@@ -11,6 +11,60 @@ namespace SharpMetal.Metal
     }
 
     [SupportedOSPlatform("macos")]
+    public struct MTLFunctionLog : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLFunctionLog obj) => obj.NativePtr;
+        public MTLFunctionLog(IntPtr ptr) => NativePtr = ptr;
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public MTLFunctionLogDebugLocation DebugLocation => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_debugLocation));
+
+        public NSString EncoderLabel => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_encoderLabel));
+
+        public MTLFunction Function => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_function));
+
+        public MTLFunctionLogType Type => (MTLFunctionLogType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_type);
+
+        private static readonly Selector sel_debugLocation = "debugLocation";
+        private static readonly Selector sel_encoderLabel = "encoderLabel";
+        private static readonly Selector sel_function = "function";
+        private static readonly Selector sel_type = "type";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
+    public struct MTLFunctionLogDebugLocation : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLFunctionLogDebugLocation obj) => obj.NativePtr;
+        public MTLFunctionLogDebugLocation(IntPtr ptr) => NativePtr = ptr;
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public ulong Column => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_column);
+
+        public NSString FunctionName => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_functionName));
+
+        public ulong Line => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_line);
+
+        public NSURL URL => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_URL));
+
+        private static readonly Selector sel_column = "column";
+        private static readonly Selector sel_functionName = "functionName";
+        private static readonly Selector sel_line = "line";
+        private static readonly Selector sel_URL = "URL";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
     public struct MTLLogContainer : IDisposable
     {
         public IntPtr NativePtr;
@@ -29,60 +83,6 @@ namespace SharpMetal.Metal
         }
 
         private static readonly Selector sel_countByEnumeratingWithStateobjectscount = "countByEnumeratingWithState:objects:count:";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLFunctionLogDebugLocation : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLFunctionLogDebugLocation obj) => obj.NativePtr;
-        public MTLFunctionLogDebugLocation(IntPtr ptr) => NativePtr = ptr;
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public NSString FunctionName => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_functionName));
-
-        public NSURL URL => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_URL));
-
-        public ulong Line => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_line);
-
-        public ulong Column => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_column);
-
-        private static readonly Selector sel_functionName = "functionName";
-        private static readonly Selector sel_URL = "URL";
-        private static readonly Selector sel_line = "line";
-        private static readonly Selector sel_column = "column";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLFunctionLog : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLFunctionLog obj) => obj.NativePtr;
-        public MTLFunctionLog(IntPtr ptr) => NativePtr = ptr;
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public MTLFunctionLogType Type => (MTLFunctionLogType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_type);
-
-        public NSString EncoderLabel => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_encoderLabel));
-
-        public MTLFunction Function => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_function));
-
-        public MTLFunctionLogDebugLocation DebugLocation => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_debugLocation));
-
-        private static readonly Selector sel_type = "type";
-        private static readonly Selector sel_encoderLabel = "encoderLabel";
-        private static readonly Selector sel_function = "function";
-        private static readonly Selector sel_debugLocation = "debugLocation";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLFunctionStitching.cs
+++ b/src/SharpMetal/Metal/MTLFunctionStitching.cs
@@ -40,16 +40,113 @@ namespace SharpMetal.Metal
     }
 
     [SupportedOSPlatform("macos")]
-    public struct MTLFunctionStitchingNode : IDisposable
+    public struct MTLFunctionStitchingFunctionNode : IDisposable
     {
         public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLFunctionStitchingNode obj) => obj.NativePtr;
-        public MTLFunctionStitchingNode(IntPtr ptr) => NativePtr = ptr;
+        public static implicit operator IntPtr(MTLFunctionStitchingFunctionNode obj) => obj.NativePtr;
+        public static implicit operator MTLFunctionStitchingNode(MTLFunctionStitchingFunctionNode obj) => new(obj.NativePtr);
+        public MTLFunctionStitchingFunctionNode(IntPtr ptr) => NativePtr = ptr;
+
+        public MTLFunctionStitchingFunctionNode()
+        {
+            var cls = new ObjectiveCClass("MTLFunctionStitchingFunctionNode");
+            NativePtr = cls.AllocInit();
+        }
 
         public void Dispose()
         {
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
+
+        public NSArray Arguments
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_arguments));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setArguments, value);
+        }
+
+        public NSArray ControlDependencies
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_controlDependencies));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setControlDependencies, value);
+        }
+
+        public NSString Name
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_name));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setName, value);
+        }
+
+        public MTLFunctionStitchingFunctionNode Init(NSString name, NSArray arguments, NSArray controlDependencies)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithNameargumentscontrolDependencies, name, arguments, controlDependencies));
+        }
+
+        private static readonly Selector sel_arguments = "arguments";
+        private static readonly Selector sel_controlDependencies = "controlDependencies";
+        private static readonly Selector sel_initWithNameargumentscontrolDependencies = "initWithName:arguments:controlDependencies:";
+        private static readonly Selector sel_name = "name";
+        private static readonly Selector sel_setArguments = "setArguments:";
+        private static readonly Selector sel_setControlDependencies = "setControlDependencies:";
+        private static readonly Selector sel_setName = "setName:";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
+    public struct MTLFunctionStitchingGraph : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLFunctionStitchingGraph obj) => obj.NativePtr;
+        public MTLFunctionStitchingGraph(IntPtr ptr) => NativePtr = ptr;
+
+        public MTLFunctionStitchingGraph()
+        {
+            var cls = new ObjectiveCClass("MTLFunctionStitchingGraph");
+            NativePtr = cls.AllocInit();
+        }
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public NSArray Attributes
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_attributes));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setAttributes, value);
+        }
+
+        public NSString FunctionName
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_functionName));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFunctionName, value);
+        }
+
+        public NSArray Nodes
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_nodes));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setNodes, value);
+        }
+
+        public MTLFunctionStitchingFunctionNode OutputNode
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_outputNode));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setOutputNode, value);
+        }
+
+        public MTLFunctionStitchingGraph Init(NSString functionName, NSArray nodes, MTLFunctionStitchingFunctionNode outputNode, NSArray attributes)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithFunctionNamenodesoutputNodeattributes, functionName, nodes, outputNode, attributes));
+        }
+
+        private static readonly Selector sel_attributes = "attributes";
+        private static readonly Selector sel_functionName = "functionName";
+        private static readonly Selector sel_initWithFunctionNamenodesoutputNodeattributes = "initWithFunctionName:nodes:outputNode:attributes:";
+        private static readonly Selector sel_nodes = "nodes";
+        private static readonly Selector sel_outputNode = "outputNode";
+        private static readonly Selector sel_setAttributes = "setAttributes:";
+        private static readonly Selector sel_setFunctionName = "setFunctionName:";
+        private static readonly Selector sel_setNodes = "setNodes:";
+        private static readonly Selector sel_setOutputNode = "setOutputNode:";
         private static readonly Selector sel_release = "release";
     }
 
@@ -84,119 +181,22 @@ namespace SharpMetal.Metal
         }
 
         private static readonly Selector sel_argumentIndex = "argumentIndex";
-        private static readonly Selector sel_setArgumentIndex = "setArgumentIndex:";
         private static readonly Selector sel_initWithArgumentIndex = "initWithArgumentIndex:";
+        private static readonly Selector sel_setArgumentIndex = "setArgumentIndex:";
         private static readonly Selector sel_release = "release";
     }
 
     [SupportedOSPlatform("macos")]
-    public struct MTLFunctionStitchingFunctionNode : IDisposable
+    public struct MTLFunctionStitchingNode : IDisposable
     {
         public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLFunctionStitchingFunctionNode obj) => obj.NativePtr;
-        public static implicit operator MTLFunctionStitchingNode(MTLFunctionStitchingFunctionNode obj) => new(obj.NativePtr);
-        public MTLFunctionStitchingFunctionNode(IntPtr ptr) => NativePtr = ptr;
-
-        public MTLFunctionStitchingFunctionNode()
-        {
-            var cls = new ObjectiveCClass("MTLFunctionStitchingFunctionNode");
-            NativePtr = cls.AllocInit();
-        }
+        public static implicit operator IntPtr(MTLFunctionStitchingNode obj) => obj.NativePtr;
+        public MTLFunctionStitchingNode(IntPtr ptr) => NativePtr = ptr;
 
         public void Dispose()
         {
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
-
-        public NSString Name
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_name));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setName, value);
-        }
-
-        public NSArray Arguments
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_arguments));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setArguments, value);
-        }
-
-        public NSArray ControlDependencies
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_controlDependencies));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setControlDependencies, value);
-        }
-
-        public MTLFunctionStitchingFunctionNode Init(NSString name, NSArray arguments, NSArray controlDependencies)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithNameargumentscontrolDependencies, name, arguments, controlDependencies));
-        }
-
-        private static readonly Selector sel_name = "name";
-        private static readonly Selector sel_setName = "setName:";
-        private static readonly Selector sel_arguments = "arguments";
-        private static readonly Selector sel_setArguments = "setArguments:";
-        private static readonly Selector sel_controlDependencies = "controlDependencies";
-        private static readonly Selector sel_setControlDependencies = "setControlDependencies:";
-        private static readonly Selector sel_initWithNameargumentscontrolDependencies = "initWithName:arguments:controlDependencies:";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLFunctionStitchingGraph : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLFunctionStitchingGraph obj) => obj.NativePtr;
-        public MTLFunctionStitchingGraph(IntPtr ptr) => NativePtr = ptr;
-
-        public MTLFunctionStitchingGraph()
-        {
-            var cls = new ObjectiveCClass("MTLFunctionStitchingGraph");
-            NativePtr = cls.AllocInit();
-        }
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public NSString FunctionName
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_functionName));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFunctionName, value);
-        }
-
-        public NSArray Nodes
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_nodes));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setNodes, value);
-        }
-
-        public MTLFunctionStitchingFunctionNode OutputNode
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_outputNode));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setOutputNode, value);
-        }
-
-        public NSArray Attributes
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_attributes));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setAttributes, value);
-        }
-
-        public MTLFunctionStitchingGraph Init(NSString functionName, NSArray nodes, MTLFunctionStitchingFunctionNode outputNode, NSArray attributes)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithFunctionNamenodesoutputNodeattributes, functionName, nodes, outputNode, attributes));
-        }
-
-        private static readonly Selector sel_functionName = "functionName";
-        private static readonly Selector sel_setFunctionName = "setFunctionName:";
-        private static readonly Selector sel_nodes = "nodes";
-        private static readonly Selector sel_setNodes = "setNodes:";
-        private static readonly Selector sel_outputNode = "outputNode";
-        private static readonly Selector sel_setOutputNode = "setOutputNode:";
-        private static readonly Selector sel_attributes = "attributes";
-        private static readonly Selector sel_setAttributes = "setAttributes:";
-        private static readonly Selector sel_initWithFunctionNamenodesoutputNodeattributes = "initWithFunctionName:nodes:outputNode:attributes:";
         private static readonly Selector sel_release = "release";
     }
 
@@ -231,8 +231,8 @@ namespace SharpMetal.Metal
         }
 
         private static readonly Selector sel_functionGraphs = "functionGraphs";
-        private static readonly Selector sel_setFunctionGraphs = "setFunctionGraphs:";
         private static readonly Selector sel_functions = "functions";
+        private static readonly Selector sel_setFunctionGraphs = "setFunctionGraphs:";
         private static readonly Selector sel_setFunctions = "setFunctions:";
         private static readonly Selector sel_release = "release";
     }

--- a/src/SharpMetal/Metal/MTLHeap.cs
+++ b/src/SharpMetal/Metal/MTLHeap.cs
@@ -13,83 +13,6 @@ namespace SharpMetal.Metal
     }
 
     [SupportedOSPlatform("macos")]
-    public struct MTLHeapDescriptor : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLHeapDescriptor obj) => obj.NativePtr;
-        public MTLHeapDescriptor(IntPtr ptr) => NativePtr = ptr;
-
-        public MTLHeapDescriptor()
-        {
-            var cls = new ObjectiveCClass("MTLHeapDescriptor");
-            NativePtr = cls.AllocInit();
-        }
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public ulong Size
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_size);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSize, value);
-        }
-
-        public MTLStorageMode StorageMode
-        {
-            get => (MTLStorageMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_storageMode);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStorageMode, (ulong)value);
-        }
-
-        public MTLCPUCacheMode CpuCacheMode
-        {
-            get => (MTLCPUCacheMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_cpuCacheMode);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setCpuCacheMode, (ulong)value);
-        }
-
-        public MTLSparsePageSize SparsePageSize
-        {
-            get => (MTLSparsePageSize)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_sparsePageSize);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSparsePageSize, (long)value);
-        }
-
-        public MTLHazardTrackingMode HazardTrackingMode
-        {
-            get => (MTLHazardTrackingMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_hazardTrackingMode);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setHazardTrackingMode, (ulong)value);
-        }
-
-        public MTLResourceOptions ResourceOptions
-        {
-            get => (MTLResourceOptions)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_resourceOptions);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setResourceOptions, (ulong)value);
-        }
-
-        public MTLHeapType Type
-        {
-            get => (MTLHeapType)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_type);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setType, (long)value);
-        }
-
-        private static readonly Selector sel_size = "size";
-        private static readonly Selector sel_setSize = "setSize:";
-        private static readonly Selector sel_storageMode = "storageMode";
-        private static readonly Selector sel_setStorageMode = "setStorageMode:";
-        private static readonly Selector sel_cpuCacheMode = "cpuCacheMode";
-        private static readonly Selector sel_setCpuCacheMode = "setCpuCacheMode:";
-        private static readonly Selector sel_sparsePageSize = "sparsePageSize";
-        private static readonly Selector sel_setSparsePageSize = "setSparsePageSize:";
-        private static readonly Selector sel_hazardTrackingMode = "hazardTrackingMode";
-        private static readonly Selector sel_setHazardTrackingMode = "setHazardTrackingMode:";
-        private static readonly Selector sel_resourceOptions = "resourceOptions";
-        private static readonly Selector sel_setResourceOptions = "setResourceOptions:";
-        private static readonly Selector sel_type = "type";
-        private static readonly Selector sel_setType = "setType:";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
     public struct MTLHeap : IDisposable
     {
         public IntPtr NativePtr;
@@ -101,58 +24,33 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
+        public MTLCPUCacheMode CpuCacheMode => (MTLCPUCacheMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_cpuCacheMode);
+
+        public ulong CurrentAllocatedSize => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_currentAllocatedSize);
+
+        public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
+
+        public MTLHazardTrackingMode HazardTrackingMode => (MTLHazardTrackingMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_hazardTrackingMode);
+
         public NSString Label
         {
             get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
         }
 
-        public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
-
-        public MTLStorageMode StorageMode => (MTLStorageMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_storageMode);
-
-        public MTLCPUCacheMode CpuCacheMode => (MTLCPUCacheMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_cpuCacheMode);
-
-        public MTLHazardTrackingMode HazardTrackingMode => (MTLHazardTrackingMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_hazardTrackingMode);
-
         public MTLResourceOptions ResourceOptions => (MTLResourceOptions)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_resourceOptions);
 
         public ulong Size => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_size);
 
-        public ulong UsedSize => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_usedSize);
-
-        public ulong CurrentAllocatedSize => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_currentAllocatedSize);
+        public MTLStorageMode StorageMode => (MTLStorageMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_storageMode);
 
         public MTLHeapType Type => (MTLHeapType)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_type);
+
+        public ulong UsedSize => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_usedSize);
 
         public ulong MaxAvailableSize(ulong alignment)
         {
             return ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxAvailableSizeWithAlignment, alignment);
-        }
-
-        public MTLBuffer NewBuffer(ulong length, MTLResourceOptions options)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newBufferWithLengthoptions, length, (ulong)options));
-        }
-
-        public MTLTexture NewTexture(MTLTextureDescriptor descriptor)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newTextureWithDescriptor, descriptor));
-        }
-
-        public MTLPurgeableState SetPurgeableState(MTLPurgeableState state)
-        {
-            return (MTLPurgeableState)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_setPurgeableState, (ulong)state);
-        }
-
-        public MTLBuffer NewBuffer(ulong length, MTLResourceOptions options, ulong offset)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newBufferWithLengthoptionsoffset, length, (ulong)options, offset));
-        }
-
-        public MTLTexture NewTexture(MTLTextureDescriptor descriptor, ulong offset)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newTextureWithDescriptoroffset, descriptor, offset));
         }
 
         public MTLAccelerationStructure NewAccelerationStructure(ulong size)
@@ -175,27 +73,129 @@ namespace SharpMetal.Metal
             return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newAccelerationStructureWithDescriptoroffset, descriptor, offset));
         }
 
-        private static readonly Selector sel_label = "label";
-        private static readonly Selector sel_setLabel = "setLabel:";
+        public MTLBuffer NewBuffer(ulong length, MTLResourceOptions options)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newBufferWithLengthoptions, length, (ulong)options));
+        }
+
+        public MTLBuffer NewBuffer(ulong length, MTLResourceOptions options, ulong offset)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newBufferWithLengthoptionsoffset, length, (ulong)options, offset));
+        }
+
+        public MTLTexture NewTexture(MTLTextureDescriptor descriptor)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newTextureWithDescriptor, descriptor));
+        }
+
+        public MTLTexture NewTexture(MTLTextureDescriptor descriptor, ulong offset)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newTextureWithDescriptoroffset, descriptor, offset));
+        }
+
+        public MTLPurgeableState SetPurgeableState(MTLPurgeableState state)
+        {
+            return (MTLPurgeableState)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_setPurgeableState, (ulong)state);
+        }
+
+        private static readonly Selector sel_cpuCacheMode = "cpuCacheMode";
+        private static readonly Selector sel_currentAllocatedSize = "currentAllocatedSize";
         private static readonly Selector sel_device = "device";
+        private static readonly Selector sel_hazardTrackingMode = "hazardTrackingMode";
+        private static readonly Selector sel_label = "label";
+        private static readonly Selector sel_maxAvailableSizeWithAlignment = "maxAvailableSizeWithAlignment:";
+        private static readonly Selector sel_newAccelerationStructureWithDescriptor = "newAccelerationStructureWithDescriptor:";
+        private static readonly Selector sel_newAccelerationStructureWithDescriptoroffset = "newAccelerationStructureWithDescriptor:offset:";
+        private static readonly Selector sel_newAccelerationStructureWithSize = "newAccelerationStructureWithSize:";
+        private static readonly Selector sel_newAccelerationStructureWithSizeoffset = "newAccelerationStructureWithSize:offset:";
+        private static readonly Selector sel_newBufferWithLengthoptions = "newBufferWithLength:options:";
+        private static readonly Selector sel_newBufferWithLengthoptionsoffset = "newBufferWithLength:options:offset:";
+        private static readonly Selector sel_newTextureWithDescriptor = "newTextureWithDescriptor:";
+        private static readonly Selector sel_newTextureWithDescriptoroffset = "newTextureWithDescriptor:offset:";
+        private static readonly Selector sel_resourceOptions = "resourceOptions";
+        private static readonly Selector sel_setLabel = "setLabel:";
+        private static readonly Selector sel_setPurgeableState = "setPurgeableState:";
+        private static readonly Selector sel_size = "size";
         private static readonly Selector sel_storageMode = "storageMode";
+        private static readonly Selector sel_type = "type";
+        private static readonly Selector sel_usedSize = "usedSize";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
+    public struct MTLHeapDescriptor : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLHeapDescriptor obj) => obj.NativePtr;
+        public MTLHeapDescriptor(IntPtr ptr) => NativePtr = ptr;
+
+        public MTLHeapDescriptor()
+        {
+            var cls = new ObjectiveCClass("MTLHeapDescriptor");
+            NativePtr = cls.AllocInit();
+        }
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public MTLCPUCacheMode CpuCacheMode
+        {
+            get => (MTLCPUCacheMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_cpuCacheMode);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setCpuCacheMode, (ulong)value);
+        }
+
+        public MTLHazardTrackingMode HazardTrackingMode
+        {
+            get => (MTLHazardTrackingMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_hazardTrackingMode);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setHazardTrackingMode, (ulong)value);
+        }
+
+        public MTLResourceOptions ResourceOptions
+        {
+            get => (MTLResourceOptions)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_resourceOptions);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setResourceOptions, (ulong)value);
+        }
+
+        public ulong Size
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_size);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSize, value);
+        }
+
+        public MTLSparsePageSize SparsePageSize
+        {
+            get => (MTLSparsePageSize)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_sparsePageSize);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSparsePageSize, (long)value);
+        }
+
+        public MTLStorageMode StorageMode
+        {
+            get => (MTLStorageMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_storageMode);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStorageMode, (ulong)value);
+        }
+
+        public MTLHeapType Type
+        {
+            get => (MTLHeapType)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_type);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setType, (long)value);
+        }
+
         private static readonly Selector sel_cpuCacheMode = "cpuCacheMode";
         private static readonly Selector sel_hazardTrackingMode = "hazardTrackingMode";
         private static readonly Selector sel_resourceOptions = "resourceOptions";
+        private static readonly Selector sel_setCpuCacheMode = "setCpuCacheMode:";
+        private static readonly Selector sel_setHazardTrackingMode = "setHazardTrackingMode:";
+        private static readonly Selector sel_setResourceOptions = "setResourceOptions:";
+        private static readonly Selector sel_setSize = "setSize:";
+        private static readonly Selector sel_setSparsePageSize = "setSparsePageSize:";
+        private static readonly Selector sel_setStorageMode = "setStorageMode:";
+        private static readonly Selector sel_setType = "setType:";
         private static readonly Selector sel_size = "size";
-        private static readonly Selector sel_usedSize = "usedSize";
-        private static readonly Selector sel_currentAllocatedSize = "currentAllocatedSize";
-        private static readonly Selector sel_maxAvailableSizeWithAlignment = "maxAvailableSizeWithAlignment:";
-        private static readonly Selector sel_newBufferWithLengthoptions = "newBufferWithLength:options:";
-        private static readonly Selector sel_newTextureWithDescriptor = "newTextureWithDescriptor:";
-        private static readonly Selector sel_setPurgeableState = "setPurgeableState:";
+        private static readonly Selector sel_sparsePageSize = "sparsePageSize";
+        private static readonly Selector sel_storageMode = "storageMode";
         private static readonly Selector sel_type = "type";
-        private static readonly Selector sel_newBufferWithLengthoptionsoffset = "newBufferWithLength:options:offset:";
-        private static readonly Selector sel_newTextureWithDescriptoroffset = "newTextureWithDescriptor:offset:";
-        private static readonly Selector sel_newAccelerationStructureWithSize = "newAccelerationStructureWithSize:";
-        private static readonly Selector sel_newAccelerationStructureWithDescriptor = "newAccelerationStructureWithDescriptor:";
-        private static readonly Selector sel_newAccelerationStructureWithSizeoffset = "newAccelerationStructureWithSize:offset:";
-        private static readonly Selector sel_newAccelerationStructureWithDescriptoroffset = "newAccelerationStructureWithDescriptor:offset:";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLIOCommandBuffer.cs
+++ b/src/SharpMetal/Metal/MTLIOCommandBuffer.cs
@@ -25,6 +25,8 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
+        public NSError Error => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_error));
+
         public NSString Label
         {
             get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
@@ -33,26 +35,9 @@ namespace SharpMetal.Metal
 
         public MTLIOStatus Status => (MTLIOStatus)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_status);
 
-        public NSError Error => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_error));
-
-        public void LoadBytes(IntPtr pointer, ulong size, IntPtr sourceHandle, ulong sourceHandleOffset)
+        public void AddBarrier()
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_loadBytessizesourceHandlesourceHandleOffset, pointer, size, sourceHandle, sourceHandleOffset);
-        }
-
-        public void LoadBuffer(MTLBuffer buffer, ulong offset, ulong size, IntPtr sourceHandle, ulong sourceHandleOffset)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_loadBufferoffsetsizesourceHandlesourceHandleOffset, buffer, offset, size, sourceHandle, sourceHandleOffset);
-        }
-
-        public void LoadTexture(MTLTexture texture, ulong slice, ulong level, MTLSize size, ulong sourceBytesPerRow, ulong sourceBytesPerImage, MTLOrigin destinationOrigin, IntPtr sourceHandle, ulong sourceHandleOffset)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_loadTextureslicelevelsizesourceBytesPerRowsourceBytesPerImagedestinationOriginsourceHandlesourceHandleOffset, texture, slice, level, size, sourceBytesPerRow, sourceBytesPerImage, destinationOrigin, sourceHandle, sourceHandleOffset);
-        }
-
-        public void CopyStatusToBuffer(MTLBuffer buffer, ulong offset)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_copyStatusToBufferoffset, buffer, offset);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_addBarrier);
         }
 
         public void Commit()
@@ -60,29 +45,9 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_commit);
         }
 
-        public void WaitUntilCompleted()
+        public void CopyStatusToBuffer(MTLBuffer buffer, ulong offset)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_waitUntilCompleted);
-        }
-
-        public void TryCancel()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_tryCancel);
-        }
-
-        public void AddBarrier()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_addBarrier);
-        }
-
-        public void PushDebugGroup(NSString nsString)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_pushDebugGroup, nsString);
-        }
-
-        public void PopDebugGroup()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_popDebugGroup);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_copyStatusToBufferoffset, buffer, offset);
         }
 
         public void Enqueue()
@@ -90,9 +55,29 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_enqueue);
         }
 
-        public void Wait(MTLSharedEvent mtlEvent, ulong value)
+        public void LoadBuffer(MTLBuffer buffer, ulong offset, ulong size, IntPtr sourceHandle, ulong sourceHandleOffset)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_waitForEventvalue, mtlEvent, value);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_loadBufferoffsetsizesourceHandlesourceHandleOffset, buffer, offset, size, sourceHandle, sourceHandleOffset);
+        }
+
+        public void LoadBytes(IntPtr pointer, ulong size, IntPtr sourceHandle, ulong sourceHandleOffset)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_loadBytessizesourceHandlesourceHandleOffset, pointer, size, sourceHandle, sourceHandleOffset);
+        }
+
+        public void LoadTexture(MTLTexture texture, ulong slice, ulong level, MTLSize size, ulong sourceBytesPerRow, ulong sourceBytesPerImage, MTLOrigin destinationOrigin, IntPtr sourceHandle, ulong sourceHandleOffset)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_loadTextureslicelevelsizesourceBytesPerRowsourceBytesPerImagedestinationOriginsourceHandlesourceHandleOffset, texture, slice, level, size, sourceBytesPerRow, sourceBytesPerImage, destinationOrigin, sourceHandle, sourceHandleOffset);
+        }
+
+        public void PopDebugGroup()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_popDebugGroup);
+        }
+
+        public void PushDebugGroup(NSString nsString)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_pushDebugGroup, nsString);
         }
 
         public void SignalEvent(MTLSharedEvent mtlEvent, ulong value)
@@ -100,23 +85,38 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_signalEventvalue, mtlEvent, value);
         }
 
-        private static readonly Selector sel_loadBytessizesourceHandlesourceHandleOffset = "loadBytes:size:sourceHandle:sourceHandleOffset:";
-        private static readonly Selector sel_loadBufferoffsetsizesourceHandlesourceHandleOffset = "loadBuffer:offset:size:sourceHandle:sourceHandleOffset:";
-        private static readonly Selector sel_loadTextureslicelevelsizesourceBytesPerRowsourceBytesPerImagedestinationOriginsourceHandlesourceHandleOffset = "loadTexture:slice:level:size:sourceBytesPerRow:sourceBytesPerImage:destinationOrigin:sourceHandle:sourceHandleOffset:";
-        private static readonly Selector sel_copyStatusToBufferoffset = "copyStatusToBuffer:offset:";
-        private static readonly Selector sel_commit = "commit";
-        private static readonly Selector sel_waitUntilCompleted = "waitUntilCompleted";
-        private static readonly Selector sel_tryCancel = "tryCancel";
+        public void TryCancel()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_tryCancel);
+        }
+
+        public void Wait(MTLSharedEvent mtlEvent, ulong value)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_waitForEventvalue, mtlEvent, value);
+        }
+
+        public void WaitUntilCompleted()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_waitUntilCompleted);
+        }
+
         private static readonly Selector sel_addBarrier = "addBarrier";
-        private static readonly Selector sel_pushDebugGroup = "pushDebugGroup:";
-        private static readonly Selector sel_popDebugGroup = "popDebugGroup";
+        private static readonly Selector sel_commit = "commit";
+        private static readonly Selector sel_copyStatusToBufferoffset = "copyStatusToBuffer:offset:";
         private static readonly Selector sel_enqueue = "enqueue";
-        private static readonly Selector sel_waitForEventvalue = "waitForEvent:value:";
-        private static readonly Selector sel_signalEventvalue = "signalEvent:value:";
-        private static readonly Selector sel_label = "label";
-        private static readonly Selector sel_setLabel = "setLabel:";
-        private static readonly Selector sel_status = "status";
         private static readonly Selector sel_error = "error";
+        private static readonly Selector sel_label = "label";
+        private static readonly Selector sel_loadBufferoffsetsizesourceHandlesourceHandleOffset = "loadBuffer:offset:size:sourceHandle:sourceHandleOffset:";
+        private static readonly Selector sel_loadBytessizesourceHandlesourceHandleOffset = "loadBytes:size:sourceHandle:sourceHandleOffset:";
+        private static readonly Selector sel_loadTextureslicelevelsizesourceBytesPerRowsourceBytesPerImagedestinationOriginsourceHandlesourceHandleOffset = "loadTexture:slice:level:size:sourceBytesPerRow:sourceBytesPerImage:destinationOrigin:sourceHandle:sourceHandleOffset:";
+        private static readonly Selector sel_popDebugGroup = "popDebugGroup";
+        private static readonly Selector sel_pushDebugGroup = "pushDebugGroup:";
+        private static readonly Selector sel_setLabel = "setLabel:";
+        private static readonly Selector sel_signalEventvalue = "signalEvent:value:";
+        private static readonly Selector sel_status = "status";
+        private static readonly Selector sel_tryCancel = "tryCancel";
+        private static readonly Selector sel_waitForEventvalue = "waitForEvent:value:";
+        private static readonly Selector sel_waitUntilCompleted = "waitUntilCompleted";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLIOCommandQueue.cs
+++ b/src/SharpMetal/Metal/MTLIOCommandQueue.cs
@@ -5,14 +5,6 @@ using SharpMetal.Foundation;
 namespace SharpMetal.Metal
 {
     [SupportedOSPlatform("macos")]
-    public enum MTLIOPriority : long
-    {
-        High = 0,
-        Normal = 1,
-        Low = 2,
-    }
-
-    [SupportedOSPlatform("macos")]
     public enum MTLIOCommandQueueType : long
     {
         Concurrent = 0,
@@ -24,6 +16,14 @@ namespace SharpMetal.Metal
     {
         URLInvalid = 1,
         Internal = 2,
+    }
+
+    [SupportedOSPlatform("macos")]
+    public enum MTLIOPriority : long
+    {
+        High = 0,
+        Normal = 1,
+        Low = 2,
     }
 
     [SupportedOSPlatform("macos")]
@@ -53,9 +53,93 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_enqueueBarrier);
         }
 
-        private static readonly Selector sel_enqueueBarrier = "enqueueBarrier";
         private static readonly Selector sel_commandBuffer = "commandBuffer";
         private static readonly Selector sel_commandBufferWithUnretainedReferences = "commandBufferWithUnretainedReferences";
+        private static readonly Selector sel_enqueueBarrier = "enqueueBarrier";
+        private static readonly Selector sel_label = "label";
+        private static readonly Selector sel_setLabel = "setLabel:";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
+    public struct MTLIOCommandQueueDescriptor : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLIOCommandQueueDescriptor obj) => obj.NativePtr;
+        public MTLIOCommandQueueDescriptor(IntPtr ptr) => NativePtr = ptr;
+
+        public MTLIOCommandQueueDescriptor()
+        {
+            var cls = new ObjectiveCClass("MTLIOCommandQueueDescriptor");
+            NativePtr = cls.AllocInit();
+        }
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public ulong MaxCommandBufferCount
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxCommandBufferCount);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxCommandBufferCount, value);
+        }
+
+        public ulong MaxCommandsInFlight
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxCommandsInFlight);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxCommandsInFlight, value);
+        }
+
+        public MTLIOPriority Priority
+        {
+            get => (MTLIOPriority)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_priority);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPriority, (long)value);
+        }
+
+        public MTLIOScratchBufferAllocator ScratchBufferAllocator
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_scratchBufferAllocator));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setScratchBufferAllocator, value);
+        }
+
+        public MTLIOCommandQueueType Type
+        {
+            get => (MTLIOCommandQueueType)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_type);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setType, (long)value);
+        }
+
+        private static readonly Selector sel_maxCommandBufferCount = "maxCommandBufferCount";
+        private static readonly Selector sel_maxCommandsInFlight = "maxCommandsInFlight";
+        private static readonly Selector sel_priority = "priority";
+        private static readonly Selector sel_scratchBufferAllocator = "scratchBufferAllocator";
+        private static readonly Selector sel_setMaxCommandBufferCount = "setMaxCommandBufferCount:";
+        private static readonly Selector sel_setMaxCommandsInFlight = "setMaxCommandsInFlight:";
+        private static readonly Selector sel_setPriority = "setPriority:";
+        private static readonly Selector sel_setScratchBufferAllocator = "setScratchBufferAllocator:";
+        private static readonly Selector sel_setType = "setType:";
+        private static readonly Selector sel_type = "type";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
+    public struct MTLIOFileHandle : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLIOFileHandle obj) => obj.NativePtr;
+        public MTLIOFileHandle(IntPtr ptr) => NativePtr = ptr;
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public NSString Label
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
+        }
+
         private static readonly Selector sel_label = "label";
         private static readonly Selector sel_setLabel = "setLabel:";
         private static readonly Selector sel_release = "release";
@@ -97,90 +181,6 @@ namespace SharpMetal.Metal
         }
 
         private static readonly Selector sel_newScratchBufferWithMinimumSize = "newScratchBufferWithMinimumSize:";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLIOCommandQueueDescriptor : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLIOCommandQueueDescriptor obj) => obj.NativePtr;
-        public MTLIOCommandQueueDescriptor(IntPtr ptr) => NativePtr = ptr;
-
-        public MTLIOCommandQueueDescriptor()
-        {
-            var cls = new ObjectiveCClass("MTLIOCommandQueueDescriptor");
-            NativePtr = cls.AllocInit();
-        }
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public ulong MaxCommandBufferCount
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxCommandBufferCount);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxCommandBufferCount, value);
-        }
-
-        public MTLIOPriority Priority
-        {
-            get => (MTLIOPriority)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_priority);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPriority, (long)value);
-        }
-
-        public MTLIOCommandQueueType Type
-        {
-            get => (MTLIOCommandQueueType)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_type);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setType, (long)value);
-        }
-
-        public ulong MaxCommandsInFlight
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxCommandsInFlight);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxCommandsInFlight, value);
-        }
-
-        public MTLIOScratchBufferAllocator ScratchBufferAllocator
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_scratchBufferAllocator));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setScratchBufferAllocator, value);
-        }
-
-        private static readonly Selector sel_maxCommandBufferCount = "maxCommandBufferCount";
-        private static readonly Selector sel_setMaxCommandBufferCount = "setMaxCommandBufferCount:";
-        private static readonly Selector sel_priority = "priority";
-        private static readonly Selector sel_setPriority = "setPriority:";
-        private static readonly Selector sel_type = "type";
-        private static readonly Selector sel_setType = "setType:";
-        private static readonly Selector sel_maxCommandsInFlight = "maxCommandsInFlight";
-        private static readonly Selector sel_setMaxCommandsInFlight = "setMaxCommandsInFlight:";
-        private static readonly Selector sel_scratchBufferAllocator = "scratchBufferAllocator";
-        private static readonly Selector sel_setScratchBufferAllocator = "setScratchBufferAllocator:";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLIOFileHandle : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLIOFileHandle obj) => obj.NativePtr;
-        public MTLIOFileHandle(IntPtr ptr) => NativePtr = ptr;
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public NSString Label
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
-        }
-
-        private static readonly Selector sel_label = "label";
-        private static readonly Selector sel_setLabel = "setLabel:";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLIndirectCommandBuffer.cs
+++ b/src/SharpMetal/Metal/MTLIndirectCommandBuffer.cs
@@ -28,6 +28,93 @@ namespace SharpMetal.Metal
     }
 
     [SupportedOSPlatform("macos")]
+    public struct MTLIndirectCommandBuffer : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLIndirectCommandBuffer obj) => obj.NativePtr;
+        public static implicit operator MTLResource(MTLIndirectCommandBuffer obj) => new(obj.NativePtr);
+        public MTLIndirectCommandBuffer(IntPtr ptr) => NativePtr = ptr;
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public ulong AllocatedSize => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_allocatedSize);
+
+        public MTLCPUCacheMode CpuCacheMode => (MTLCPUCacheMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_cpuCacheMode);
+
+        public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
+
+        public MTLResourceID GpuResourceID => ObjectiveCRuntime.MTLResourceID_objc_msgSend(NativePtr, sel_gpuResourceID);
+
+        public MTLHazardTrackingMode HazardTrackingMode => (MTLHazardTrackingMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_hazardTrackingMode);
+
+        public MTLHeap Heap => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_heap));
+
+        public ulong HeapOffset => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_heapOffset);
+
+        public bool IsAliasable => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isAliasable);
+
+        public NSString Label
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
+        }
+
+        public MTLResourceOptions ResourceOptions => (MTLResourceOptions)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_resourceOptions);
+
+        public ulong Size => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_size);
+
+        public MTLStorageMode StorageMode => (MTLStorageMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_storageMode);
+
+        public MTLIndirectComputeCommand IndirectComputeCommand(ulong commandIndex)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_indirectComputeCommandAtIndex, commandIndex));
+        }
+
+        public MTLIndirectRenderCommand IndirectRenderCommand(ulong commandIndex)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_indirectRenderCommandAtIndex, commandIndex));
+        }
+
+        public void MakeAliasable()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_makeAliasable);
+        }
+
+        public void Reset(NSRange range)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_resetWithRange, range);
+        }
+
+        public MTLPurgeableState SetPurgeableState(MTLPurgeableState state)
+        {
+            return (MTLPurgeableState)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_setPurgeableState, (ulong)state);
+        }
+
+        private static readonly Selector sel_allocatedSize = "allocatedSize";
+        private static readonly Selector sel_cpuCacheMode = "cpuCacheMode";
+        private static readonly Selector sel_device = "device";
+        private static readonly Selector sel_gpuResourceID = "gpuResourceID";
+        private static readonly Selector sel_hazardTrackingMode = "hazardTrackingMode";
+        private static readonly Selector sel_heap = "heap";
+        private static readonly Selector sel_heapOffset = "heapOffset";
+        private static readonly Selector sel_indirectComputeCommandAtIndex = "indirectComputeCommandAtIndex:";
+        private static readonly Selector sel_indirectRenderCommandAtIndex = "indirectRenderCommandAtIndex:";
+        private static readonly Selector sel_isAliasable = "isAliasable";
+        private static readonly Selector sel_label = "label";
+        private static readonly Selector sel_makeAliasable = "makeAliasable";
+        private static readonly Selector sel_resetWithRange = "resetWithRange:";
+        private static readonly Selector sel_resourceOptions = "resourceOptions";
+        private static readonly Selector sel_setLabel = "setLabel:";
+        private static readonly Selector sel_setPurgeableState = "setPurgeableState:";
+        private static readonly Selector sel_size = "size";
+        private static readonly Selector sel_storageMode = "storageMode";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
     public struct MTLIndirectCommandBufferDescriptor : IDisposable
     {
         public IntPtr NativePtr;
@@ -51,22 +138,16 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setCommandTypes, (ulong)value);
         }
 
-        public bool InheritPipelineState
-        {
-            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_inheritPipelineState);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setInheritPipelineState, value);
-        }
-
         public bool InheritBuffers
         {
             get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_inheritBuffers);
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setInheritBuffers, value);
         }
 
-        public ulong MaxVertexBufferBindCount
+        public bool InheritPipelineState
         {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxVertexBufferBindCount);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxVertexBufferBindCount, value);
+            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_inheritPipelineState);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setInheritPipelineState, value);
         }
 
         public ulong MaxFragmentBufferBindCount
@@ -87,16 +168,16 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxKernelThreadgroupMemoryBindCount, value);
         }
 
-        public ulong MaxObjectBufferBindCount
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxObjectBufferBindCount);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxObjectBufferBindCount, value);
-        }
-
         public ulong MaxMeshBufferBindCount
         {
             get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxMeshBufferBindCount);
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxMeshBufferBindCount, value);
+        }
+
+        public ulong MaxObjectBufferBindCount
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxObjectBufferBindCount);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxObjectBufferBindCount, value);
         }
 
         public ulong MaxObjectThreadgroupMemoryBindCount
@@ -105,10 +186,10 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxObjectThreadgroupMemoryBindCount, value);
         }
 
-        public bool SupportRayTracing
+        public ulong MaxVertexBufferBindCount
         {
-            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportRayTracing);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSupportRayTracing, value);
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxVertexBufferBindCount);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxVertexBufferBindCount, value);
         }
 
         public bool SupportDynamicAttributeStride
@@ -117,117 +198,36 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSupportDynamicAttributeStride, value);
         }
 
+        public bool SupportRayTracing
+        {
+            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportRayTracing);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSupportRayTracing, value);
+        }
+
         private static readonly Selector sel_commandTypes = "commandTypes";
-        private static readonly Selector sel_setCommandTypes = "setCommandTypes:";
-        private static readonly Selector sel_inheritPipelineState = "inheritPipelineState";
-        private static readonly Selector sel_setInheritPipelineState = "setInheritPipelineState:";
         private static readonly Selector sel_inheritBuffers = "inheritBuffers";
-        private static readonly Selector sel_setInheritBuffers = "setInheritBuffers:";
-        private static readonly Selector sel_maxVertexBufferBindCount = "maxVertexBufferBindCount";
-        private static readonly Selector sel_setMaxVertexBufferBindCount = "setMaxVertexBufferBindCount:";
+        private static readonly Selector sel_inheritPipelineState = "inheritPipelineState";
         private static readonly Selector sel_maxFragmentBufferBindCount = "maxFragmentBufferBindCount";
-        private static readonly Selector sel_setMaxFragmentBufferBindCount = "setMaxFragmentBufferBindCount:";
         private static readonly Selector sel_maxKernelBufferBindCount = "maxKernelBufferBindCount";
-        private static readonly Selector sel_setMaxKernelBufferBindCount = "setMaxKernelBufferBindCount:";
         private static readonly Selector sel_maxKernelThreadgroupMemoryBindCount = "maxKernelThreadgroupMemoryBindCount";
-        private static readonly Selector sel_setMaxKernelThreadgroupMemoryBindCount = "setMaxKernelThreadgroupMemoryBindCount:";
-        private static readonly Selector sel_maxObjectBufferBindCount = "maxObjectBufferBindCount";
-        private static readonly Selector sel_setMaxObjectBufferBindCount = "setMaxObjectBufferBindCount:";
         private static readonly Selector sel_maxMeshBufferBindCount = "maxMeshBufferBindCount";
-        private static readonly Selector sel_setMaxMeshBufferBindCount = "setMaxMeshBufferBindCount:";
+        private static readonly Selector sel_maxObjectBufferBindCount = "maxObjectBufferBindCount";
         private static readonly Selector sel_maxObjectThreadgroupMemoryBindCount = "maxObjectThreadgroupMemoryBindCount";
+        private static readonly Selector sel_maxVertexBufferBindCount = "maxVertexBufferBindCount";
+        private static readonly Selector sel_setCommandTypes = "setCommandTypes:";
+        private static readonly Selector sel_setInheritBuffers = "setInheritBuffers:";
+        private static readonly Selector sel_setInheritPipelineState = "setInheritPipelineState:";
+        private static readonly Selector sel_setMaxFragmentBufferBindCount = "setMaxFragmentBufferBindCount:";
+        private static readonly Selector sel_setMaxKernelBufferBindCount = "setMaxKernelBufferBindCount:";
+        private static readonly Selector sel_setMaxKernelThreadgroupMemoryBindCount = "setMaxKernelThreadgroupMemoryBindCount:";
+        private static readonly Selector sel_setMaxMeshBufferBindCount = "setMaxMeshBufferBindCount:";
+        private static readonly Selector sel_setMaxObjectBufferBindCount = "setMaxObjectBufferBindCount:";
         private static readonly Selector sel_setMaxObjectThreadgroupMemoryBindCount = "setMaxObjectThreadgroupMemoryBindCount:";
-        private static readonly Selector sel_supportRayTracing = "supportRayTracing";
+        private static readonly Selector sel_setMaxVertexBufferBindCount = "setMaxVertexBufferBindCount:";
+        private static readonly Selector sel_setSupportDynamicAttributeStride = "setSupportDynamicAttributeStride:";
         private static readonly Selector sel_setSupportRayTracing = "setSupportRayTracing:";
         private static readonly Selector sel_supportDynamicAttributeStride = "supportDynamicAttributeStride";
-        private static readonly Selector sel_setSupportDynamicAttributeStride = "setSupportDynamicAttributeStride:";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLIndirectCommandBuffer : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLIndirectCommandBuffer obj) => obj.NativePtr;
-        public static implicit operator MTLResource(MTLIndirectCommandBuffer obj) => new(obj.NativePtr);
-        public MTLIndirectCommandBuffer(IntPtr ptr) => NativePtr = ptr;
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public ulong Size => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_size);
-
-        public MTLResourceID GpuResourceID => ObjectiveCRuntime.MTLResourceID_objc_msgSend(NativePtr, sel_gpuResourceID);
-
-        public NSString Label
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
-        }
-
-        public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
-
-        public MTLCPUCacheMode CpuCacheMode => (MTLCPUCacheMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_cpuCacheMode);
-
-        public MTLStorageMode StorageMode => (MTLStorageMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_storageMode);
-
-        public MTLHazardTrackingMode HazardTrackingMode => (MTLHazardTrackingMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_hazardTrackingMode);
-
-        public MTLResourceOptions ResourceOptions => (MTLResourceOptions)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_resourceOptions);
-
-        public MTLHeap Heap => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_heap));
-
-        public ulong HeapOffset => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_heapOffset);
-
-        public ulong AllocatedSize => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_allocatedSize);
-
-        public bool IsAliasable => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isAliasable);
-
-        public void Reset(NSRange range)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_resetWithRange, range);
-        }
-
-        public MTLIndirectRenderCommand IndirectRenderCommand(ulong commandIndex)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_indirectRenderCommandAtIndex, commandIndex));
-        }
-
-        public MTLIndirectComputeCommand IndirectComputeCommand(ulong commandIndex)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_indirectComputeCommandAtIndex, commandIndex));
-        }
-
-        public MTLPurgeableState SetPurgeableState(MTLPurgeableState state)
-        {
-            return (MTLPurgeableState)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_setPurgeableState, (ulong)state);
-        }
-
-        public void MakeAliasable()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_makeAliasable);
-        }
-
-        private static readonly Selector sel_size = "size";
-        private static readonly Selector sel_gpuResourceID = "gpuResourceID";
-        private static readonly Selector sel_resetWithRange = "resetWithRange:";
-        private static readonly Selector sel_indirectRenderCommandAtIndex = "indirectRenderCommandAtIndex:";
-        private static readonly Selector sel_indirectComputeCommandAtIndex = "indirectComputeCommandAtIndex:";
-        private static readonly Selector sel_label = "label";
-        private static readonly Selector sel_setLabel = "setLabel:";
-        private static readonly Selector sel_device = "device";
-        private static readonly Selector sel_cpuCacheMode = "cpuCacheMode";
-        private static readonly Selector sel_storageMode = "storageMode";
-        private static readonly Selector sel_hazardTrackingMode = "hazardTrackingMode";
-        private static readonly Selector sel_resourceOptions = "resourceOptions";
-        private static readonly Selector sel_setPurgeableState = "setPurgeableState:";
-        private static readonly Selector sel_heap = "heap";
-        private static readonly Selector sel_heapOffset = "heapOffset";
-        private static readonly Selector sel_allocatedSize = "allocatedSize";
-        private static readonly Selector sel_makeAliasable = "makeAliasable";
-        private static readonly Selector sel_isAliasable = "isAliasable";
+        private static readonly Selector sel_supportRayTracing = "supportRayTracing";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLIndirectCommandEncoder.cs
+++ b/src/SharpMetal/Metal/MTLIndirectCommandEncoder.cs
@@ -5,117 +5,6 @@ using SharpMetal.Foundation;
 namespace SharpMetal.Metal
 {
     [SupportedOSPlatform("macos")]
-    public struct MTLIndirectRenderCommand : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLIndirectRenderCommand obj) => obj.NativePtr;
-        public MTLIndirectRenderCommand(IntPtr ptr) => NativePtr = ptr;
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public void SetRenderPipelineState(MTLRenderPipelineState pipelineState)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRenderPipelineState, pipelineState);
-        }
-
-        public void SetVertexBuffer(MTLBuffer buffer, ulong offset, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexBufferoffsetatIndex, buffer, offset, index);
-        }
-
-        public void SetFragmentBuffer(MTLBuffer buffer, ulong offset, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFragmentBufferoffsetatIndex, buffer, offset, index);
-        }
-
-        public void SetVertexBuffer(MTLBuffer buffer, ulong offset, ulong stride, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexBufferoffsetattributeStrideatIndex, buffer, offset, stride, index);
-        }
-
-        public void DrawPatches(ulong numberOfPatchControlPoints, ulong patchStart, ulong patchCount, MTLBuffer patchIndexBuffer, ulong patchIndexBufferOffset, ulong instanceCount, ulong baseInstance, MTLBuffer buffer, ulong offset, ulong instanceStride)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawPatchespatchStartpatchCountpatchIndexBufferpatchIndexBufferOffsetinstanceCountbaseInstancetessellationFactorBuffertessellationFactorBufferOffsettessellationFactorBufferInstanceStride, numberOfPatchControlPoints, patchStart, patchCount, patchIndexBuffer, patchIndexBufferOffset, instanceCount, baseInstance, buffer, offset, instanceStride);
-        }
-
-        public void DrawIndexedPatches(ulong numberOfPatchControlPoints, ulong patchStart, ulong patchCount, MTLBuffer patchIndexBuffer, ulong patchIndexBufferOffset, MTLBuffer controlPointIndexBuffer, ulong controlPointIndexBufferOffset, ulong instanceCount, ulong baseInstance, MTLBuffer buffer, ulong offset, ulong instanceStride)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawIndexedPatchespatchStartpatchCountpatchIndexBufferpatchIndexBufferOffsetcontrolPointIndexBuffercontrolPointIndexBufferOffsetinstanceCountbaseInstancetessellationFactorBuffertessellationFactorBufferOffsettessellationFactorBufferInstanceStride, numberOfPatchControlPoints, patchStart, patchCount, patchIndexBuffer, patchIndexBufferOffset, controlPointIndexBuffer, controlPointIndexBufferOffset, instanceCount, baseInstance, buffer, offset, instanceStride);
-        }
-
-        public void DrawPrimitives(MTLPrimitiveType primitiveType, ulong vertexStart, ulong vertexCount, ulong instanceCount, ulong baseInstance)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawPrimitivesvertexStartvertexCountinstanceCountbaseInstance, (ulong)primitiveType, vertexStart, vertexCount, instanceCount, baseInstance);
-        }
-
-        public void DrawIndexedPrimitives(MTLPrimitiveType primitiveType, ulong indexCount, MTLIndexType indexType, MTLBuffer indexBuffer, ulong indexBufferOffset, ulong instanceCount, long baseVertex, ulong baseInstance)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawIndexedPrimitivesindexCountindexTypeindexBufferindexBufferOffsetinstanceCountbaseVertexbaseInstance, (ulong)primitiveType, indexCount, (ulong)indexType, indexBuffer, indexBufferOffset, instanceCount, baseVertex, baseInstance);
-        }
-
-        public void SetObjectThreadgroupMemoryLength(ulong length, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setObjectThreadgroupMemoryLengthatIndex, length, index);
-        }
-
-        public void SetObjectBuffer(MTLBuffer buffer, ulong offset, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setObjectBufferoffsetatIndex, buffer, offset, index);
-        }
-
-        public void SetMeshBuffer(MTLBuffer buffer, ulong offset, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMeshBufferoffsetatIndex, buffer, offset, index);
-        }
-
-        public void DrawMeshThreadgroups(MTLSize threadgroupsPerGrid, MTLSize threadsPerObjectThreadgroup, MTLSize threadsPerMeshThreadgroup)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawMeshThreadgroupsthreadsPerObjectThreadgroupthreadsPerMeshThreadgroup, threadgroupsPerGrid, threadsPerObjectThreadgroup, threadsPerMeshThreadgroup);
-        }
-
-        public void DrawMeshThreads(MTLSize threadsPerGrid, MTLSize threadsPerObjectThreadgroup, MTLSize threadsPerMeshThreadgroup)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawMeshThreadsthreadsPerObjectThreadgroupthreadsPerMeshThreadgroup, threadsPerGrid, threadsPerObjectThreadgroup, threadsPerMeshThreadgroup);
-        }
-
-        public void SetBarrier()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBarrier);
-        }
-
-        public void ClearBarrier()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_clearBarrier);
-        }
-
-        public void Reset()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_reset);
-        }
-
-        private static readonly Selector sel_setRenderPipelineState = "setRenderPipelineState:";
-        private static readonly Selector sel_setVertexBufferoffsetatIndex = "setVertexBuffer:offset:atIndex:";
-        private static readonly Selector sel_setFragmentBufferoffsetatIndex = "setFragmentBuffer:offset:atIndex:";
-        private static readonly Selector sel_setVertexBufferoffsetattributeStrideatIndex = "setVertexBuffer:offset:attributeStride:atIndex:";
-        private static readonly Selector sel_drawPatchespatchStartpatchCountpatchIndexBufferpatchIndexBufferOffsetinstanceCountbaseInstancetessellationFactorBuffertessellationFactorBufferOffsettessellationFactorBufferInstanceStride = "drawPatches:patchStart:patchCount:patchIndexBuffer:patchIndexBufferOffset:instanceCount:baseInstance:tessellationFactorBuffer:tessellationFactorBufferOffset:tessellationFactorBufferInstanceStride:";
-        private static readonly Selector sel_drawIndexedPatchespatchStartpatchCountpatchIndexBufferpatchIndexBufferOffsetcontrolPointIndexBuffercontrolPointIndexBufferOffsetinstanceCountbaseInstancetessellationFactorBuffertessellationFactorBufferOffsettessellationFactorBufferInstanceStride = "drawIndexedPatches:patchStart:patchCount:patchIndexBuffer:patchIndexBufferOffset:controlPointIndexBuffer:controlPointIndexBufferOffset:instanceCount:baseInstance:tessellationFactorBuffer:tessellationFactorBufferOffset:tessellationFactorBufferInstanceStride:";
-        private static readonly Selector sel_drawPrimitivesvertexStartvertexCountinstanceCountbaseInstance = "drawPrimitives:vertexStart:vertexCount:instanceCount:baseInstance:";
-        private static readonly Selector sel_drawIndexedPrimitivesindexCountindexTypeindexBufferindexBufferOffsetinstanceCountbaseVertexbaseInstance = "drawIndexedPrimitives:indexCount:indexType:indexBuffer:indexBufferOffset:instanceCount:baseVertex:baseInstance:";
-        private static readonly Selector sel_setObjectThreadgroupMemoryLengthatIndex = "setObjectThreadgroupMemoryLength:atIndex:";
-        private static readonly Selector sel_setObjectBufferoffsetatIndex = "setObjectBuffer:offset:atIndex:";
-        private static readonly Selector sel_setMeshBufferoffsetatIndex = "setMeshBuffer:offset:atIndex:";
-        private static readonly Selector sel_drawMeshThreadgroupsthreadsPerObjectThreadgroupthreadsPerMeshThreadgroup = "drawMeshThreadgroups:threadsPerObjectThreadgroup:threadsPerMeshThreadgroup:";
-        private static readonly Selector sel_drawMeshThreadsthreadsPerObjectThreadgroupthreadsPerMeshThreadgroup = "drawMeshThreads:threadsPerObjectThreadgroup:threadsPerMeshThreadgroup:";
-        private static readonly Selector sel_setBarrier = "setBarrier";
-        private static readonly Selector sel_clearBarrier = "clearBarrier";
-        private static readonly Selector sel_reset = "reset";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
     public struct MTLIndirectComputeCommand : IDisposable
     {
         public IntPtr NativePtr;
@@ -127,19 +16,9 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public void SetComputePipelineState(MTLComputePipelineState pipelineState)
+        public void ClearBarrier()
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setComputePipelineState, pipelineState);
-        }
-
-        public void SetKernelBuffer(MTLBuffer buffer, ulong offset, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setKernelBufferoffsetatIndex, buffer, offset, index);
-        }
-
-        public void SetKernelBuffer(MTLBuffer buffer, ulong offset, ulong stride, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setKernelBufferoffsetattributeStrideatIndex, buffer, offset, stride, index);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_clearBarrier);
         }
 
         public void ConcurrentDispatchThreadgroups(MTLSize threadgroupsPerGrid, MTLSize threadsPerThreadgroup)
@@ -152,14 +31,19 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_concurrentDispatchThreadsthreadsPerThreadgroup, threadsPerGrid, threadsPerThreadgroup);
         }
 
+        public void Reset()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_reset);
+        }
+
         public void SetBarrier()
         {
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBarrier);
         }
 
-        public void ClearBarrier()
+        public void SetComputePipelineState(MTLComputePipelineState pipelineState)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_clearBarrier);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setComputePipelineState, pipelineState);
         }
 
         public void SetImageblockWidth(ulong width, ulong height)
@@ -167,14 +51,14 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setImageblockWidthheight, width, height);
         }
 
-        public void Reset()
+        public void SetKernelBuffer(MTLBuffer buffer, ulong offset, ulong index)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_reset);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setKernelBufferoffsetatIndex, buffer, offset, index);
         }
 
-        public void SetThreadgroupMemoryLength(ulong length, ulong index)
+        public void SetKernelBuffer(MTLBuffer buffer, ulong offset, ulong stride, ulong index)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setThreadgroupMemoryLengthatIndex, length, index);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setKernelBufferoffsetattributeStrideatIndex, buffer, offset, stride, index);
         }
 
         public void SetStageInRegion(MTLRegion region)
@@ -182,17 +66,133 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStageInRegion, region);
         }
 
-        private static readonly Selector sel_setComputePipelineState = "setComputePipelineState:";
-        private static readonly Selector sel_setKernelBufferoffsetatIndex = "setKernelBuffer:offset:atIndex:";
-        private static readonly Selector sel_setKernelBufferoffsetattributeStrideatIndex = "setKernelBuffer:offset:attributeStride:atIndex:";
+        public void SetThreadgroupMemoryLength(ulong length, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setThreadgroupMemoryLengthatIndex, length, index);
+        }
+
+        private static readonly Selector sel_clearBarrier = "clearBarrier";
         private static readonly Selector sel_concurrentDispatchThreadgroupsthreadsPerThreadgroup = "concurrentDispatchThreadgroups:threadsPerThreadgroup:";
         private static readonly Selector sel_concurrentDispatchThreadsthreadsPerThreadgroup = "concurrentDispatchThreads:threadsPerThreadgroup:";
-        private static readonly Selector sel_setBarrier = "setBarrier";
-        private static readonly Selector sel_clearBarrier = "clearBarrier";
-        private static readonly Selector sel_setImageblockWidthheight = "setImageblockWidth:height:";
         private static readonly Selector sel_reset = "reset";
-        private static readonly Selector sel_setThreadgroupMemoryLengthatIndex = "setThreadgroupMemoryLength:atIndex:";
+        private static readonly Selector sel_setBarrier = "setBarrier";
+        private static readonly Selector sel_setComputePipelineState = "setComputePipelineState:";
+        private static readonly Selector sel_setImageblockWidthheight = "setImageblockWidth:height:";
+        private static readonly Selector sel_setKernelBufferoffsetatIndex = "setKernelBuffer:offset:atIndex:";
+        private static readonly Selector sel_setKernelBufferoffsetattributeStrideatIndex = "setKernelBuffer:offset:attributeStride:atIndex:";
         private static readonly Selector sel_setStageInRegion = "setStageInRegion:";
+        private static readonly Selector sel_setThreadgroupMemoryLengthatIndex = "setThreadgroupMemoryLength:atIndex:";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
+    public struct MTLIndirectRenderCommand : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLIndirectRenderCommand obj) => obj.NativePtr;
+        public MTLIndirectRenderCommand(IntPtr ptr) => NativePtr = ptr;
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public void ClearBarrier()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_clearBarrier);
+        }
+
+        public void DrawIndexedPatches(ulong numberOfPatchControlPoints, ulong patchStart, ulong patchCount, MTLBuffer patchIndexBuffer, ulong patchIndexBufferOffset, MTLBuffer controlPointIndexBuffer, ulong controlPointIndexBufferOffset, ulong instanceCount, ulong baseInstance, MTLBuffer buffer, ulong offset, ulong instanceStride)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawIndexedPatchespatchStartpatchCountpatchIndexBufferpatchIndexBufferOffsetcontrolPointIndexBuffercontrolPointIndexBufferOffsetinstanceCountbaseInstancetessellationFactorBuffertessellationFactorBufferOffsettessellationFactorBufferInstanceStride, numberOfPatchControlPoints, patchStart, patchCount, patchIndexBuffer, patchIndexBufferOffset, controlPointIndexBuffer, controlPointIndexBufferOffset, instanceCount, baseInstance, buffer, offset, instanceStride);
+        }
+
+        public void DrawIndexedPrimitives(MTLPrimitiveType primitiveType, ulong indexCount, MTLIndexType indexType, MTLBuffer indexBuffer, ulong indexBufferOffset, ulong instanceCount, long baseVertex, ulong baseInstance)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawIndexedPrimitivesindexCountindexTypeindexBufferindexBufferOffsetinstanceCountbaseVertexbaseInstance, (ulong)primitiveType, indexCount, (ulong)indexType, indexBuffer, indexBufferOffset, instanceCount, baseVertex, baseInstance);
+        }
+
+        public void DrawMeshThreadgroups(MTLSize threadgroupsPerGrid, MTLSize threadsPerObjectThreadgroup, MTLSize threadsPerMeshThreadgroup)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawMeshThreadgroupsthreadsPerObjectThreadgroupthreadsPerMeshThreadgroup, threadgroupsPerGrid, threadsPerObjectThreadgroup, threadsPerMeshThreadgroup);
+        }
+
+        public void DrawMeshThreads(MTLSize threadsPerGrid, MTLSize threadsPerObjectThreadgroup, MTLSize threadsPerMeshThreadgroup)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawMeshThreadsthreadsPerObjectThreadgroupthreadsPerMeshThreadgroup, threadsPerGrid, threadsPerObjectThreadgroup, threadsPerMeshThreadgroup);
+        }
+
+        public void DrawPatches(ulong numberOfPatchControlPoints, ulong patchStart, ulong patchCount, MTLBuffer patchIndexBuffer, ulong patchIndexBufferOffset, ulong instanceCount, ulong baseInstance, MTLBuffer buffer, ulong offset, ulong instanceStride)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawPatchespatchStartpatchCountpatchIndexBufferpatchIndexBufferOffsetinstanceCountbaseInstancetessellationFactorBuffertessellationFactorBufferOffsettessellationFactorBufferInstanceStride, numberOfPatchControlPoints, patchStart, patchCount, patchIndexBuffer, patchIndexBufferOffset, instanceCount, baseInstance, buffer, offset, instanceStride);
+        }
+
+        public void DrawPrimitives(MTLPrimitiveType primitiveType, ulong vertexStart, ulong vertexCount, ulong instanceCount, ulong baseInstance)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawPrimitivesvertexStartvertexCountinstanceCountbaseInstance, (ulong)primitiveType, vertexStart, vertexCount, instanceCount, baseInstance);
+        }
+
+        public void Reset()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_reset);
+        }
+
+        public void SetBarrier()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBarrier);
+        }
+
+        public void SetFragmentBuffer(MTLBuffer buffer, ulong offset, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFragmentBufferoffsetatIndex, buffer, offset, index);
+        }
+
+        public void SetMeshBuffer(MTLBuffer buffer, ulong offset, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMeshBufferoffsetatIndex, buffer, offset, index);
+        }
+
+        public void SetObjectBuffer(MTLBuffer buffer, ulong offset, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setObjectBufferoffsetatIndex, buffer, offset, index);
+        }
+
+        public void SetObjectThreadgroupMemoryLength(ulong length, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setObjectThreadgroupMemoryLengthatIndex, length, index);
+        }
+
+        public void SetRenderPipelineState(MTLRenderPipelineState pipelineState)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRenderPipelineState, pipelineState);
+        }
+
+        public void SetVertexBuffer(MTLBuffer buffer, ulong offset, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexBufferoffsetatIndex, buffer, offset, index);
+        }
+
+        public void SetVertexBuffer(MTLBuffer buffer, ulong offset, ulong stride, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexBufferoffsetattributeStrideatIndex, buffer, offset, stride, index);
+        }
+
+        private static readonly Selector sel_clearBarrier = "clearBarrier";
+        private static readonly Selector sel_drawIndexedPatchespatchStartpatchCountpatchIndexBufferpatchIndexBufferOffsetcontrolPointIndexBuffercontrolPointIndexBufferOffsetinstanceCountbaseInstancetessellationFactorBuffertessellationFactorBufferOffsettessellationFactorBufferInstanceStride = "drawIndexedPatches:patchStart:patchCount:patchIndexBuffer:patchIndexBufferOffset:controlPointIndexBuffer:controlPointIndexBufferOffset:instanceCount:baseInstance:tessellationFactorBuffer:tessellationFactorBufferOffset:tessellationFactorBufferInstanceStride:";
+        private static readonly Selector sel_drawIndexedPrimitivesindexCountindexTypeindexBufferindexBufferOffsetinstanceCountbaseVertexbaseInstance = "drawIndexedPrimitives:indexCount:indexType:indexBuffer:indexBufferOffset:instanceCount:baseVertex:baseInstance:";
+        private static readonly Selector sel_drawMeshThreadgroupsthreadsPerObjectThreadgroupthreadsPerMeshThreadgroup = "drawMeshThreadgroups:threadsPerObjectThreadgroup:threadsPerMeshThreadgroup:";
+        private static readonly Selector sel_drawMeshThreadsthreadsPerObjectThreadgroupthreadsPerMeshThreadgroup = "drawMeshThreads:threadsPerObjectThreadgroup:threadsPerMeshThreadgroup:";
+        private static readonly Selector sel_drawPatchespatchStartpatchCountpatchIndexBufferpatchIndexBufferOffsetinstanceCountbaseInstancetessellationFactorBuffertessellationFactorBufferOffsettessellationFactorBufferInstanceStride = "drawPatches:patchStart:patchCount:patchIndexBuffer:patchIndexBufferOffset:instanceCount:baseInstance:tessellationFactorBuffer:tessellationFactorBufferOffset:tessellationFactorBufferInstanceStride:";
+        private static readonly Selector sel_drawPrimitivesvertexStartvertexCountinstanceCountbaseInstance = "drawPrimitives:vertexStart:vertexCount:instanceCount:baseInstance:";
+        private static readonly Selector sel_reset = "reset";
+        private static readonly Selector sel_setBarrier = "setBarrier";
+        private static readonly Selector sel_setFragmentBufferoffsetatIndex = "setFragmentBuffer:offset:atIndex:";
+        private static readonly Selector sel_setMeshBufferoffsetatIndex = "setMeshBuffer:offset:atIndex:";
+        private static readonly Selector sel_setObjectBufferoffsetatIndex = "setObjectBuffer:offset:atIndex:";
+        private static readonly Selector sel_setObjectThreadgroupMemoryLengthatIndex = "setObjectThreadgroupMemoryLength:atIndex:";
+        private static readonly Selector sel_setRenderPipelineState = "setRenderPipelineState:";
+        private static readonly Selector sel_setVertexBufferoffsetatIndex = "setVertexBuffer:offset:atIndex:";
+        private static readonly Selector sel_setVertexBufferoffsetattributeStrideatIndex = "setVertexBuffer:offset:attributeStride:atIndex:";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLIntersectionFunctionTable.cs
+++ b/src/SharpMetal/Metal/MTLIntersectionFunctionTable.cs
@@ -20,6 +20,132 @@ namespace SharpMetal.Metal
     }
 
     [SupportedOSPlatform("macos")]
+    public struct MTLIntersectionFunctionTable : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLIntersectionFunctionTable obj) => obj.NativePtr;
+        public static implicit operator MTLResource(MTLIntersectionFunctionTable obj) => new(obj.NativePtr);
+        public MTLIntersectionFunctionTable(IntPtr ptr) => NativePtr = ptr;
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public ulong AllocatedSize => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_allocatedSize);
+
+        public MTLCPUCacheMode CpuCacheMode => (MTLCPUCacheMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_cpuCacheMode);
+
+        public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
+
+        public MTLResourceID GpuResourceID => ObjectiveCRuntime.MTLResourceID_objc_msgSend(NativePtr, sel_gpuResourceID);
+
+        public MTLHazardTrackingMode HazardTrackingMode => (MTLHazardTrackingMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_hazardTrackingMode);
+
+        public MTLHeap Heap => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_heap));
+
+        public ulong HeapOffset => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_heapOffset);
+
+        public bool IsAliasable => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isAliasable);
+
+        public NSString Label
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
+        }
+
+        public MTLResourceOptions ResourceOptions => (MTLResourceOptions)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_resourceOptions);
+
+        public MTLStorageMode StorageMode => (MTLStorageMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_storageMode);
+
+        public void MakeAliasable()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_makeAliasable);
+        }
+
+        public void SetBuffer(MTLBuffer buffer, ulong offset, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBufferoffsetatIndex, buffer, offset, index);
+        }
+
+        public void SetBuffers(MTLBuffer[] buffers, ulong[] offsets, NSRange range)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SetFunction(MTLFunctionHandle function, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFunctionatIndex, function, index);
+        }
+
+        public void SetFunctions(MTLFunctionHandle[] functions, NSRange range)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SetOpaqueCurveIntersectionFunction(MTLIntersectionFunctionSignature signature, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setOpaqueCurveIntersectionFunctionWithSignatureatIndex, (ulong)signature, index);
+        }
+
+        public void SetOpaqueCurveIntersectionFunction(MTLIntersectionFunctionSignature signature, NSRange range)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setOpaqueCurveIntersectionFunctionWithSignaturewithRange, (ulong)signature, range);
+        }
+
+        public void SetOpaqueTriangleIntersectionFunction(MTLIntersectionFunctionSignature signature, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setOpaqueTriangleIntersectionFunctionWithSignatureatIndex, (ulong)signature, index);
+        }
+
+        public void SetOpaqueTriangleIntersectionFunction(MTLIntersectionFunctionSignature signature, NSRange range)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setOpaqueTriangleIntersectionFunctionWithSignaturewithRange, (ulong)signature, range);
+        }
+
+        public MTLPurgeableState SetPurgeableState(MTLPurgeableState state)
+        {
+            return (MTLPurgeableState)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_setPurgeableState, (ulong)state);
+        }
+
+        public void SetVisibleFunctionTable(MTLVisibleFunctionTable functionTable, ulong bufferIndex)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVisibleFunctionTableatBufferIndex, functionTable, bufferIndex);
+        }
+
+        public void SetVisibleFunctionTables(MTLVisibleFunctionTable[] functionTables, NSRange bufferRange)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static readonly Selector sel_allocatedSize = "allocatedSize";
+        private static readonly Selector sel_cpuCacheMode = "cpuCacheMode";
+        private static readonly Selector sel_device = "device";
+        private static readonly Selector sel_gpuResourceID = "gpuResourceID";
+        private static readonly Selector sel_hazardTrackingMode = "hazardTrackingMode";
+        private static readonly Selector sel_heap = "heap";
+        private static readonly Selector sel_heapOffset = "heapOffset";
+        private static readonly Selector sel_isAliasable = "isAliasable";
+        private static readonly Selector sel_label = "label";
+        private static readonly Selector sel_makeAliasable = "makeAliasable";
+        private static readonly Selector sel_resourceOptions = "resourceOptions";
+        private static readonly Selector sel_setBufferoffsetatIndex = "setBuffer:offset:atIndex:";
+        private static readonly Selector sel_setBuffersoffsetswithRange = "setBuffers:offsets:withRange:";
+        private static readonly Selector sel_setFunctionatIndex = "setFunction:atIndex:";
+        private static readonly Selector sel_setFunctionswithRange = "setFunctions:withRange:";
+        private static readonly Selector sel_setLabel = "setLabel:";
+        private static readonly Selector sel_setOpaqueCurveIntersectionFunctionWithSignatureatIndex = "setOpaqueCurveIntersectionFunctionWithSignature:atIndex:";
+        private static readonly Selector sel_setOpaqueCurveIntersectionFunctionWithSignaturewithRange = "setOpaqueCurveIntersectionFunctionWithSignature:withRange:";
+        private static readonly Selector sel_setOpaqueTriangleIntersectionFunctionWithSignatureatIndex = "setOpaqueTriangleIntersectionFunctionWithSignature:atIndex:";
+        private static readonly Selector sel_setOpaqueTriangleIntersectionFunctionWithSignaturewithRange = "setOpaqueTriangleIntersectionFunctionWithSignature:withRange:";
+        private static readonly Selector sel_setPurgeableState = "setPurgeableState:";
+        private static readonly Selector sel_setVisibleFunctionTableatBufferIndex = "setVisibleFunctionTable:atBufferIndex:";
+        private static readonly Selector sel_setVisibleFunctionTableswithBufferRange = "setVisibleFunctionTables:withBufferRange:";
+        private static readonly Selector sel_storageMode = "storageMode";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
     public struct MTLIntersectionFunctionTableDescriptor : IDisposable
     {
         public IntPtr NativePtr;
@@ -43,135 +169,9 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFunctionCount, value);
         }
 
-        private static readonly Selector sel_intersectionFunctionTableDescriptor = "intersectionFunctionTableDescriptor";
         private static readonly Selector sel_functionCount = "functionCount";
+        private static readonly Selector sel_intersectionFunctionTableDescriptor = "intersectionFunctionTableDescriptor";
         private static readonly Selector sel_setFunctionCount = "setFunctionCount:";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLIntersectionFunctionTable : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLIntersectionFunctionTable obj) => obj.NativePtr;
-        public static implicit operator MTLResource(MTLIntersectionFunctionTable obj) => new(obj.NativePtr);
-        public MTLIntersectionFunctionTable(IntPtr ptr) => NativePtr = ptr;
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public MTLResourceID GpuResourceID => ObjectiveCRuntime.MTLResourceID_objc_msgSend(NativePtr, sel_gpuResourceID);
-
-        public NSString Label
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
-        }
-
-        public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
-
-        public MTLCPUCacheMode CpuCacheMode => (MTLCPUCacheMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_cpuCacheMode);
-
-        public MTLStorageMode StorageMode => (MTLStorageMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_storageMode);
-
-        public MTLHazardTrackingMode HazardTrackingMode => (MTLHazardTrackingMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_hazardTrackingMode);
-
-        public MTLResourceOptions ResourceOptions => (MTLResourceOptions)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_resourceOptions);
-
-        public MTLHeap Heap => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_heap));
-
-        public ulong HeapOffset => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_heapOffset);
-
-        public ulong AllocatedSize => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_allocatedSize);
-
-        public bool IsAliasable => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isAliasable);
-
-        public void SetBuffer(MTLBuffer buffer, ulong offset, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBufferoffsetatIndex, buffer, offset, index);
-        }
-
-        public void SetBuffers(MTLBuffer[] buffers, ulong[] offsets, NSRange range)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void SetFunction(MTLFunctionHandle function, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFunctionatIndex, function, index);
-        }
-
-        public void SetFunctions(MTLFunctionHandle[] functions, NSRange range)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void SetOpaqueTriangleIntersectionFunction(MTLIntersectionFunctionSignature signature, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setOpaqueTriangleIntersectionFunctionWithSignatureatIndex, (ulong)signature, index);
-        }
-
-        public void SetOpaqueTriangleIntersectionFunction(MTLIntersectionFunctionSignature signature, NSRange range)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setOpaqueTriangleIntersectionFunctionWithSignaturewithRange, (ulong)signature, range);
-        }
-
-        public void SetOpaqueCurveIntersectionFunction(MTLIntersectionFunctionSignature signature, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setOpaqueCurveIntersectionFunctionWithSignatureatIndex, (ulong)signature, index);
-        }
-
-        public void SetOpaqueCurveIntersectionFunction(MTLIntersectionFunctionSignature signature, NSRange range)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setOpaqueCurveIntersectionFunctionWithSignaturewithRange, (ulong)signature, range);
-        }
-
-        public void SetVisibleFunctionTable(MTLVisibleFunctionTable functionTable, ulong bufferIndex)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVisibleFunctionTableatBufferIndex, functionTable, bufferIndex);
-        }
-
-        public void SetVisibleFunctionTables(MTLVisibleFunctionTable[] functionTables, NSRange bufferRange)
-        {
-            throw new NotImplementedException();
-        }
-
-        public MTLPurgeableState SetPurgeableState(MTLPurgeableState state)
-        {
-            return (MTLPurgeableState)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_setPurgeableState, (ulong)state);
-        }
-
-        public void MakeAliasable()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_makeAliasable);
-        }
-
-        private static readonly Selector sel_setBufferoffsetatIndex = "setBuffer:offset:atIndex:";
-        private static readonly Selector sel_setBuffersoffsetswithRange = "setBuffers:offsets:withRange:";
-        private static readonly Selector sel_gpuResourceID = "gpuResourceID";
-        private static readonly Selector sel_setFunctionatIndex = "setFunction:atIndex:";
-        private static readonly Selector sel_setFunctionswithRange = "setFunctions:withRange:";
-        private static readonly Selector sel_setOpaqueTriangleIntersectionFunctionWithSignatureatIndex = "setOpaqueTriangleIntersectionFunctionWithSignature:atIndex:";
-        private static readonly Selector sel_setOpaqueTriangleIntersectionFunctionWithSignaturewithRange = "setOpaqueTriangleIntersectionFunctionWithSignature:withRange:";
-        private static readonly Selector sel_setOpaqueCurveIntersectionFunctionWithSignatureatIndex = "setOpaqueCurveIntersectionFunctionWithSignature:atIndex:";
-        private static readonly Selector sel_setOpaqueCurveIntersectionFunctionWithSignaturewithRange = "setOpaqueCurveIntersectionFunctionWithSignature:withRange:";
-        private static readonly Selector sel_setVisibleFunctionTableatBufferIndex = "setVisibleFunctionTable:atBufferIndex:";
-        private static readonly Selector sel_setVisibleFunctionTableswithBufferRange = "setVisibleFunctionTables:withBufferRange:";
-        private static readonly Selector sel_label = "label";
-        private static readonly Selector sel_setLabel = "setLabel:";
-        private static readonly Selector sel_device = "device";
-        private static readonly Selector sel_cpuCacheMode = "cpuCacheMode";
-        private static readonly Selector sel_storageMode = "storageMode";
-        private static readonly Selector sel_hazardTrackingMode = "hazardTrackingMode";
-        private static readonly Selector sel_resourceOptions = "resourceOptions";
-        private static readonly Selector sel_setPurgeableState = "setPurgeableState:";
-        private static readonly Selector sel_heap = "heap";
-        private static readonly Selector sel_heapOffset = "heapOffset";
-        private static readonly Selector sel_allocatedSize = "allocatedSize";
-        private static readonly Selector sel_makeAliasable = "makeAliasable";
-        private static readonly Selector sel_isAliasable = "isAliasable";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLLibrary.cs
+++ b/src/SharpMetal/Metal/MTLLibrary.cs
@@ -5,11 +5,10 @@ using SharpMetal.Foundation;
 namespace SharpMetal.Metal
 {
     [SupportedOSPlatform("macos")]
-    public enum MTLPatchType : ulong
+    public enum MTLCompileSymbolVisibility : long
     {
-        None = 0,
-        Triangle = 1,
-        Quad = 2,
+        Default = 0,
+        Hidden = 1,
     }
 
     [SupportedOSPlatform("macos")]
@@ -40,27 +39,6 @@ namespace SharpMetal.Metal
     }
 
     [SupportedOSPlatform("macos")]
-    public enum MTLLibraryType : long
-    {
-        Executable = 0,
-        Dynamic = 1,
-    }
-
-    [SupportedOSPlatform("macos")]
-    public enum MTLLibraryOptimizationLevel : long
-    {
-        Default = 0,
-        Size = 1,
-    }
-
-    [SupportedOSPlatform("macos")]
-    public enum MTLCompileSymbolVisibility : long
-    {
-        Default = 0,
-        Hidden = 1,
-    }
-
-    [SupportedOSPlatform("macos")]
     public enum MTLLibraryError : ulong
     {
         Unsupported = 1,
@@ -72,42 +50,25 @@ namespace SharpMetal.Metal
     }
 
     [SupportedOSPlatform("macos")]
-    public struct MTLVertexAttribute : IDisposable
+    public enum MTLLibraryOptimizationLevel : long
     {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLVertexAttribute obj) => obj.NativePtr;
-        public MTLVertexAttribute(IntPtr ptr) => NativePtr = ptr;
+        Default = 0,
+        Size = 1,
+    }
 
-        public MTLVertexAttribute()
-        {
-            var cls = new ObjectiveCClass("MTLVertexAttribute");
-            NativePtr = cls.AllocInit();
-        }
+    [SupportedOSPlatform("macos")]
+    public enum MTLLibraryType : long
+    {
+        Executable = 0,
+        Dynamic = 1,
+    }
 
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public NSString Name => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_name));
-
-        public ulong AttributeIndex => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_attributeIndex);
-
-        public MTLDataType AttributeType => (MTLDataType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_attributeType);
-
-        public bool Active => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isActive);
-
-        public bool PatchData => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isPatchData);
-
-        public bool PatchControlPointData => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isPatchControlPointData);
-
-        private static readonly Selector sel_name = "name";
-        private static readonly Selector sel_attributeIndex = "attributeIndex";
-        private static readonly Selector sel_attributeType = "attributeType";
-        private static readonly Selector sel_isActive = "isActive";
-        private static readonly Selector sel_isPatchData = "isPatchData";
-        private static readonly Selector sel_isPatchControlPointData = "isPatchControlPointData";
-        private static readonly Selector sel_release = "release";
+    [SupportedOSPlatform("macos")]
+    public enum MTLPatchType : ulong
+    {
+        None = 0,
+        Triangle = 1,
+        Quad = 2,
     }
 
     [SupportedOSPlatform("macos")]
@@ -128,119 +89,24 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public NSString Name => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_name));
+        public bool Active => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isActive);
 
         public ulong AttributeIndex => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_attributeIndex);
 
         public MTLDataType AttributeType => (MTLDataType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_attributeType);
 
-        public bool Active => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isActive);
-
-        public bool PatchData => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isPatchData);
+        public NSString Name => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_name));
 
         public bool PatchControlPointData => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isPatchControlPointData);
 
-        private static readonly Selector sel_name = "name";
+        public bool PatchData => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isPatchData);
+
         private static readonly Selector sel_attributeIndex = "attributeIndex";
         private static readonly Selector sel_attributeType = "attributeType";
         private static readonly Selector sel_isActive = "isActive";
-        private static readonly Selector sel_isPatchData = "isPatchData";
         private static readonly Selector sel_isPatchControlPointData = "isPatchControlPointData";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLFunctionConstant : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLFunctionConstant obj) => obj.NativePtr;
-        public MTLFunctionConstant(IntPtr ptr) => NativePtr = ptr;
-
-        public MTLFunctionConstant()
-        {
-            var cls = new ObjectiveCClass("MTLFunctionConstant");
-            NativePtr = cls.AllocInit();
-        }
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public NSString Name => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_name));
-
-        public MTLDataType Type => (MTLDataType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_type);
-
-        public ulong Index => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_index);
-
-        public bool Required => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_required);
-
+        private static readonly Selector sel_isPatchData = "isPatchData";
         private static readonly Selector sel_name = "name";
-        private static readonly Selector sel_type = "type";
-        private static readonly Selector sel_index = "index";
-        private static readonly Selector sel_required = "required";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLFunction : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLFunction obj) => obj.NativePtr;
-        public MTLFunction(IntPtr ptr) => NativePtr = ptr;
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public NSString Label
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
-        }
-
-        public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
-
-        public MTLFunctionType FunctionType => (MTLFunctionType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_functionType);
-
-        public MTLPatchType PatchType => (MTLPatchType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_patchType);
-
-        public long PatchControlPointCount => ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_patchControlPointCount);
-
-        public NSArray VertexAttributes => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_vertexAttributes));
-
-        public NSArray StageInputAttributes => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_stageInputAttributes));
-
-        public NSString Name => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_name));
-
-        public NSDictionary FunctionConstantsDictionary => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_functionConstantsDictionary));
-
-        public MTLFunctionOptions Options => (MTLFunctionOptions)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_options);
-
-        public MTLArgumentEncoder NewArgumentEncoder(ulong bufferIndex)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newArgumentEncoderWithBufferIndex, bufferIndex));
-        }
-
-        public MTLArgumentEncoder NewArgumentEncoder(ulong bufferIndex, IntPtr reflection)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newArgumentEncoderWithBufferIndexreflection, bufferIndex, reflection));
-        }
-
-        private static readonly Selector sel_label = "label";
-        private static readonly Selector sel_setLabel = "setLabel:";
-        private static readonly Selector sel_device = "device";
-        private static readonly Selector sel_functionType = "functionType";
-        private static readonly Selector sel_patchType = "patchType";
-        private static readonly Selector sel_patchControlPointCount = "patchControlPointCount";
-        private static readonly Selector sel_vertexAttributes = "vertexAttributes";
-        private static readonly Selector sel_stageInputAttributes = "stageInputAttributes";
-        private static readonly Selector sel_name = "name";
-        private static readonly Selector sel_functionConstantsDictionary = "functionConstantsDictionary";
-        private static readonly Selector sel_newArgumentEncoderWithBufferIndex = "newArgumentEncoderWithBufferIndex:";
-        private static readonly Selector sel_newArgumentEncoderWithBufferIndexreflection = "newArgumentEncoderWithBufferIndex:reflection:";
-        private static readonly Selector sel_options = "options";
         private static readonly Selector sel_release = "release";
     }
 
@@ -262,52 +128,10 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public NSDictionary PreprocessorMacros
+        public bool AllowReferencingUndefinedSymbols
         {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_preprocessorMacros));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPreprocessorMacros, value);
-        }
-
-        public bool FastMathEnabled
-        {
-            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_fastMathEnabled);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFastMathEnabled, value);
-        }
-
-        public MTLLanguageVersion LanguageVersion
-        {
-            get => (MTLLanguageVersion)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_languageVersion);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLanguageVersion, (ulong)value);
-        }
-
-        public MTLLibraryType LibraryType
-        {
-            get => (MTLLibraryType)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_libraryType);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLibraryType, (long)value);
-        }
-
-        public NSString InstallName
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_installName));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setInstallName, value);
-        }
-
-        public NSArray Libraries
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_libraries));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLibraries, value);
-        }
-
-        public bool PreserveInvariance
-        {
-            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_preserveInvariance);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPreserveInvariance, value);
-        }
-
-        public MTLLibraryOptimizationLevel OptimizationLevel
-        {
-            get => (MTLLibraryOptimizationLevel)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_optimizationLevel);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setOptimizationLevel, (long)value);
+            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_allowReferencingUndefinedSymbols);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setAllowReferencingUndefinedSymbols, value);
         }
 
         public MTLCompileSymbolVisibility CompileSymbolVisibility
@@ -316,10 +140,34 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setCompileSymbolVisibility, (long)value);
         }
 
-        public bool AllowReferencingUndefinedSymbols
+        public bool FastMathEnabled
         {
-            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_allowReferencingUndefinedSymbols);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setAllowReferencingUndefinedSymbols, value);
+            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_fastMathEnabled);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFastMathEnabled, value);
+        }
+
+        public NSString InstallName
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_installName));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setInstallName, value);
+        }
+
+        public MTLLanguageVersion LanguageVersion
+        {
+            get => (MTLLanguageVersion)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_languageVersion);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLanguageVersion, (ulong)value);
+        }
+
+        public NSArray Libraries
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_libraries));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLibraries, value);
+        }
+
+        public MTLLibraryType LibraryType
+        {
+            get => (MTLLibraryType)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_libraryType);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLibraryType, (long)value);
         }
 
         public ulong MaxTotalThreadsPerThreadgroup
@@ -328,28 +176,141 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxTotalThreadsPerThreadgroup, value);
         }
 
-        private static readonly Selector sel_preprocessorMacros = "preprocessorMacros";
-        private static readonly Selector sel_setPreprocessorMacros = "setPreprocessorMacros:";
-        private static readonly Selector sel_fastMathEnabled = "fastMathEnabled";
-        private static readonly Selector sel_setFastMathEnabled = "setFastMathEnabled:";
-        private static readonly Selector sel_languageVersion = "languageVersion";
-        private static readonly Selector sel_setLanguageVersion = "setLanguageVersion:";
-        private static readonly Selector sel_libraryType = "libraryType";
-        private static readonly Selector sel_setLibraryType = "setLibraryType:";
-        private static readonly Selector sel_installName = "installName";
-        private static readonly Selector sel_setInstallName = "setInstallName:";
-        private static readonly Selector sel_libraries = "libraries";
-        private static readonly Selector sel_setLibraries = "setLibraries:";
-        private static readonly Selector sel_preserveInvariance = "preserveInvariance";
-        private static readonly Selector sel_setPreserveInvariance = "setPreserveInvariance:";
-        private static readonly Selector sel_optimizationLevel = "optimizationLevel";
-        private static readonly Selector sel_setOptimizationLevel = "setOptimizationLevel:";
-        private static readonly Selector sel_compileSymbolVisibility = "compileSymbolVisibility";
-        private static readonly Selector sel_setCompileSymbolVisibility = "setCompileSymbolVisibility:";
+        public MTLLibraryOptimizationLevel OptimizationLevel
+        {
+            get => (MTLLibraryOptimizationLevel)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_optimizationLevel);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setOptimizationLevel, (long)value);
+        }
+
+        public NSDictionary PreprocessorMacros
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_preprocessorMacros));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPreprocessorMacros, value);
+        }
+
+        public bool PreserveInvariance
+        {
+            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_preserveInvariance);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPreserveInvariance, value);
+        }
+
         private static readonly Selector sel_allowReferencingUndefinedSymbols = "allowReferencingUndefinedSymbols";
-        private static readonly Selector sel_setAllowReferencingUndefinedSymbols = "setAllowReferencingUndefinedSymbols:";
+        private static readonly Selector sel_compileSymbolVisibility = "compileSymbolVisibility";
+        private static readonly Selector sel_fastMathEnabled = "fastMathEnabled";
+        private static readonly Selector sel_installName = "installName";
+        private static readonly Selector sel_languageVersion = "languageVersion";
+        private static readonly Selector sel_libraries = "libraries";
+        private static readonly Selector sel_libraryType = "libraryType";
         private static readonly Selector sel_maxTotalThreadsPerThreadgroup = "maxTotalThreadsPerThreadgroup";
+        private static readonly Selector sel_optimizationLevel = "optimizationLevel";
+        private static readonly Selector sel_preprocessorMacros = "preprocessorMacros";
+        private static readonly Selector sel_preserveInvariance = "preserveInvariance";
+        private static readonly Selector sel_setAllowReferencingUndefinedSymbols = "setAllowReferencingUndefinedSymbols:";
+        private static readonly Selector sel_setCompileSymbolVisibility = "setCompileSymbolVisibility:";
+        private static readonly Selector sel_setFastMathEnabled = "setFastMathEnabled:";
+        private static readonly Selector sel_setInstallName = "setInstallName:";
+        private static readonly Selector sel_setLanguageVersion = "setLanguageVersion:";
+        private static readonly Selector sel_setLibraries = "setLibraries:";
+        private static readonly Selector sel_setLibraryType = "setLibraryType:";
         private static readonly Selector sel_setMaxTotalThreadsPerThreadgroup = "setMaxTotalThreadsPerThreadgroup:";
+        private static readonly Selector sel_setOptimizationLevel = "setOptimizationLevel:";
+        private static readonly Selector sel_setPreprocessorMacros = "setPreprocessorMacros:";
+        private static readonly Selector sel_setPreserveInvariance = "setPreserveInvariance:";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
+    public struct MTLFunction : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLFunction obj) => obj.NativePtr;
+        public MTLFunction(IntPtr ptr) => NativePtr = ptr;
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
+
+        public NSDictionary FunctionConstantsDictionary => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_functionConstantsDictionary));
+
+        public MTLFunctionType FunctionType => (MTLFunctionType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_functionType);
+
+        public NSString Label
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
+        }
+
+        public NSString Name => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_name));
+
+        public MTLFunctionOptions Options => (MTLFunctionOptions)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_options);
+
+        public long PatchControlPointCount => ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_patchControlPointCount);
+
+        public MTLPatchType PatchType => (MTLPatchType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_patchType);
+
+        public NSArray StageInputAttributes => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_stageInputAttributes));
+
+        public NSArray VertexAttributes => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_vertexAttributes));
+
+        public MTLArgumentEncoder NewArgumentEncoder(ulong bufferIndex)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newArgumentEncoderWithBufferIndex, bufferIndex));
+        }
+
+        public MTLArgumentEncoder NewArgumentEncoder(ulong bufferIndex, IntPtr reflection)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newArgumentEncoderWithBufferIndexreflection, bufferIndex, reflection));
+        }
+
+        private static readonly Selector sel_device = "device";
+        private static readonly Selector sel_functionConstantsDictionary = "functionConstantsDictionary";
+        private static readonly Selector sel_functionType = "functionType";
+        private static readonly Selector sel_label = "label";
+        private static readonly Selector sel_name = "name";
+        private static readonly Selector sel_newArgumentEncoderWithBufferIndex = "newArgumentEncoderWithBufferIndex:";
+        private static readonly Selector sel_newArgumentEncoderWithBufferIndexreflection = "newArgumentEncoderWithBufferIndex:reflection:";
+        private static readonly Selector sel_options = "options";
+        private static readonly Selector sel_patchControlPointCount = "patchControlPointCount";
+        private static readonly Selector sel_patchType = "patchType";
+        private static readonly Selector sel_setLabel = "setLabel:";
+        private static readonly Selector sel_stageInputAttributes = "stageInputAttributes";
+        private static readonly Selector sel_vertexAttributes = "vertexAttributes";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
+    public struct MTLFunctionConstant : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLFunctionConstant obj) => obj.NativePtr;
+        public MTLFunctionConstant(IntPtr ptr) => NativePtr = ptr;
+
+        public MTLFunctionConstant()
+        {
+            var cls = new ObjectiveCClass("MTLFunctionConstant");
+            NativePtr = cls.AllocInit();
+        }
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public ulong Index => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_index);
+
+        public NSString Name => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_name));
+
+        public bool Required => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_required);
+
+        public MTLDataType Type => (MTLDataType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_type);
+
+        private static readonly Selector sel_index = "index";
+        private static readonly Selector sel_name = "name";
+        private static readonly Selector sel_required = "required";
+        private static readonly Selector sel_type = "type";
         private static readonly Selector sel_release = "release";
     }
 
@@ -365,19 +326,19 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
+        public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
+
+        public NSArray FunctionNames => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_functionNames));
+
+        public NSString InstallName => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_installName));
+
         public NSString Label
         {
             get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
         }
 
-        public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
-
-        public NSArray FunctionNames => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_functionNames));
-
         public MTLLibraryType Type => (MTLLibraryType)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_type);
-
-        public NSString InstallName => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_installName));
 
         public MTLFunction NewFunction(NSString functionName)
         {
@@ -399,16 +360,55 @@ namespace SharpMetal.Metal
             return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newIntersectionFunctionWithDescriptorerror, descriptor, ref error.NativePtr));
         }
 
-        private static readonly Selector sel_label = "label";
-        private static readonly Selector sel_setLabel = "setLabel:";
         private static readonly Selector sel_device = "device";
+        private static readonly Selector sel_functionNames = "functionNames";
+        private static readonly Selector sel_installName = "installName";
+        private static readonly Selector sel_label = "label";
+        private static readonly Selector sel_newFunctionWithDescriptorerror = "newFunctionWithDescriptor:error:";
         private static readonly Selector sel_newFunctionWithName = "newFunctionWithName:";
         private static readonly Selector sel_newFunctionWithNameconstantValueserror = "newFunctionWithName:constantValues:error:";
-        private static readonly Selector sel_newFunctionWithDescriptorerror = "newFunctionWithDescriptor:error:";
         private static readonly Selector sel_newIntersectionFunctionWithDescriptorerror = "newIntersectionFunctionWithDescriptor:error:";
-        private static readonly Selector sel_functionNames = "functionNames";
+        private static readonly Selector sel_setLabel = "setLabel:";
         private static readonly Selector sel_type = "type";
-        private static readonly Selector sel_installName = "installName";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
+    public struct MTLVertexAttribute : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLVertexAttribute obj) => obj.NativePtr;
+        public MTLVertexAttribute(IntPtr ptr) => NativePtr = ptr;
+
+        public MTLVertexAttribute()
+        {
+            var cls = new ObjectiveCClass("MTLVertexAttribute");
+            NativePtr = cls.AllocInit();
+        }
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public bool Active => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isActive);
+
+        public ulong AttributeIndex => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_attributeIndex);
+
+        public MTLDataType AttributeType => (MTLDataType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_attributeType);
+
+        public NSString Name => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_name));
+
+        public bool PatchControlPointData => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isPatchControlPointData);
+
+        public bool PatchData => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isPatchData);
+
+        private static readonly Selector sel_attributeIndex = "attributeIndex";
+        private static readonly Selector sel_attributeType = "attributeType";
+        private static readonly Selector sel_isActive = "isActive";
+        private static readonly Selector sel_isPatchControlPointData = "isPatchControlPointData";
+        private static readonly Selector sel_isPatchData = "isPatchData";
+        private static readonly Selector sel_name = "name";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLLinkedFunctions.cs
+++ b/src/SharpMetal/Metal/MTLLinkedFunctions.cs
@@ -22,16 +22,16 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public NSArray Functions
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_functions));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFunctions, value);
-        }
-
         public NSArray BinaryFunctions
         {
             get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_binaryFunctions));
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBinaryFunctions, value);
+        }
+
+        public NSArray Functions
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_functions));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFunctions, value);
         }
 
         public NSDictionary Groups
@@ -46,14 +46,14 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPrivateFunctions, value);
         }
 
-        private static readonly Selector sel_linkedFunctions = "linkedFunctions";
-        private static readonly Selector sel_functions = "functions";
-        private static readonly Selector sel_setFunctions = "setFunctions:";
         private static readonly Selector sel_binaryFunctions = "binaryFunctions";
-        private static readonly Selector sel_setBinaryFunctions = "setBinaryFunctions:";
+        private static readonly Selector sel_functions = "functions";
         private static readonly Selector sel_groups = "groups";
-        private static readonly Selector sel_setGroups = "setGroups:";
+        private static readonly Selector sel_linkedFunctions = "linkedFunctions";
         private static readonly Selector sel_privateFunctions = "privateFunctions";
+        private static readonly Selector sel_setBinaryFunctions = "setBinaryFunctions:";
+        private static readonly Selector sel_setFunctions = "setFunctions:";
+        private static readonly Selector sel_setGroups = "setGroups:";
         private static readonly Selector sel_setPrivateFunctions = "setPrivateFunctions:";
         private static readonly Selector sel_release = "release";
     }

--- a/src/SharpMetal/Metal/MTLParallelRenderCommandEncoder.cs
+++ b/src/SharpMetal/Metal/MTLParallelRenderCommandEncoder.cs
@@ -17,8 +17,6 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public MTLRenderCommandEncoder RenderCommandEncoder => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_renderCommandEncoder));
-
         public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
 
         public NSString Label
@@ -27,35 +25,7 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
         }
 
-        public void SetColorStoreAction(MTLStoreAction storeAction, ulong colorAttachmentIndex)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setColorStoreActionatIndex, (ulong)storeAction, colorAttachmentIndex);
-        }
-
-        public void SetDepthStoreAction(MTLStoreAction storeAction)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDepthStoreAction, (ulong)storeAction);
-        }
-
-        public void SetStencilStoreAction(MTLStoreAction storeAction)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStencilStoreAction, (ulong)storeAction);
-        }
-
-        public void SetColorStoreActionOptions(MTLStoreActionOptions storeActionOptions, ulong colorAttachmentIndex)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setColorStoreActionOptionsatIndex, (ulong)storeActionOptions, colorAttachmentIndex);
-        }
-
-        public void SetDepthStoreActionOptions(MTLStoreActionOptions storeActionOptions)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDepthStoreActionOptions, (ulong)storeActionOptions);
-        }
-
-        public void SetStencilStoreActionOptions(MTLStoreActionOptions storeActionOptions)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStencilStoreActionOptions, (ulong)storeActionOptions);
-        }
+        public MTLRenderCommandEncoder RenderCommandEncoder => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_renderCommandEncoder));
 
         public void EndEncoding()
         {
@@ -67,30 +37,60 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_insertDebugSignpost, nsString);
         }
 
-        public void PushDebugGroup(NSString nsString)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_pushDebugGroup, nsString);
-        }
-
         public void PopDebugGroup()
         {
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_popDebugGroup);
         }
 
-        private static readonly Selector sel_renderCommandEncoder = "renderCommandEncoder";
-        private static readonly Selector sel_setColorStoreActionatIndex = "setColorStoreAction:atIndex:";
-        private static readonly Selector sel_setDepthStoreAction = "setDepthStoreAction:";
-        private static readonly Selector sel_setStencilStoreAction = "setStencilStoreAction:";
-        private static readonly Selector sel_setColorStoreActionOptionsatIndex = "setColorStoreActionOptions:atIndex:";
-        private static readonly Selector sel_setDepthStoreActionOptions = "setDepthStoreActionOptions:";
-        private static readonly Selector sel_setStencilStoreActionOptions = "setStencilStoreActionOptions:";
+        public void PushDebugGroup(NSString nsString)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_pushDebugGroup, nsString);
+        }
+
+        public void SetColorStoreAction(MTLStoreAction storeAction, ulong colorAttachmentIndex)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setColorStoreActionatIndex, (ulong)storeAction, colorAttachmentIndex);
+        }
+
+        public void SetColorStoreActionOptions(MTLStoreActionOptions storeActionOptions, ulong colorAttachmentIndex)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setColorStoreActionOptionsatIndex, (ulong)storeActionOptions, colorAttachmentIndex);
+        }
+
+        public void SetDepthStoreAction(MTLStoreAction storeAction)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDepthStoreAction, (ulong)storeAction);
+        }
+
+        public void SetDepthStoreActionOptions(MTLStoreActionOptions storeActionOptions)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDepthStoreActionOptions, (ulong)storeActionOptions);
+        }
+
+        public void SetStencilStoreAction(MTLStoreAction storeAction)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStencilStoreAction, (ulong)storeAction);
+        }
+
+        public void SetStencilStoreActionOptions(MTLStoreActionOptions storeActionOptions)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStencilStoreActionOptions, (ulong)storeActionOptions);
+        }
+
         private static readonly Selector sel_device = "device";
-        private static readonly Selector sel_label = "label";
-        private static readonly Selector sel_setLabel = "setLabel:";
         private static readonly Selector sel_endEncoding = "endEncoding";
         private static readonly Selector sel_insertDebugSignpost = "insertDebugSignpost:";
-        private static readonly Selector sel_pushDebugGroup = "pushDebugGroup:";
+        private static readonly Selector sel_label = "label";
         private static readonly Selector sel_popDebugGroup = "popDebugGroup";
+        private static readonly Selector sel_pushDebugGroup = "pushDebugGroup:";
+        private static readonly Selector sel_renderCommandEncoder = "renderCommandEncoder";
+        private static readonly Selector sel_setColorStoreActionatIndex = "setColorStoreAction:atIndex:";
+        private static readonly Selector sel_setColorStoreActionOptionsatIndex = "setColorStoreActionOptions:atIndex:";
+        private static readonly Selector sel_setDepthStoreAction = "setDepthStoreAction:";
+        private static readonly Selector sel_setDepthStoreActionOptions = "setDepthStoreActionOptions:";
+        private static readonly Selector sel_setLabel = "setLabel:";
+        private static readonly Selector sel_setStencilStoreAction = "setStencilStoreAction:";
+        private static readonly Selector sel_setStencilStoreActionOptions = "setStencilStoreActionOptions:";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLRasterizationRate.cs
+++ b/src/SharpMetal/Metal/MTLRasterizationRate.cs
@@ -5,95 +5,6 @@ using SharpMetal.Foundation;
 namespace SharpMetal.Metal
 {
     [SupportedOSPlatform("macos")]
-    public struct MTLRasterizationRateSampleArray : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLRasterizationRateSampleArray obj) => obj.NativePtr;
-        public MTLRasterizationRateSampleArray(IntPtr ptr) => NativePtr = ptr;
-
-        public MTLRasterizationRateSampleArray()
-        {
-            var cls = new ObjectiveCClass("MTLRasterizationRateSampleArray");
-            NativePtr = cls.AllocInit();
-        }
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public NSNumber Object(ulong index)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_objectAtIndexedSubscript, index));
-        }
-
-        public void SetObject(NSNumber value, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setObjectatIndexedSubscript, value, index);
-        }
-
-        private static readonly Selector sel_objectAtIndexedSubscript = "objectAtIndexedSubscript:";
-        private static readonly Selector sel_setObjectatIndexedSubscript = "setObject:atIndexedSubscript:";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLRasterizationRateLayerDescriptor : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLRasterizationRateLayerDescriptor obj) => obj.NativePtr;
-        public MTLRasterizationRateLayerDescriptor(IntPtr ptr) => NativePtr = ptr;
-
-        public MTLRasterizationRateLayerDescriptor()
-        {
-            var cls = new ObjectiveCClass("MTLRasterizationRateLayerDescriptor");
-            NativePtr = cls.AllocInit();
-        }
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public MTLSize SampleCount
-        {
-            get => ObjectiveCRuntime.MTLSize_objc_msgSend(NativePtr, sel_sampleCount);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSampleCount, value);
-        }
-
-        public MTLSize MaxSampleCount => ObjectiveCRuntime.MTLSize_objc_msgSend(NativePtr, sel_maxSampleCount);
-
-        public float HorizontalSampleStorage => ObjectiveCRuntime.float_objc_msgSend(NativePtr, sel_horizontalSampleStorage);
-
-        public float VerticalSampleStorage => ObjectiveCRuntime.float_objc_msgSend(NativePtr, sel_verticalSampleStorage);
-
-        public MTLRasterizationRateSampleArray Horizontal => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_horizontal));
-
-        public MTLRasterizationRateSampleArray Vertical => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_vertical));
-
-        public MTLRasterizationRateLayerDescriptor Init(MTLSize sampleCount)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithSampleCount, sampleCount));
-        }
-
-        public MTLRasterizationRateLayerDescriptor Init(MTLSize sampleCount, float horizontal, float vertical)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithSampleCounthorizontalvertical, sampleCount, horizontal, vertical));
-        }
-
-        private static readonly Selector sel_initWithSampleCount = "initWithSampleCount:";
-        private static readonly Selector sel_initWithSampleCounthorizontalvertical = "initWithSampleCount:horizontal:vertical:";
-        private static readonly Selector sel_sampleCount = "sampleCount";
-        private static readonly Selector sel_maxSampleCount = "maxSampleCount";
-        private static readonly Selector sel_horizontalSampleStorage = "horizontalSampleStorage";
-        private static readonly Selector sel_verticalSampleStorage = "verticalSampleStorage";
-        private static readonly Selector sel_horizontal = "horizontal";
-        private static readonly Selector sel_vertical = "vertical";
-        private static readonly Selector sel_setSampleCount = "setSampleCount:";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
     public struct MTLRasterizationRateLayerArray : IDisposable
     {
         public IntPtr NativePtr;
@@ -127,15 +38,15 @@ namespace SharpMetal.Metal
     }
 
     [SupportedOSPlatform("macos")]
-    public struct MTLRasterizationRateMapDescriptor : IDisposable
+    public struct MTLRasterizationRateLayerDescriptor : IDisposable
     {
         public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLRasterizationRateMapDescriptor obj) => obj.NativePtr;
-        public MTLRasterizationRateMapDescriptor(IntPtr ptr) => NativePtr = ptr;
+        public static implicit operator IntPtr(MTLRasterizationRateLayerDescriptor obj) => obj.NativePtr;
+        public MTLRasterizationRateLayerDescriptor(IntPtr ptr) => NativePtr = ptr;
 
-        public MTLRasterizationRateMapDescriptor()
+        public MTLRasterizationRateLayerDescriptor()
         {
-            var cls = new ObjectiveCClass("MTLRasterizationRateMapDescriptor");
+            var cls = new ObjectiveCClass("MTLRasterizationRateLayerDescriptor");
             NativePtr = cls.AllocInit();
         }
 
@@ -144,58 +55,41 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public MTLRasterizationRateLayerArray Layers => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_layers));
+        public MTLRasterizationRateSampleArray Horizontal => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_horizontal));
 
-        public MTLSize ScreenSize
+        public float HorizontalSampleStorage => ObjectiveCRuntime.float_objc_msgSend(NativePtr, sel_horizontalSampleStorage);
+
+        public MTLSize MaxSampleCount => ObjectiveCRuntime.MTLSize_objc_msgSend(NativePtr, sel_maxSampleCount);
+
+        public MTLSize SampleCount
         {
-            get => ObjectiveCRuntime.MTLSize_objc_msgSend(NativePtr, sel_screenSize);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setScreenSize, value);
+            get => ObjectiveCRuntime.MTLSize_objc_msgSend(NativePtr, sel_sampleCount);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSampleCount, value);
         }
 
-        public NSString Label
+        public MTLRasterizationRateSampleArray Vertical => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_vertical));
+
+        public float VerticalSampleStorage => ObjectiveCRuntime.float_objc_msgSend(NativePtr, sel_verticalSampleStorage);
+
+        public MTLRasterizationRateLayerDescriptor Init(MTLSize sampleCount)
         {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithSampleCount, sampleCount));
         }
 
-        public ulong LayerCount => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_layerCount);
-
-        public static MTLRasterizationRateMapDescriptor RasterizationRateMapDescriptor(MTLSize screenSize)
+        public MTLRasterizationRateLayerDescriptor Init(MTLSize sampleCount, float horizontal, float vertical)
         {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(new ObjectiveCClass("MTLRasterizationRateMapDescriptor"), sel_rasterizationRateMapDescriptorWithScreenSize, screenSize));
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_initWithSampleCounthorizontalvertical, sampleCount, horizontal, vertical));
         }
 
-        public static MTLRasterizationRateMapDescriptor RasterizationRateMapDescriptor(MTLSize screenSize, MTLRasterizationRateLayerDescriptor layer)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(new ObjectiveCClass("MTLRasterizationRateMapDescriptor"), sel_rasterizationRateMapDescriptorWithScreenSizelayer, screenSize, layer));
-        }
-
-        public static MTLRasterizationRateMapDescriptor RasterizationRateMapDescriptor(MTLSize screenSize, ulong layerCount, MTLRasterizationRateLayerDescriptor layers)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(new ObjectiveCClass("MTLRasterizationRateMapDescriptor"), sel_rasterizationRateMapDescriptorWithScreenSizelayerCountlayers, screenSize, layerCount, layers));
-        }
-
-        public MTLRasterizationRateLayerDescriptor Layer(ulong layerIndex)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_layerAtIndex, layerIndex));
-        }
-
-        public void SetLayer(MTLRasterizationRateLayerDescriptor layer, ulong layerIndex)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLayeratIndex, layer, layerIndex);
-        }
-
-        private static readonly Selector sel_rasterizationRateMapDescriptorWithScreenSize = "rasterizationRateMapDescriptorWithScreenSize:";
-        private static readonly Selector sel_rasterizationRateMapDescriptorWithScreenSizelayer = "rasterizationRateMapDescriptorWithScreenSize:layer:";
-        private static readonly Selector sel_rasterizationRateMapDescriptorWithScreenSizelayerCountlayers = "rasterizationRateMapDescriptorWithScreenSize:layerCount:layers:";
-        private static readonly Selector sel_layerAtIndex = "layerAtIndex:";
-        private static readonly Selector sel_setLayeratIndex = "setLayer:atIndex:";
-        private static readonly Selector sel_layers = "layers";
-        private static readonly Selector sel_screenSize = "screenSize";
-        private static readonly Selector sel_setScreenSize = "setScreenSize:";
-        private static readonly Selector sel_label = "label";
-        private static readonly Selector sel_setLabel = "setLabel:";
-        private static readonly Selector sel_layerCount = "layerCount";
+        private static readonly Selector sel_horizontal = "horizontal";
+        private static readonly Selector sel_horizontalSampleStorage = "horizontalSampleStorage";
+        private static readonly Selector sel_initWithSampleCount = "initWithSampleCount:";
+        private static readonly Selector sel_initWithSampleCounthorizontalvertical = "initWithSampleCount:horizontal:vertical:";
+        private static readonly Selector sel_maxSampleCount = "maxSampleCount";
+        private static readonly Selector sel_sampleCount = "sampleCount";
+        private static readonly Selector sel_setSampleCount = "setSampleCount:";
+        private static readonly Selector sel_vertical = "vertical";
+        private static readonly Selector sel_verticalSampleStorage = "verticalSampleStorage";
         private static readonly Selector sel_release = "release";
     }
 
@@ -215,27 +109,17 @@ namespace SharpMetal.Metal
 
         public NSString Label => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
 
-        public MTLSize ScreenSize => ObjectiveCRuntime.MTLSize_objc_msgSend(NativePtr, sel_screenSize);
-
-        public MTLSize PhysicalGranularity => ObjectiveCRuntime.MTLSize_objc_msgSend(NativePtr, sel_physicalGranularity);
-
         public ulong LayerCount => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_layerCount);
 
         public MTLSizeAndAlign ParameterBufferSizeAndAlign => ObjectiveCRuntime.MTLSizeAndAlign_objc_msgSend(NativePtr, sel_parameterBufferSizeAndAlign);
 
+        public MTLSize PhysicalGranularity => ObjectiveCRuntime.MTLSize_objc_msgSend(NativePtr, sel_physicalGranularity);
+
+        public MTLSize ScreenSize => ObjectiveCRuntime.MTLSize_objc_msgSend(NativePtr, sel_screenSize);
+
         public void CopyParameterDataToBuffer(MTLBuffer buffer, ulong offset)
         {
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_copyParameterDataToBufferoffset, buffer, offset);
-        }
-
-        public MTLSize PhysicalSize(ulong layerIndex)
-        {
-            return ObjectiveCRuntime.MTLSize_objc_msgSend(NativePtr, sel_physicalSizeForLayer, layerIndex);
-        }
-
-        public IntPtr MapScreenToPhysicalCoordinates(IntPtr screenCoordinates, ulong layerIndex)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_mapScreenToPhysicalCoordinatesforLayer, screenCoordinates, layerIndex));
         }
 
         public IntPtr MapPhysicalToScreenCoordinates(IntPtr physicalCoordinates, ulong layerIndex)
@@ -243,16 +127,132 @@ namespace SharpMetal.Metal
             return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_mapPhysicalToScreenCoordinatesforLayer, physicalCoordinates, layerIndex));
         }
 
+        public IntPtr MapScreenToPhysicalCoordinates(IntPtr screenCoordinates, ulong layerIndex)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_mapScreenToPhysicalCoordinatesforLayer, screenCoordinates, layerIndex));
+        }
+
+        public MTLSize PhysicalSize(ulong layerIndex)
+        {
+            return ObjectiveCRuntime.MTLSize_objc_msgSend(NativePtr, sel_physicalSizeForLayer, layerIndex);
+        }
+
+        private static readonly Selector sel_copyParameterDataToBufferoffset = "copyParameterDataToBuffer:offset:";
         private static readonly Selector sel_device = "device";
         private static readonly Selector sel_label = "label";
-        private static readonly Selector sel_screenSize = "screenSize";
-        private static readonly Selector sel_physicalGranularity = "physicalGranularity";
         private static readonly Selector sel_layerCount = "layerCount";
-        private static readonly Selector sel_parameterBufferSizeAndAlign = "parameterBufferSizeAndAlign";
-        private static readonly Selector sel_copyParameterDataToBufferoffset = "copyParameterDataToBuffer:offset:";
-        private static readonly Selector sel_physicalSizeForLayer = "physicalSizeForLayer:";
-        private static readonly Selector sel_mapScreenToPhysicalCoordinatesforLayer = "mapScreenToPhysicalCoordinates:forLayer:";
         private static readonly Selector sel_mapPhysicalToScreenCoordinatesforLayer = "mapPhysicalToScreenCoordinates:forLayer:";
+        private static readonly Selector sel_mapScreenToPhysicalCoordinatesforLayer = "mapScreenToPhysicalCoordinates:forLayer:";
+        private static readonly Selector sel_parameterBufferSizeAndAlign = "parameterBufferSizeAndAlign";
+        private static readonly Selector sel_physicalGranularity = "physicalGranularity";
+        private static readonly Selector sel_physicalSizeForLayer = "physicalSizeForLayer:";
+        private static readonly Selector sel_screenSize = "screenSize";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
+    public struct MTLRasterizationRateMapDescriptor : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLRasterizationRateMapDescriptor obj) => obj.NativePtr;
+        public MTLRasterizationRateMapDescriptor(IntPtr ptr) => NativePtr = ptr;
+
+        public MTLRasterizationRateMapDescriptor()
+        {
+            var cls = new ObjectiveCClass("MTLRasterizationRateMapDescriptor");
+            NativePtr = cls.AllocInit();
+        }
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public NSString Label
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
+        }
+
+        public ulong LayerCount => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_layerCount);
+
+        public MTLRasterizationRateLayerArray Layers => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_layers));
+
+        public MTLSize ScreenSize
+        {
+            get => ObjectiveCRuntime.MTLSize_objc_msgSend(NativePtr, sel_screenSize);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setScreenSize, value);
+        }
+
+        public MTLRasterizationRateLayerDescriptor Layer(ulong layerIndex)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_layerAtIndex, layerIndex));
+        }
+
+        public static MTLRasterizationRateMapDescriptor RasterizationRateMapDescriptor(MTLSize screenSize)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(new ObjectiveCClass("MTLRasterizationRateMapDescriptor"), sel_rasterizationRateMapDescriptorWithScreenSize, screenSize));
+        }
+
+        public static MTLRasterizationRateMapDescriptor RasterizationRateMapDescriptor(MTLSize screenSize, MTLRasterizationRateLayerDescriptor layer)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(new ObjectiveCClass("MTLRasterizationRateMapDescriptor"), sel_rasterizationRateMapDescriptorWithScreenSizelayer, screenSize, layer));
+        }
+
+        public static MTLRasterizationRateMapDescriptor RasterizationRateMapDescriptor(MTLSize screenSize, ulong layerCount, MTLRasterizationRateLayerDescriptor layers)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(new ObjectiveCClass("MTLRasterizationRateMapDescriptor"), sel_rasterizationRateMapDescriptorWithScreenSizelayerCountlayers, screenSize, layerCount, layers));
+        }
+
+        public void SetLayer(MTLRasterizationRateLayerDescriptor layer, ulong layerIndex)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLayeratIndex, layer, layerIndex);
+        }
+
+        private static readonly Selector sel_label = "label";
+        private static readonly Selector sel_layerAtIndex = "layerAtIndex:";
+        private static readonly Selector sel_layerCount = "layerCount";
+        private static readonly Selector sel_layers = "layers";
+        private static readonly Selector sel_rasterizationRateMapDescriptorWithScreenSize = "rasterizationRateMapDescriptorWithScreenSize:";
+        private static readonly Selector sel_rasterizationRateMapDescriptorWithScreenSizelayer = "rasterizationRateMapDescriptorWithScreenSize:layer:";
+        private static readonly Selector sel_rasterizationRateMapDescriptorWithScreenSizelayerCountlayers = "rasterizationRateMapDescriptorWithScreenSize:layerCount:layers:";
+        private static readonly Selector sel_screenSize = "screenSize";
+        private static readonly Selector sel_setLabel = "setLabel:";
+        private static readonly Selector sel_setLayeratIndex = "setLayer:atIndex:";
+        private static readonly Selector sel_setScreenSize = "setScreenSize:";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
+    public struct MTLRasterizationRateSampleArray : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLRasterizationRateSampleArray obj) => obj.NativePtr;
+        public MTLRasterizationRateSampleArray(IntPtr ptr) => NativePtr = ptr;
+
+        public MTLRasterizationRateSampleArray()
+        {
+            var cls = new ObjectiveCClass("MTLRasterizationRateSampleArray");
+            NativePtr = cls.AllocInit();
+        }
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public NSNumber Object(ulong index)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_objectAtIndexedSubscript, index));
+        }
+
+        public void SetObject(NSNumber value, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setObjectatIndexedSubscript, value, index);
+        }
+
+        private static readonly Selector sel_objectAtIndexedSubscript = "objectAtIndexedSubscript:";
+        private static readonly Selector sel_setObjectatIndexedSubscript = "setObject:atIndexedSubscript:";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLRenderCommandEncoder.cs
+++ b/src/SharpMetal/Metal/MTLRenderCommandEncoder.cs
@@ -6,36 +6,11 @@ using SharpMetal.Foundation;
 namespace SharpMetal.Metal
 {
     [SupportedOSPlatform("macos")]
-    public enum MTLPrimitiveType : ulong
-    {
-        Point = 0,
-        Line = 1,
-        LineStrip = 2,
-        Triangle = 3,
-        TriangleStrip = 4,
-    }
-
-    [SupportedOSPlatform("macos")]
-    public enum MTLVisibilityResultMode : ulong
-    {
-        Disabled = 0,
-        Boolean = 1,
-        Counting = 2,
-    }
-
-    [SupportedOSPlatform("macos")]
     public enum MTLCullMode : ulong
     {
         None = 0,
         Front = 1,
         Back = 2,
-    }
-
-    [SupportedOSPlatform("macos")]
-    public enum MTLWinding : ulong
-    {
-        Clockwise = 0,
-        CounterClockwise = 1,
     }
 
     [SupportedOSPlatform("macos")]
@@ -46,10 +21,13 @@ namespace SharpMetal.Metal
     }
 
     [SupportedOSPlatform("macos")]
-    public enum MTLTriangleFillMode : ulong
+    public enum MTLPrimitiveType : ulong
     {
-        Fill = 0,
-        Lines = 1,
+        Point = 0,
+        Line = 1,
+        LineStrip = 2,
+        Triangle = 3,
+        TriangleStrip = 4,
     }
 
     [SupportedOSPlatform("macos")]
@@ -64,35 +42,25 @@ namespace SharpMetal.Metal
     }
 
     [SupportedOSPlatform("macos")]
-    [StructLayout(LayoutKind.Sequential)]
-    public struct MTLScissorRect
+    public enum MTLTriangleFillMode : ulong
     {
-        public ulong x;
-        public ulong y;
-        public ulong width;
-        public ulong height;
+        Fill = 0,
+        Lines = 1,
     }
 
     [SupportedOSPlatform("macos")]
-    [StructLayout(LayoutKind.Sequential)]
-    public struct MTLViewport
+    public enum MTLVisibilityResultMode : ulong
     {
-        public double originX;
-        public double originY;
-        public double width;
-        public double height;
-        public double znear;
-        public double zfar;
+        Disabled = 0,
+        Boolean = 1,
+        Counting = 2,
     }
 
     [SupportedOSPlatform("macos")]
-    [StructLayout(LayoutKind.Sequential)]
-    public struct MTLDrawPrimitivesIndirectArguments
+    public enum MTLWinding : ulong
     {
-        public uint vertexCount;
-        public uint instanceCount;
-        public uint vertexStart;
-        public uint baseInstance;
+        Clockwise = 0,
+        CounterClockwise = 1,
     }
 
     [SupportedOSPlatform("macos")]
@@ -108,19 +76,21 @@ namespace SharpMetal.Metal
 
     [SupportedOSPlatform("macos")]
     [StructLayout(LayoutKind.Sequential)]
-    public struct MTLVertexAmplificationViewMapping
-    {
-        public uint viewportArrayIndexOffset;
-        public uint renderTargetArrayIndexOffset;
-    }
-
-    [SupportedOSPlatform("macos")]
-    [StructLayout(LayoutKind.Sequential)]
     public struct MTLDrawPatchIndirectArguments
     {
         public uint patchCount;
         public uint instanceCount;
         public uint patchStart;
+        public uint baseInstance;
+    }
+
+    [SupportedOSPlatform("macos")]
+    [StructLayout(LayoutKind.Sequential)]
+    public struct MTLDrawPrimitivesIndirectArguments
+    {
+        public uint vertexCount;
+        public uint instanceCount;
+        public uint vertexStart;
         public uint baseInstance;
     }
 
@@ -134,10 +104,40 @@ namespace SharpMetal.Metal
 
     [SupportedOSPlatform("macos")]
     [StructLayout(LayoutKind.Sequential)]
+    public struct MTLScissorRect
+    {
+        public ulong x;
+        public ulong y;
+        public ulong width;
+        public ulong height;
+    }
+
+    [SupportedOSPlatform("macos")]
+    [StructLayout(LayoutKind.Sequential)]
     public struct MTLTriangleTessellationFactorsHalf
     {
         public ushort edgeTessellationFactor;
         public ushort insideTessellationFactor;
+    }
+
+    [SupportedOSPlatform("macos")]
+    [StructLayout(LayoutKind.Sequential)]
+    public struct MTLVertexAmplificationViewMapping
+    {
+        public uint viewportArrayIndexOffset;
+        public uint renderTargetArrayIndexOffset;
+    }
+
+    [SupportedOSPlatform("macos")]
+    [StructLayout(LayoutKind.Sequential)]
+    public struct MTLViewport
+    {
+        public double originX;
+        public double originY;
+        public double width;
+        public double height;
+        public double znear;
+        public double zfar;
     }
 
     [SupportedOSPlatform("macos")]
@@ -153,10 +153,6 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public ulong TileWidth => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_tileWidth);
-
-        public ulong TileHeight => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_tileHeight);
-
         public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
 
         public NSString Label
@@ -165,124 +161,148 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
         }
 
-        public void SetRenderPipelineState(MTLRenderPipelineState pipelineState)
+        public ulong TileHeight => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_tileHeight);
+
+        public ulong TileWidth => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_tileWidth);
+
+        public void DispatchThreadsPerTile(MTLSize threadsPerTile)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRenderPipelineState, pipelineState);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_dispatchThreadsPerTile, threadsPerTile);
         }
 
-        public void SetVertexBytes(IntPtr bytes, ulong length, ulong index)
+        public void DrawIndexedPatches(ulong numberOfPatchControlPoints, MTLBuffer patchIndexBuffer, ulong patchIndexBufferOffset, MTLBuffer controlPointIndexBuffer, ulong controlPointIndexBufferOffset, MTLBuffer indirectBuffer, ulong indirectBufferOffset)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexByteslengthatIndex, bytes, length, index);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawIndexedPatchespatchIndexBufferpatchIndexBufferOffsetcontrolPointIndexBuffercontrolPointIndexBufferOffsetindirectBufferindirectBufferOffset, numberOfPatchControlPoints, patchIndexBuffer, patchIndexBufferOffset, controlPointIndexBuffer, controlPointIndexBufferOffset, indirectBuffer, indirectBufferOffset);
         }
 
-        public void SetVertexBuffer(MTLBuffer buffer, ulong offset, ulong index)
+        public void DrawIndexedPatches(ulong numberOfPatchControlPoints, ulong patchStart, ulong patchCount, MTLBuffer patchIndexBuffer, ulong patchIndexBufferOffset, MTLBuffer controlPointIndexBuffer, ulong controlPointIndexBufferOffset, ulong instanceCount, ulong baseInstance)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexBufferoffsetatIndex, buffer, offset, index);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawIndexedPatchespatchStartpatchCountpatchIndexBufferpatchIndexBufferOffsetcontrolPointIndexBuffercontrolPointIndexBufferOffsetinstanceCountbaseInstance, numberOfPatchControlPoints, patchStart, patchCount, patchIndexBuffer, patchIndexBufferOffset, controlPointIndexBuffer, controlPointIndexBufferOffset, instanceCount, baseInstance);
         }
 
-        public void SetVertexBufferOffset(ulong offset, ulong index)
+        public void DrawIndexedPrimitives(MTLPrimitiveType primitiveType, ulong indexCount, MTLIndexType indexType, MTLBuffer indexBuffer, ulong indexBufferOffset, ulong instanceCount)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexBufferOffsetatIndex, offset, index);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawIndexedPrimitivesindexCountindexTypeindexBufferindexBufferOffsetinstanceCount, (ulong)primitiveType, indexCount, (ulong)indexType, indexBuffer, indexBufferOffset, instanceCount);
         }
 
-        public void SetVertexBuffers(MTLBuffer[] buffers, ulong[] offsets, NSRange range)
+        public void DrawIndexedPrimitives(MTLPrimitiveType primitiveType, ulong indexCount, MTLIndexType indexType, MTLBuffer indexBuffer, ulong indexBufferOffset, ulong instanceCount, long baseVertex, ulong baseInstance)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawIndexedPrimitivesindexCountindexTypeindexBufferindexBufferOffsetinstanceCountbaseVertexbaseInstance, (ulong)primitiveType, indexCount, (ulong)indexType, indexBuffer, indexBufferOffset, instanceCount, baseVertex, baseInstance);
+        }
+
+        public void DrawIndexedPrimitives(MTLPrimitiveType primitiveType, MTLIndexType indexType, MTLBuffer indexBuffer, ulong indexBufferOffset, MTLBuffer indirectBuffer, ulong indirectBufferOffset)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawIndexedPrimitivesindexTypeindexBufferindexBufferOffsetindirectBufferindirectBufferOffset, (ulong)primitiveType, (ulong)indexType, indexBuffer, indexBufferOffset, indirectBuffer, indirectBufferOffset);
+        }
+
+        public void DrawIndexedPrimitives(MTLPrimitiveType primitiveType, ulong indexCount, MTLIndexType indexType, MTLBuffer indexBuffer, ulong indexBufferOffset)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawIndexedPrimitivesindexCountindexTypeindexBufferindexBufferOffset, (ulong)primitiveType, indexCount, (ulong)indexType, indexBuffer, indexBufferOffset);
+        }
+
+        public void DrawMeshThreadgroups(MTLSize threadgroupsPerGrid, MTLSize threadsPerObjectThreadgroup, MTLSize threadsPerMeshThreadgroup)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawMeshThreadgroupsthreadsPerObjectThreadgroupthreadsPerMeshThreadgroup, threadgroupsPerGrid, threadsPerObjectThreadgroup, threadsPerMeshThreadgroup);
+        }
+
+        public void DrawMeshThreadgroups(MTLBuffer indirectBuffer, ulong indirectBufferOffset, MTLSize threadsPerObjectThreadgroup, MTLSize threadsPerMeshThreadgroup)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawMeshThreadgroupsWithIndirectBufferindirectBufferOffsetthreadsPerObjectThreadgroupthreadsPerMeshThreadgroup, indirectBuffer, indirectBufferOffset, threadsPerObjectThreadgroup, threadsPerMeshThreadgroup);
+        }
+
+        public void DrawMeshThreads(MTLSize threadsPerGrid, MTLSize threadsPerObjectThreadgroup, MTLSize threadsPerMeshThreadgroup)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawMeshThreadsthreadsPerObjectThreadgroupthreadsPerMeshThreadgroup, threadsPerGrid, threadsPerObjectThreadgroup, threadsPerMeshThreadgroup);
+        }
+
+        public void DrawPatches(ulong numberOfPatchControlPoints, MTLBuffer patchIndexBuffer, ulong patchIndexBufferOffset, MTLBuffer indirectBuffer, ulong indirectBufferOffset)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawPatchespatchIndexBufferpatchIndexBufferOffsetindirectBufferindirectBufferOffset, numberOfPatchControlPoints, patchIndexBuffer, patchIndexBufferOffset, indirectBuffer, indirectBufferOffset);
+        }
+
+        public void DrawPatches(ulong numberOfPatchControlPoints, ulong patchStart, ulong patchCount, MTLBuffer patchIndexBuffer, ulong patchIndexBufferOffset, ulong instanceCount, ulong baseInstance)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawPatchespatchStartpatchCountpatchIndexBufferpatchIndexBufferOffsetinstanceCountbaseInstance, numberOfPatchControlPoints, patchStart, patchCount, patchIndexBuffer, patchIndexBufferOffset, instanceCount, baseInstance);
+        }
+
+        public void DrawPrimitives(MTLPrimitiveType primitiveType, ulong vertexStart, ulong vertexCount)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawPrimitivesvertexStartvertexCount, (ulong)primitiveType, vertexStart, vertexCount);
+        }
+
+        public void DrawPrimitives(MTLPrimitiveType primitiveType, MTLBuffer indirectBuffer, ulong indirectBufferOffset)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawPrimitivesindirectBufferindirectBufferOffset, (ulong)primitiveType, indirectBuffer, indirectBufferOffset);
+        }
+
+        public void DrawPrimitives(MTLPrimitiveType primitiveType, ulong vertexStart, ulong vertexCount, ulong instanceCount, ulong baseInstance)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawPrimitivesvertexStartvertexCountinstanceCountbaseInstance, (ulong)primitiveType, vertexStart, vertexCount, instanceCount, baseInstance);
+        }
+
+        public void DrawPrimitives(MTLPrimitiveType primitiveType, ulong vertexStart, ulong vertexCount, ulong instanceCount)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawPrimitivesvertexStartvertexCountinstanceCount, (ulong)primitiveType, vertexStart, vertexCount, instanceCount);
+        }
+
+        public void EndEncoding()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_endEncoding);
+        }
+
+        public void ExecuteCommandsInBuffer(MTLIndirectCommandBuffer indirectCommandbuffer, MTLBuffer indirectRangeBuffer, ulong indirectBufferOffset)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_executeCommandsInBufferindirectBufferindirectBufferOffset, indirectCommandbuffer, indirectRangeBuffer, indirectBufferOffset);
+        }
+
+        public void ExecuteCommandsInBuffer(MTLIndirectCommandBuffer indirectCommandBuffer, NSRange executionRange)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_executeCommandsInBufferwithRange, indirectCommandBuffer, executionRange);
+        }
+
+        public void InsertDebugSignpost(NSString nsString)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_insertDebugSignpost, nsString);
+        }
+
+        public void MemoryBarrier(MTLResource[] resources, ulong count, MTLRenderStages after, MTLRenderStages before)
         {
             throw new NotImplementedException();
         }
 
-        public void SetVertexBuffer(MTLBuffer buffer, ulong offset, ulong stride, ulong index)
+        public void MemoryBarrier(MTLBarrierScope scope, MTLRenderStages after, MTLRenderStages before)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexBufferoffsetattributeStrideatIndex, buffer, offset, stride, index);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_memoryBarrierWithScopeafterStagesbeforeStages, (ulong)scope, (ulong)after, (ulong)before);
         }
 
-        public void SetVertexBuffers(MTLBuffer[] buffers, ulong offsets, ulong strides, NSRange range)
+        public void PopDebugGroup()
         {
-            throw new NotImplementedException();
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_popDebugGroup);
         }
 
-        public void SetVertexBufferOffset(ulong offset, ulong stride, ulong index)
+        public void PushDebugGroup(NSString nsString)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexBufferOffsetattributeStrideatIndex, offset, stride, index);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_pushDebugGroup, nsString);
         }
 
-        public void SetVertexBytes(IntPtr bytes, ulong length, ulong stride, ulong index)
+        public void SampleCountersInBuffer(MTLCounterSampleBuffer sampleBuffer, ulong sampleIndex, bool barrier)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexByteslengthattributeStrideatIndex, bytes, length, stride, index);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_sampleCountersInBufferatSampleIndexwithBarrier, sampleBuffer, sampleIndex, barrier);
         }
 
-        public void SetVertexTexture(MTLTexture texture, ulong index)
+        public void SetBlendColor(float red, float green, float blue, float alpha)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexTextureatIndex, texture, index);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBlendColorRedgreenbluealpha, red, green, blue, alpha);
         }
 
-        public void SetVertexTextures(MTLTexture[] textures, NSRange range)
+        public void SetColorStoreAction(MTLStoreAction storeAction, ulong colorAttachmentIndex)
         {
-            throw new NotImplementedException();
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setColorStoreActionatIndex, (ulong)storeAction, colorAttachmentIndex);
         }
 
-        public void SetVertexSamplerState(MTLSamplerState sampler, ulong index)
+        public void SetColorStoreActionOptions(MTLStoreActionOptions storeActionOptions, ulong colorAttachmentIndex)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexSamplerStateatIndex, sampler, index);
-        }
-
-        public void SetVertexSamplerStates(MTLSamplerState[] samplers, NSRange range)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void SetVertexSamplerState(MTLSamplerState sampler, float lodMinClamp, float lodMaxClamp, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexSamplerStatelodMinClamplodMaxClampatIndex, sampler, lodMinClamp, lodMaxClamp, index);
-        }
-
-        public void SetVertexSamplerStates(MTLSamplerState[] samplers, float[] lodMinClamps, float[] lodMaxClamps, NSRange range)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void SetVertexVisibleFunctionTable(MTLVisibleFunctionTable functionTable, ulong bufferIndex)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexVisibleFunctionTableatBufferIndex, functionTable, bufferIndex);
-        }
-
-        public void SetVertexVisibleFunctionTables(MTLVisibleFunctionTable[] functionTables, NSRange range)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void SetVertexIntersectionFunctionTable(MTLIntersectionFunctionTable intersectionFunctionTable, ulong bufferIndex)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexIntersectionFunctionTableatBufferIndex, intersectionFunctionTable, bufferIndex);
-        }
-
-        public void SetVertexIntersectionFunctionTables(MTLIntersectionFunctionTable[] intersectionFunctionTables, NSRange range)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void SetVertexAccelerationStructure(MTLAccelerationStructure accelerationStructure, ulong bufferIndex)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexAccelerationStructureatBufferIndex, accelerationStructure, bufferIndex);
-        }
-
-        public void SetViewport(MTLViewport viewport)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setViewport, viewport);
-        }
-
-        public void SetViewports(IntPtr viewports, ulong count)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setViewportscount, viewports, count);
-        }
-
-        public void SetFrontFacingWinding(MTLWinding frontFacingWinding)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFrontFacingWinding, (ulong)frontFacingWinding);
-        }
-
-        public void SetVertexAmplificationCount(ulong count, MTLVertexAmplificationViewMapping viewMappings)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexAmplificationCountviewMappings, count, viewMappings);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setColorStoreActionOptionsatIndex, (ulong)storeActionOptions, colorAttachmentIndex);
         }
 
         public void SetCullMode(MTLCullMode cullMode)
@@ -290,34 +310,34 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setCullMode, (ulong)cullMode);
         }
 
-        public void SetDepthClipMode(MTLDepthClipMode depthClipMode)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDepthClipMode, (ulong)depthClipMode);
-        }
-
         public void SetDepthBias(float depthBias, float slopeScale, float clamp)
         {
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDepthBiasslopeScaleclamp, depthBias, slopeScale, clamp);
         }
 
-        public void SetScissorRect(MTLScissorRect rect)
+        public void SetDepthClipMode(MTLDepthClipMode depthClipMode)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setScissorRect, rect);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDepthClipMode, (ulong)depthClipMode);
         }
 
-        public void SetScissorRects(IntPtr scissorRects, ulong count)
+        public void SetDepthStencilState(MTLDepthStencilState depthStencilState)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setScissorRectscount, scissorRects, count);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDepthStencilState, depthStencilState);
         }
 
-        public void SetTriangleFillMode(MTLTriangleFillMode fillMode)
+        public void SetDepthStoreAction(MTLStoreAction storeAction)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTriangleFillMode, (ulong)fillMode);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDepthStoreAction, (ulong)storeAction);
         }
 
-        public void SetFragmentBytes(IntPtr bytes, ulong length, ulong index)
+        public void SetDepthStoreActionOptions(MTLStoreActionOptions storeActionOptions)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFragmentByteslengthatIndex, bytes, length, index);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDepthStoreActionOptions, (ulong)storeActionOptions);
+        }
+
+        public void SetFragmentAccelerationStructure(MTLAccelerationStructure accelerationStructure, ulong bufferIndex)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFragmentAccelerationStructureatBufferIndex, accelerationStructure, bufferIndex);
         }
 
         public void SetFragmentBuffer(MTLBuffer buffer, ulong offset, ulong index)
@@ -335,22 +355,17 @@ namespace SharpMetal.Metal
             throw new NotImplementedException();
         }
 
-        public void SetFragmentTexture(MTLTexture texture, ulong index)
+        public void SetFragmentBytes(IntPtr bytes, ulong length, ulong index)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFragmentTextureatIndex, texture, index);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFragmentByteslengthatIndex, bytes, length, index);
         }
 
-        public void SetFragmentTextures(MTLTexture[] textures, NSRange range)
+        public void SetFragmentIntersectionFunctionTable(MTLIntersectionFunctionTable intersectionFunctionTable, ulong bufferIndex)
         {
-            throw new NotImplementedException();
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFragmentIntersectionFunctionTableatBufferIndex, intersectionFunctionTable, bufferIndex);
         }
 
-        public void SetFragmentSamplerState(MTLSamplerState sampler, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFragmentSamplerStateatIndex, sampler, index);
-        }
-
-        public void SetFragmentSamplerStates(MTLSamplerState[] samplers, NSRange range)
+        public void SetFragmentIntersectionFunctionTables(MTLIntersectionFunctionTable[] intersectionFunctionTables, NSRange range)
         {
             throw new NotImplementedException();
         }
@@ -360,7 +375,27 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFragmentSamplerStatelodMinClamplodMaxClampatIndex, sampler, lodMinClamp, lodMaxClamp, index);
         }
 
+        public void SetFragmentSamplerState(MTLSamplerState sampler, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFragmentSamplerStateatIndex, sampler, index);
+        }
+
         public void SetFragmentSamplerStates(MTLSamplerState[] samplers, float[] lodMinClamps, float[] lodMaxClamps, NSRange range)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SetFragmentSamplerStates(MTLSamplerState[] samplers, NSRange range)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SetFragmentTexture(MTLTexture texture, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFragmentTextureatIndex, texture, index);
+        }
+
+        public void SetFragmentTextures(MTLTexture[] textures, NSRange range)
         {
             throw new NotImplementedException();
         }
@@ -375,134 +410,9 @@ namespace SharpMetal.Metal
             throw new NotImplementedException();
         }
 
-        public void SetFragmentIntersectionFunctionTable(MTLIntersectionFunctionTable intersectionFunctionTable, ulong bufferIndex)
+        public void SetFrontFacingWinding(MTLWinding frontFacingWinding)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFragmentIntersectionFunctionTableatBufferIndex, intersectionFunctionTable, bufferIndex);
-        }
-
-        public void SetFragmentIntersectionFunctionTables(MTLIntersectionFunctionTable[] intersectionFunctionTables, NSRange range)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void SetFragmentAccelerationStructure(MTLAccelerationStructure accelerationStructure, ulong bufferIndex)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFragmentAccelerationStructureatBufferIndex, accelerationStructure, bufferIndex);
-        }
-
-        public void SetBlendColor(float red, float green, float blue, float alpha)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBlendColorRedgreenbluealpha, red, green, blue, alpha);
-        }
-
-        public void SetDepthStencilState(MTLDepthStencilState depthStencilState)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDepthStencilState, depthStencilState);
-        }
-
-        public void SetStencilReferenceValue(uint referenceValue)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStencilReferenceValue, referenceValue);
-        }
-
-        public void SetStencilReferenceValues(uint frontReferenceValue, uint backReferenceValue)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStencilFrontReferenceValuebackReferenceValue, frontReferenceValue, backReferenceValue);
-        }
-
-        public void SetVisibilityResultMode(MTLVisibilityResultMode mode, ulong offset)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVisibilityResultModeoffset, (ulong)mode, offset);
-        }
-
-        public void SetColorStoreAction(MTLStoreAction storeAction, ulong colorAttachmentIndex)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setColorStoreActionatIndex, (ulong)storeAction, colorAttachmentIndex);
-        }
-
-        public void SetDepthStoreAction(MTLStoreAction storeAction)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDepthStoreAction, (ulong)storeAction);
-        }
-
-        public void SetStencilStoreAction(MTLStoreAction storeAction)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStencilStoreAction, (ulong)storeAction);
-        }
-
-        public void SetColorStoreActionOptions(MTLStoreActionOptions storeActionOptions, ulong colorAttachmentIndex)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setColorStoreActionOptionsatIndex, (ulong)storeActionOptions, colorAttachmentIndex);
-        }
-
-        public void SetDepthStoreActionOptions(MTLStoreActionOptions storeActionOptions)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDepthStoreActionOptions, (ulong)storeActionOptions);
-        }
-
-        public void SetStencilStoreActionOptions(MTLStoreActionOptions storeActionOptions)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStencilStoreActionOptions, (ulong)storeActionOptions);
-        }
-
-        public void SetObjectBytes(IntPtr bytes, ulong length, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setObjectByteslengthatIndex, bytes, length, index);
-        }
-
-        public void SetObjectBuffer(MTLBuffer buffer, ulong offset, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setObjectBufferoffsetatIndex, buffer, offset, index);
-        }
-
-        public void SetObjectBufferOffset(ulong offset, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setObjectBufferOffsetatIndex, offset, index);
-        }
-
-        public void SetObjectBuffers(MTLBuffer[] buffers, ulong offsets, NSRange range)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void SetObjectTexture(MTLTexture texture, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setObjectTextureatIndex, texture, index);
-        }
-
-        public void SetObjectTextures(MTLTexture[] textures, NSRange range)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void SetObjectSamplerState(MTLSamplerState sampler, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setObjectSamplerStateatIndex, sampler, index);
-        }
-
-        public void SetObjectSamplerStates(MTLSamplerState[] samplers, NSRange range)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void SetObjectSamplerState(MTLSamplerState sampler, float lodMinClamp, float lodMaxClamp, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setObjectSamplerStatelodMinClamplodMaxClampatIndex, sampler, lodMinClamp, lodMaxClamp, index);
-        }
-
-        public void SetObjectSamplerStates(MTLSamplerState[] samplers, float lodMinClamps, float lodMaxClamps, NSRange range)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void SetObjectThreadgroupMemoryLength(ulong length, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setObjectThreadgroupMemoryLengthatIndex, length, index);
-        }
-
-        public void SetMeshBytes(IntPtr bytes, ulong length, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMeshByteslengthatIndex, bytes, length, index);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFrontFacingWinding, (ulong)frontFacingWinding);
         }
 
         public void SetMeshBuffer(MTLBuffer buffer, ulong offset, ulong index)
@@ -520,6 +430,31 @@ namespace SharpMetal.Metal
             throw new NotImplementedException();
         }
 
+        public void SetMeshBytes(IntPtr bytes, ulong length, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMeshByteslengthatIndex, bytes, length, index);
+        }
+
+        public void SetMeshSamplerState(MTLSamplerState sampler, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMeshSamplerStateatIndex, sampler, index);
+        }
+
+        public void SetMeshSamplerState(MTLSamplerState sampler, float lodMinClamp, float lodMaxClamp, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMeshSamplerStatelodMinClamplodMaxClampatIndex, sampler, lodMinClamp, lodMaxClamp, index);
+        }
+
+        public void SetMeshSamplerStates(MTLSamplerState[] samplers, NSRange range)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SetMeshSamplerStates(MTLSamplerState[] samplers, float lodMinClamps, float lodMaxClamps, NSRange range)
+        {
+            throw new NotImplementedException();
+        }
+
         public void SetMeshTexture(MTLTexture texture, ulong index)
         {
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMeshTextureatIndex, texture, index);
@@ -530,94 +465,94 @@ namespace SharpMetal.Metal
             throw new NotImplementedException();
         }
 
-        public void SetMeshSamplerState(MTLSamplerState sampler, ulong index)
+        public void SetObjectBuffer(MTLBuffer buffer, ulong offset, ulong index)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMeshSamplerStateatIndex, sampler, index);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setObjectBufferoffsetatIndex, buffer, offset, index);
         }
 
-        public void SetMeshSamplerStates(MTLSamplerState[] samplers, NSRange range)
+        public void SetObjectBufferOffset(ulong offset, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setObjectBufferOffsetatIndex, offset, index);
+        }
+
+        public void SetObjectBuffers(MTLBuffer[] buffers, ulong offsets, NSRange range)
         {
             throw new NotImplementedException();
         }
 
-        public void SetMeshSamplerState(MTLSamplerState sampler, float lodMinClamp, float lodMaxClamp, ulong index)
+        public void SetObjectBytes(IntPtr bytes, ulong length, ulong index)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMeshSamplerStatelodMinClamplodMaxClampatIndex, sampler, lodMinClamp, lodMaxClamp, index);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setObjectByteslengthatIndex, bytes, length, index);
         }
 
-        public void SetMeshSamplerStates(MTLSamplerState[] samplers, float lodMinClamps, float lodMaxClamps, NSRange range)
+        public void SetObjectSamplerState(MTLSamplerState sampler, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setObjectSamplerStateatIndex, sampler, index);
+        }
+
+        public void SetObjectSamplerState(MTLSamplerState sampler, float lodMinClamp, float lodMaxClamp, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setObjectSamplerStatelodMinClamplodMaxClampatIndex, sampler, lodMinClamp, lodMaxClamp, index);
+        }
+
+        public void SetObjectSamplerStates(MTLSamplerState[] samplers, float lodMinClamps, float lodMaxClamps, NSRange range)
         {
             throw new NotImplementedException();
         }
 
-        public void DrawMeshThreadgroups(MTLSize threadgroupsPerGrid, MTLSize threadsPerObjectThreadgroup, MTLSize threadsPerMeshThreadgroup)
+        public void SetObjectSamplerStates(MTLSamplerState[] samplers, NSRange range)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawMeshThreadgroupsthreadsPerObjectThreadgroupthreadsPerMeshThreadgroup, threadgroupsPerGrid, threadsPerObjectThreadgroup, threadsPerMeshThreadgroup);
+            throw new NotImplementedException();
         }
 
-        public void DrawMeshThreads(MTLSize threadsPerGrid, MTLSize threadsPerObjectThreadgroup, MTLSize threadsPerMeshThreadgroup)
+        public void SetObjectTexture(MTLTexture texture, ulong index)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawMeshThreadsthreadsPerObjectThreadgroupthreadsPerMeshThreadgroup, threadsPerGrid, threadsPerObjectThreadgroup, threadsPerMeshThreadgroup);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setObjectTextureatIndex, texture, index);
         }
 
-        public void DrawMeshThreadgroups(MTLBuffer indirectBuffer, ulong indirectBufferOffset, MTLSize threadsPerObjectThreadgroup, MTLSize threadsPerMeshThreadgroup)
+        public void SetObjectTextures(MTLTexture[] textures, NSRange range)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawMeshThreadgroupsWithIndirectBufferindirectBufferOffsetthreadsPerObjectThreadgroupthreadsPerMeshThreadgroup, indirectBuffer, indirectBufferOffset, threadsPerObjectThreadgroup, threadsPerMeshThreadgroup);
+            throw new NotImplementedException();
         }
 
-        public void DrawPrimitives(MTLPrimitiveType primitiveType, ulong vertexStart, ulong vertexCount, ulong instanceCount)
+        public void SetObjectThreadgroupMemoryLength(ulong length, ulong index)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawPrimitivesvertexStartvertexCountinstanceCount, (ulong)primitiveType, vertexStart, vertexCount, instanceCount);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setObjectThreadgroupMemoryLengthatIndex, length, index);
         }
 
-        public void DrawPrimitives(MTLPrimitiveType primitiveType, ulong vertexStart, ulong vertexCount)
+        public void SetRenderPipelineState(MTLRenderPipelineState pipelineState)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawPrimitivesvertexStartvertexCount, (ulong)primitiveType, vertexStart, vertexCount);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRenderPipelineState, pipelineState);
         }
 
-        public void DrawIndexedPrimitives(MTLPrimitiveType primitiveType, ulong indexCount, MTLIndexType indexType, MTLBuffer indexBuffer, ulong indexBufferOffset, ulong instanceCount)
+        public void SetScissorRect(MTLScissorRect rect)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawIndexedPrimitivesindexCountindexTypeindexBufferindexBufferOffsetinstanceCount, (ulong)primitiveType, indexCount, (ulong)indexType, indexBuffer, indexBufferOffset, instanceCount);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setScissorRect, rect);
         }
 
-        public void DrawIndexedPrimitives(MTLPrimitiveType primitiveType, ulong indexCount, MTLIndexType indexType, MTLBuffer indexBuffer, ulong indexBufferOffset)
+        public void SetScissorRects(IntPtr scissorRects, ulong count)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawIndexedPrimitivesindexCountindexTypeindexBufferindexBufferOffset, (ulong)primitiveType, indexCount, (ulong)indexType, indexBuffer, indexBufferOffset);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setScissorRectscount, scissorRects, count);
         }
 
-        public void DrawPrimitives(MTLPrimitiveType primitiveType, ulong vertexStart, ulong vertexCount, ulong instanceCount, ulong baseInstance)
+        public void SetStencilReferenceValue(uint referenceValue)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawPrimitivesvertexStartvertexCountinstanceCountbaseInstance, (ulong)primitiveType, vertexStart, vertexCount, instanceCount, baseInstance);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStencilReferenceValue, referenceValue);
         }
 
-        public void DrawIndexedPrimitives(MTLPrimitiveType primitiveType, ulong indexCount, MTLIndexType indexType, MTLBuffer indexBuffer, ulong indexBufferOffset, ulong instanceCount, long baseVertex, ulong baseInstance)
+        public void SetStencilReferenceValues(uint frontReferenceValue, uint backReferenceValue)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawIndexedPrimitivesindexCountindexTypeindexBufferindexBufferOffsetinstanceCountbaseVertexbaseInstance, (ulong)primitiveType, indexCount, (ulong)indexType, indexBuffer, indexBufferOffset, instanceCount, baseVertex, baseInstance);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStencilFrontReferenceValuebackReferenceValue, frontReferenceValue, backReferenceValue);
         }
 
-        public void DrawPrimitives(MTLPrimitiveType primitiveType, MTLBuffer indirectBuffer, ulong indirectBufferOffset)
+        public void SetStencilStoreAction(MTLStoreAction storeAction)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawPrimitivesindirectBufferindirectBufferOffset, (ulong)primitiveType, indirectBuffer, indirectBufferOffset);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStencilStoreAction, (ulong)storeAction);
         }
 
-        public void DrawIndexedPrimitives(MTLPrimitiveType primitiveType, MTLIndexType indexType, MTLBuffer indexBuffer, ulong indexBufferOffset, MTLBuffer indirectBuffer, ulong indirectBufferOffset)
+        public void SetStencilStoreActionOptions(MTLStoreActionOptions storeActionOptions)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawIndexedPrimitivesindexTypeindexBufferindexBufferOffsetindirectBufferindirectBufferOffset, (ulong)primitiveType, (ulong)indexType, indexBuffer, indexBufferOffset, indirectBuffer, indirectBufferOffset);
-        }
-
-        public void TextureBarrier()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_textureBarrier);
-        }
-
-        public void UpdateFence(MTLFence fence, MTLRenderStages stages)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_updateFenceafterStages, fence, (ulong)stages);
-        }
-
-        public void WaitForFence(MTLFence fence, MTLRenderStages stages)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_waitForFencebeforeStages, fence, (ulong)stages);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStencilStoreActionOptions, (ulong)storeActionOptions);
         }
 
         public void SetTessellationFactorBuffer(MTLBuffer buffer, ulong offset, ulong instanceStride)
@@ -630,29 +565,14 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTessellationFactorScale, scale);
         }
 
-        public void DrawPatches(ulong numberOfPatchControlPoints, ulong patchStart, ulong patchCount, MTLBuffer patchIndexBuffer, ulong patchIndexBufferOffset, ulong instanceCount, ulong baseInstance)
+        public void SetThreadgroupMemoryLength(ulong length, ulong offset, ulong index)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawPatchespatchStartpatchCountpatchIndexBufferpatchIndexBufferOffsetinstanceCountbaseInstance, numberOfPatchControlPoints, patchStart, patchCount, patchIndexBuffer, patchIndexBufferOffset, instanceCount, baseInstance);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setThreadgroupMemoryLengthoffsetatIndex, length, offset, index);
         }
 
-        public void DrawPatches(ulong numberOfPatchControlPoints, MTLBuffer patchIndexBuffer, ulong patchIndexBufferOffset, MTLBuffer indirectBuffer, ulong indirectBufferOffset)
+        public void SetTileAccelerationStructure(MTLAccelerationStructure accelerationStructure, ulong bufferIndex)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawPatchespatchIndexBufferpatchIndexBufferOffsetindirectBufferindirectBufferOffset, numberOfPatchControlPoints, patchIndexBuffer, patchIndexBufferOffset, indirectBuffer, indirectBufferOffset);
-        }
-
-        public void DrawIndexedPatches(ulong numberOfPatchControlPoints, ulong patchStart, ulong patchCount, MTLBuffer patchIndexBuffer, ulong patchIndexBufferOffset, MTLBuffer controlPointIndexBuffer, ulong controlPointIndexBufferOffset, ulong instanceCount, ulong baseInstance)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawIndexedPatchespatchStartpatchCountpatchIndexBufferpatchIndexBufferOffsetcontrolPointIndexBuffercontrolPointIndexBufferOffsetinstanceCountbaseInstance, numberOfPatchControlPoints, patchStart, patchCount, patchIndexBuffer, patchIndexBufferOffset, controlPointIndexBuffer, controlPointIndexBufferOffset, instanceCount, baseInstance);
-        }
-
-        public void DrawIndexedPatches(ulong numberOfPatchControlPoints, MTLBuffer patchIndexBuffer, ulong patchIndexBufferOffset, MTLBuffer controlPointIndexBuffer, ulong controlPointIndexBufferOffset, MTLBuffer indirectBuffer, ulong indirectBufferOffset)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_drawIndexedPatchespatchIndexBufferpatchIndexBufferOffsetcontrolPointIndexBuffercontrolPointIndexBufferOffsetindirectBufferindirectBufferOffset, numberOfPatchControlPoints, patchIndexBuffer, patchIndexBufferOffset, controlPointIndexBuffer, controlPointIndexBufferOffset, indirectBuffer, indirectBufferOffset);
-        }
-
-        public void SetTileBytes(IntPtr bytes, ulong length, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTileByteslengthatIndex, bytes, length, index);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTileAccelerationStructureatBufferIndex, accelerationStructure, bufferIndex);
         }
 
         public void SetTileBuffer(MTLBuffer buffer, ulong offset, ulong index)
@@ -670,12 +590,17 @@ namespace SharpMetal.Metal
             throw new NotImplementedException();
         }
 
-        public void SetTileTexture(MTLTexture texture, ulong index)
+        public void SetTileBytes(IntPtr bytes, ulong length, ulong index)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTileTextureatIndex, texture, index);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTileByteslengthatIndex, bytes, length, index);
         }
 
-        public void SetTileTextures(MTLTexture[] textures, NSRange range)
+        public void SetTileIntersectionFunctionTable(MTLIntersectionFunctionTable intersectionFunctionTable, ulong bufferIndex)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTileIntersectionFunctionTableatBufferIndex, intersectionFunctionTable, bufferIndex);
+        }
+
+        public void SetTileIntersectionFunctionTables(MTLIntersectionFunctionTable[] intersectionFunctionTables, NSRange range)
         {
             throw new NotImplementedException();
         }
@@ -685,17 +610,27 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTileSamplerStateatIndex, sampler, index);
         }
 
-        public void SetTileSamplerStates(MTLSamplerState[] samplers, NSRange range)
-        {
-            throw new NotImplementedException();
-        }
-
         public void SetTileSamplerState(MTLSamplerState sampler, float lodMinClamp, float lodMaxClamp, ulong index)
         {
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTileSamplerStatelodMinClamplodMaxClampatIndex, sampler, lodMinClamp, lodMaxClamp, index);
         }
 
+        public void SetTileSamplerStates(MTLSamplerState[] samplers, NSRange range)
+        {
+            throw new NotImplementedException();
+        }
+
         public void SetTileSamplerStates(MTLSamplerState[] samplers, float[] lodMinClamps, float[] lodMaxClamps, NSRange range)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SetTileTexture(MTLTexture texture, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTileTextureatIndex, texture, index);
+        }
+
+        public void SetTileTextures(MTLTexture[] textures, NSRange range)
         {
             throw new NotImplementedException();
         }
@@ -710,37 +645,152 @@ namespace SharpMetal.Metal
             throw new NotImplementedException();
         }
 
-        public void SetTileIntersectionFunctionTable(MTLIntersectionFunctionTable intersectionFunctionTable, ulong bufferIndex)
+        public void SetTriangleFillMode(MTLTriangleFillMode fillMode)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTileIntersectionFunctionTableatBufferIndex, intersectionFunctionTable, bufferIndex);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTriangleFillMode, (ulong)fillMode);
         }
 
-        public void SetTileIntersectionFunctionTables(MTLIntersectionFunctionTable[] intersectionFunctionTables, NSRange range)
+        public void SetVertexAccelerationStructure(MTLAccelerationStructure accelerationStructure, ulong bufferIndex)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexAccelerationStructureatBufferIndex, accelerationStructure, bufferIndex);
+        }
+
+        public void SetVertexAmplificationCount(ulong count, MTLVertexAmplificationViewMapping viewMappings)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexAmplificationCountviewMappings, count, viewMappings);
+        }
+
+        public void SetVertexBuffer(MTLBuffer buffer, ulong offset, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexBufferoffsetatIndex, buffer, offset, index);
+        }
+
+        public void SetVertexBuffer(MTLBuffer buffer, ulong offset, ulong stride, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexBufferoffsetattributeStrideatIndex, buffer, offset, stride, index);
+        }
+
+        public void SetVertexBufferOffset(ulong offset, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexBufferOffsetatIndex, offset, index);
+        }
+
+        public void SetVertexBufferOffset(ulong offset, ulong stride, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexBufferOffsetattributeStrideatIndex, offset, stride, index);
+        }
+
+        public void SetVertexBuffers(MTLBuffer[] buffers, ulong[] offsets, NSRange range)
         {
             throw new NotImplementedException();
         }
 
-        public void SetTileAccelerationStructure(MTLAccelerationStructure accelerationStructure, ulong bufferIndex)
+        public void SetVertexBuffers(MTLBuffer[] buffers, ulong offsets, ulong strides, NSRange range)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTileAccelerationStructureatBufferIndex, accelerationStructure, bufferIndex);
+            throw new NotImplementedException();
         }
 
-        public void DispatchThreadsPerTile(MTLSize threadsPerTile)
+        public void SetVertexBytes(IntPtr bytes, ulong length, ulong index)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_dispatchThreadsPerTile, threadsPerTile);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexByteslengthatIndex, bytes, length, index);
         }
 
-        public void SetThreadgroupMemoryLength(ulong length, ulong offset, ulong index)
+        public void SetVertexBytes(IntPtr bytes, ulong length, ulong stride, ulong index)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setThreadgroupMemoryLengthoffsetatIndex, length, offset, index);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexByteslengthattributeStrideatIndex, bytes, length, stride, index);
         }
 
-        public void UseResource(MTLResource resource, MTLResourceUsage usage)
+        public void SetVertexIntersectionFunctionTable(MTLIntersectionFunctionTable intersectionFunctionTable, ulong bufferIndex)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_useResourceusage, resource, (ulong)usage);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexIntersectionFunctionTableatBufferIndex, intersectionFunctionTable, bufferIndex);
         }
 
-        public void UseResources(MTLResource[] resources, ulong count, MTLResourceUsage usage)
+        public void SetVertexIntersectionFunctionTables(MTLIntersectionFunctionTable[] intersectionFunctionTables, NSRange range)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SetVertexSamplerState(MTLSamplerState sampler, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexSamplerStateatIndex, sampler, index);
+        }
+
+        public void SetVertexSamplerState(MTLSamplerState sampler, float lodMinClamp, float lodMaxClamp, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexSamplerStatelodMinClamplodMaxClampatIndex, sampler, lodMinClamp, lodMaxClamp, index);
+        }
+
+        public void SetVertexSamplerStates(MTLSamplerState[] samplers, NSRange range)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SetVertexSamplerStates(MTLSamplerState[] samplers, float[] lodMinClamps, float[] lodMaxClamps, NSRange range)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SetVertexTexture(MTLTexture texture, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexTextureatIndex, texture, index);
+        }
+
+        public void SetVertexTextures(MTLTexture[] textures, NSRange range)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SetVertexVisibleFunctionTable(MTLVisibleFunctionTable functionTable, ulong bufferIndex)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexVisibleFunctionTableatBufferIndex, functionTable, bufferIndex);
+        }
+
+        public void SetVertexVisibleFunctionTables(MTLVisibleFunctionTable[] functionTables, NSRange range)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SetViewport(MTLViewport viewport)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setViewport, viewport);
+        }
+
+        public void SetViewports(IntPtr viewports, ulong count)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setViewportscount, viewports, count);
+        }
+
+        public void SetVisibilityResultMode(MTLVisibilityResultMode mode, ulong offset)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVisibilityResultModeoffset, (ulong)mode, offset);
+        }
+
+        public void TextureBarrier()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_textureBarrier);
+        }
+
+        public void UpdateFence(MTLFence fence, MTLRenderStages stages)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_updateFenceafterStages, fence, (ulong)stages);
+        }
+
+        public void UseHeap(MTLHeap heap)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_useHeap, heap);
+        }
+
+        public void UseHeap(MTLHeap heap, MTLRenderStages stages)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_useHeapstages, heap, (ulong)stages);
+        }
+
+        public void UseHeaps(MTLHeap[] heaps, ulong count)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void UseHeaps(MTLHeap[] heaps, ulong count, MTLRenderStages stages)
         {
             throw new NotImplementedException();
         }
@@ -750,212 +800,162 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_useResourceusagestages, resource, (ulong)usage, (ulong)stages);
         }
 
+        public void UseResource(MTLResource resource, MTLResourceUsage usage)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_useResourceusage, resource, (ulong)usage);
+        }
+
         public void UseResources(MTLResource[] resources, ulong count, MTLResourceUsage usage, MTLRenderStages stages)
         {
             throw new NotImplementedException();
         }
 
-        public void UseHeap(MTLHeap heap)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_useHeap, heap);
-        }
-
-        public void UseHeaps(MTLHeap[] heaps, ulong count)
+        public void UseResources(MTLResource[] resources, ulong count, MTLResourceUsage usage)
         {
             throw new NotImplementedException();
         }
 
-        public void UseHeap(MTLHeap heap, MTLRenderStages stages)
+        public void WaitForFence(MTLFence fence, MTLRenderStages stages)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_useHeapstages, heap, (ulong)stages);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_waitForFencebeforeStages, fence, (ulong)stages);
         }
 
-        public void UseHeaps(MTLHeap[] heaps, ulong count, MTLRenderStages stages)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void ExecuteCommandsInBuffer(MTLIndirectCommandBuffer indirectCommandBuffer, NSRange executionRange)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_executeCommandsInBufferwithRange, indirectCommandBuffer, executionRange);
-        }
-
-        public void ExecuteCommandsInBuffer(MTLIndirectCommandBuffer indirectCommandbuffer, MTLBuffer indirectRangeBuffer, ulong indirectBufferOffset)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_executeCommandsInBufferindirectBufferindirectBufferOffset, indirectCommandbuffer, indirectRangeBuffer, indirectBufferOffset);
-        }
-
-        public void MemoryBarrier(MTLBarrierScope scope, MTLRenderStages after, MTLRenderStages before)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_memoryBarrierWithScopeafterStagesbeforeStages, (ulong)scope, (ulong)after, (ulong)before);
-        }
-
-        public void MemoryBarrier(MTLResource[] resources, ulong count, MTLRenderStages after, MTLRenderStages before)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void SampleCountersInBuffer(MTLCounterSampleBuffer sampleBuffer, ulong sampleIndex, bool barrier)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_sampleCountersInBufferatSampleIndexwithBarrier, sampleBuffer, sampleIndex, barrier);
-        }
-
-        public void EndEncoding()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_endEncoding);
-        }
-
-        public void InsertDebugSignpost(NSString nsString)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_insertDebugSignpost, nsString);
-        }
-
-        public void PushDebugGroup(NSString nsString)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_pushDebugGroup, nsString);
-        }
-
-        public void PopDebugGroup()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_popDebugGroup);
-        }
-
-        private static readonly Selector sel_setRenderPipelineState = "setRenderPipelineState:";
-        private static readonly Selector sel_setVertexByteslengthatIndex = "setVertexBytes:length:atIndex:";
-        private static readonly Selector sel_setVertexBufferoffsetatIndex = "setVertexBuffer:offset:atIndex:";
-        private static readonly Selector sel_setVertexBufferOffsetatIndex = "setVertexBufferOffset:atIndex:";
-        private static readonly Selector sel_setVertexBuffersoffsetswithRange = "setVertexBuffers:offsets:withRange:";
-        private static readonly Selector sel_setVertexBufferoffsetattributeStrideatIndex = "setVertexBuffer:offset:attributeStride:atIndex:";
-        private static readonly Selector sel_setVertexBuffersoffsetsattributeStrideswithRange = "setVertexBuffers:offsets:attributeStrides:withRange:";
-        private static readonly Selector sel_setVertexBufferOffsetattributeStrideatIndex = "setVertexBufferOffset:attributeStride:atIndex:";
-        private static readonly Selector sel_setVertexByteslengthattributeStrideatIndex = "setVertexBytes:length:attributeStride:atIndex:";
-        private static readonly Selector sel_setVertexTextureatIndex = "setVertexTexture:atIndex:";
-        private static readonly Selector sel_setVertexTextureswithRange = "setVertexTextures:withRange:";
-        private static readonly Selector sel_setVertexSamplerStateatIndex = "setVertexSamplerState:atIndex:";
-        private static readonly Selector sel_setVertexSamplerStateswithRange = "setVertexSamplerStates:withRange:";
-        private static readonly Selector sel_setVertexSamplerStatelodMinClamplodMaxClampatIndex = "setVertexSamplerState:lodMinClamp:lodMaxClamp:atIndex:";
-        private static readonly Selector sel_setVertexSamplerStateslodMinClampslodMaxClampswithRange = "setVertexSamplerStates:lodMinClamps:lodMaxClamps:withRange:";
-        private static readonly Selector sel_setVertexVisibleFunctionTableatBufferIndex = "setVertexVisibleFunctionTable:atBufferIndex:";
-        private static readonly Selector sel_setVertexVisibleFunctionTableswithBufferRange = "setVertexVisibleFunctionTables:withBufferRange:";
-        private static readonly Selector sel_setVertexIntersectionFunctionTableatBufferIndex = "setVertexIntersectionFunctionTable:atBufferIndex:";
-        private static readonly Selector sel_setVertexIntersectionFunctionTableswithBufferRange = "setVertexIntersectionFunctionTables:withBufferRange:";
-        private static readonly Selector sel_setVertexAccelerationStructureatBufferIndex = "setVertexAccelerationStructure:atBufferIndex:";
-        private static readonly Selector sel_setViewport = "setViewport:";
-        private static readonly Selector sel_setViewportscount = "setViewports:count:";
-        private static readonly Selector sel_setFrontFacingWinding = "setFrontFacingWinding:";
-        private static readonly Selector sel_setVertexAmplificationCountviewMappings = "setVertexAmplificationCount:viewMappings:";
+        private static readonly Selector sel_device = "device";
+        private static readonly Selector sel_dispatchThreadsPerTile = "dispatchThreadsPerTile:";
+        private static readonly Selector sel_drawIndexedPatchespatchIndexBufferpatchIndexBufferOffsetcontrolPointIndexBuffercontrolPointIndexBufferOffsetindirectBufferindirectBufferOffset = "drawIndexedPatches:patchIndexBuffer:patchIndexBufferOffset:controlPointIndexBuffer:controlPointIndexBufferOffset:indirectBuffer:indirectBufferOffset:";
+        private static readonly Selector sel_drawIndexedPatchespatchStartpatchCountpatchIndexBufferpatchIndexBufferOffsetcontrolPointIndexBuffercontrolPointIndexBufferOffsetinstanceCountbaseInstance = "drawIndexedPatches:patchStart:patchCount:patchIndexBuffer:patchIndexBufferOffset:controlPointIndexBuffer:controlPointIndexBufferOffset:instanceCount:baseInstance:";
+        private static readonly Selector sel_drawIndexedPrimitivesindexCountindexTypeindexBufferindexBufferOffset = "drawIndexedPrimitives:indexCount:indexType:indexBuffer:indexBufferOffset:";
+        private static readonly Selector sel_drawIndexedPrimitivesindexCountindexTypeindexBufferindexBufferOffsetinstanceCount = "drawIndexedPrimitives:indexCount:indexType:indexBuffer:indexBufferOffset:instanceCount:";
+        private static readonly Selector sel_drawIndexedPrimitivesindexCountindexTypeindexBufferindexBufferOffsetinstanceCountbaseVertexbaseInstance = "drawIndexedPrimitives:indexCount:indexType:indexBuffer:indexBufferOffset:instanceCount:baseVertex:baseInstance:";
+        private static readonly Selector sel_drawIndexedPrimitivesindexTypeindexBufferindexBufferOffsetindirectBufferindirectBufferOffset = "drawIndexedPrimitives:indexType:indexBuffer:indexBufferOffset:indirectBuffer:indirectBufferOffset:";
+        private static readonly Selector sel_drawMeshThreadgroupsthreadsPerObjectThreadgroupthreadsPerMeshThreadgroup = "drawMeshThreadgroups:threadsPerObjectThreadgroup:threadsPerMeshThreadgroup:";
+        private static readonly Selector sel_drawMeshThreadgroupsWithIndirectBufferindirectBufferOffsetthreadsPerObjectThreadgroupthreadsPerMeshThreadgroup = "drawMeshThreadgroupsWithIndirectBuffer:indirectBufferOffset:threadsPerObjectThreadgroup:threadsPerMeshThreadgroup:";
+        private static readonly Selector sel_drawMeshThreadsthreadsPerObjectThreadgroupthreadsPerMeshThreadgroup = "drawMeshThreads:threadsPerObjectThreadgroup:threadsPerMeshThreadgroup:";
+        private static readonly Selector sel_drawPatchespatchIndexBufferpatchIndexBufferOffsetindirectBufferindirectBufferOffset = "drawPatches:patchIndexBuffer:patchIndexBufferOffset:indirectBuffer:indirectBufferOffset:";
+        private static readonly Selector sel_drawPatchespatchStartpatchCountpatchIndexBufferpatchIndexBufferOffsetinstanceCountbaseInstance = "drawPatches:patchStart:patchCount:patchIndexBuffer:patchIndexBufferOffset:instanceCount:baseInstance:";
+        private static readonly Selector sel_drawPrimitivesindirectBufferindirectBufferOffset = "drawPrimitives:indirectBuffer:indirectBufferOffset:";
+        private static readonly Selector sel_drawPrimitivesvertexStartvertexCount = "drawPrimitives:vertexStart:vertexCount:";
+        private static readonly Selector sel_drawPrimitivesvertexStartvertexCountinstanceCount = "drawPrimitives:vertexStart:vertexCount:instanceCount:";
+        private static readonly Selector sel_drawPrimitivesvertexStartvertexCountinstanceCountbaseInstance = "drawPrimitives:vertexStart:vertexCount:instanceCount:baseInstance:";
+        private static readonly Selector sel_endEncoding = "endEncoding";
+        private static readonly Selector sel_executeCommandsInBufferindirectBufferindirectBufferOffset = "executeCommandsInBuffer:indirectBuffer:indirectBufferOffset:";
+        private static readonly Selector sel_executeCommandsInBufferwithRange = "executeCommandsInBuffer:withRange:";
+        private static readonly Selector sel_insertDebugSignpost = "insertDebugSignpost:";
+        private static readonly Selector sel_label = "label";
+        private static readonly Selector sel_memoryBarrierWithResourcescountafterStagesbeforeStages = "memoryBarrierWithResources:count:afterStages:beforeStages:";
+        private static readonly Selector sel_memoryBarrierWithScopeafterStagesbeforeStages = "memoryBarrierWithScope:afterStages:beforeStages:";
+        private static readonly Selector sel_popDebugGroup = "popDebugGroup";
+        private static readonly Selector sel_pushDebugGroup = "pushDebugGroup:";
+        private static readonly Selector sel_sampleCountersInBufferatSampleIndexwithBarrier = "sampleCountersInBuffer:atSampleIndex:withBarrier:";
+        private static readonly Selector sel_setBlendColorRedgreenbluealpha = "setBlendColorRed:green:blue:alpha:";
+        private static readonly Selector sel_setColorStoreActionatIndex = "setColorStoreAction:atIndex:";
+        private static readonly Selector sel_setColorStoreActionOptionsatIndex = "setColorStoreActionOptions:atIndex:";
         private static readonly Selector sel_setCullMode = "setCullMode:";
-        private static readonly Selector sel_setDepthClipMode = "setDepthClipMode:";
         private static readonly Selector sel_setDepthBiasslopeScaleclamp = "setDepthBias:slopeScale:clamp:";
-        private static readonly Selector sel_setScissorRect = "setScissorRect:";
-        private static readonly Selector sel_setScissorRectscount = "setScissorRects:count:";
-        private static readonly Selector sel_setTriangleFillMode = "setTriangleFillMode:";
-        private static readonly Selector sel_setFragmentByteslengthatIndex = "setFragmentBytes:length:atIndex:";
-        private static readonly Selector sel_setFragmentBufferoffsetatIndex = "setFragmentBuffer:offset:atIndex:";
+        private static readonly Selector sel_setDepthClipMode = "setDepthClipMode:";
+        private static readonly Selector sel_setDepthStencilState = "setDepthStencilState:";
+        private static readonly Selector sel_setDepthStoreAction = "setDepthStoreAction:";
+        private static readonly Selector sel_setDepthStoreActionOptions = "setDepthStoreActionOptions:";
+        private static readonly Selector sel_setFragmentAccelerationStructureatBufferIndex = "setFragmentAccelerationStructure:atBufferIndex:";
         private static readonly Selector sel_setFragmentBufferOffsetatIndex = "setFragmentBufferOffset:atIndex:";
+        private static readonly Selector sel_setFragmentBufferoffsetatIndex = "setFragmentBuffer:offset:atIndex:";
         private static readonly Selector sel_setFragmentBuffersoffsetswithRange = "setFragmentBuffers:offsets:withRange:";
-        private static readonly Selector sel_setFragmentTextureatIndex = "setFragmentTexture:atIndex:";
-        private static readonly Selector sel_setFragmentTextureswithRange = "setFragmentTextures:withRange:";
-        private static readonly Selector sel_setFragmentSamplerStateatIndex = "setFragmentSamplerState:atIndex:";
-        private static readonly Selector sel_setFragmentSamplerStateswithRange = "setFragmentSamplerStates:withRange:";
-        private static readonly Selector sel_setFragmentSamplerStatelodMinClamplodMaxClampatIndex = "setFragmentSamplerState:lodMinClamp:lodMaxClamp:atIndex:";
-        private static readonly Selector sel_setFragmentSamplerStateslodMinClampslodMaxClampswithRange = "setFragmentSamplerStates:lodMinClamps:lodMaxClamps:withRange:";
-        private static readonly Selector sel_setFragmentVisibleFunctionTableatBufferIndex = "setFragmentVisibleFunctionTable:atBufferIndex:";
-        private static readonly Selector sel_setFragmentVisibleFunctionTableswithBufferRange = "setFragmentVisibleFunctionTables:withBufferRange:";
+        private static readonly Selector sel_setFragmentByteslengthatIndex = "setFragmentBytes:length:atIndex:";
         private static readonly Selector sel_setFragmentIntersectionFunctionTableatBufferIndex = "setFragmentIntersectionFunctionTable:atBufferIndex:";
         private static readonly Selector sel_setFragmentIntersectionFunctionTableswithBufferRange = "setFragmentIntersectionFunctionTables:withBufferRange:";
-        private static readonly Selector sel_setFragmentAccelerationStructureatBufferIndex = "setFragmentAccelerationStructure:atBufferIndex:";
-        private static readonly Selector sel_setBlendColorRedgreenbluealpha = "setBlendColorRed:green:blue:alpha:";
-        private static readonly Selector sel_setDepthStencilState = "setDepthStencilState:";
-        private static readonly Selector sel_setStencilReferenceValue = "setStencilReferenceValue:";
-        private static readonly Selector sel_setStencilFrontReferenceValuebackReferenceValue = "setStencilFrontReferenceValue:backReferenceValue:";
-        private static readonly Selector sel_setVisibilityResultModeoffset = "setVisibilityResultMode:offset:";
-        private static readonly Selector sel_setColorStoreActionatIndex = "setColorStoreAction:atIndex:";
-        private static readonly Selector sel_setDepthStoreAction = "setDepthStoreAction:";
-        private static readonly Selector sel_setStencilStoreAction = "setStencilStoreAction:";
-        private static readonly Selector sel_setColorStoreActionOptionsatIndex = "setColorStoreActionOptions:atIndex:";
-        private static readonly Selector sel_setDepthStoreActionOptions = "setDepthStoreActionOptions:";
-        private static readonly Selector sel_setStencilStoreActionOptions = "setStencilStoreActionOptions:";
-        private static readonly Selector sel_setObjectByteslengthatIndex = "setObjectBytes:length:atIndex:";
+        private static readonly Selector sel_setFragmentSamplerStateatIndex = "setFragmentSamplerState:atIndex:";
+        private static readonly Selector sel_setFragmentSamplerStatelodMinClamplodMaxClampatIndex = "setFragmentSamplerState:lodMinClamp:lodMaxClamp:atIndex:";
+        private static readonly Selector sel_setFragmentSamplerStateslodMinClampslodMaxClampswithRange = "setFragmentSamplerStates:lodMinClamps:lodMaxClamps:withRange:";
+        private static readonly Selector sel_setFragmentSamplerStateswithRange = "setFragmentSamplerStates:withRange:";
+        private static readonly Selector sel_setFragmentTextureatIndex = "setFragmentTexture:atIndex:";
+        private static readonly Selector sel_setFragmentTextureswithRange = "setFragmentTextures:withRange:";
+        private static readonly Selector sel_setFragmentVisibleFunctionTableatBufferIndex = "setFragmentVisibleFunctionTable:atBufferIndex:";
+        private static readonly Selector sel_setFragmentVisibleFunctionTableswithBufferRange = "setFragmentVisibleFunctionTables:withBufferRange:";
+        private static readonly Selector sel_setFrontFacingWinding = "setFrontFacingWinding:";
+        private static readonly Selector sel_setLabel = "setLabel:";
+        private static readonly Selector sel_setMeshBufferOffsetatIndex = "setMeshBufferOffset:atIndex:";
+        private static readonly Selector sel_setMeshBufferoffsetatIndex = "setMeshBuffer:offset:atIndex:";
+        private static readonly Selector sel_setMeshBuffersoffsetswithRange = "setMeshBuffers:offsets:withRange:";
+        private static readonly Selector sel_setMeshByteslengthatIndex = "setMeshBytes:length:atIndex:";
+        private static readonly Selector sel_setMeshSamplerStateatIndex = "setMeshSamplerState:atIndex:";
+        private static readonly Selector sel_setMeshSamplerStatelodMinClamplodMaxClampatIndex = "setMeshSamplerState:lodMinClamp:lodMaxClamp:atIndex:";
+        private static readonly Selector sel_setMeshSamplerStateslodMinClampslodMaxClampswithRange = "setMeshSamplerStates:lodMinClamps:lodMaxClamps:withRange:";
+        private static readonly Selector sel_setMeshSamplerStateswithRange = "setMeshSamplerStates:withRange:";
+        private static readonly Selector sel_setMeshTextureatIndex = "setMeshTexture:atIndex:";
+        private static readonly Selector sel_setMeshTextureswithRange = "setMeshTextures:withRange:";
         private static readonly Selector sel_setObjectBufferoffsetatIndex = "setObjectBuffer:offset:atIndex:";
         private static readonly Selector sel_setObjectBufferOffsetatIndex = "setObjectBufferOffset:atIndex:";
         private static readonly Selector sel_setObjectBuffersoffsetswithRange = "setObjectBuffers:offsets:withRange:";
-        private static readonly Selector sel_setObjectTextureatIndex = "setObjectTexture:atIndex:";
-        private static readonly Selector sel_setObjectTextureswithRange = "setObjectTextures:withRange:";
+        private static readonly Selector sel_setObjectByteslengthatIndex = "setObjectBytes:length:atIndex:";
         private static readonly Selector sel_setObjectSamplerStateatIndex = "setObjectSamplerState:atIndex:";
-        private static readonly Selector sel_setObjectSamplerStateswithRange = "setObjectSamplerStates:withRange:";
         private static readonly Selector sel_setObjectSamplerStatelodMinClamplodMaxClampatIndex = "setObjectSamplerState:lodMinClamp:lodMaxClamp:atIndex:";
         private static readonly Selector sel_setObjectSamplerStateslodMinClampslodMaxClampswithRange = "setObjectSamplerStates:lodMinClamps:lodMaxClamps:withRange:";
+        private static readonly Selector sel_setObjectSamplerStateswithRange = "setObjectSamplerStates:withRange:";
+        private static readonly Selector sel_setObjectTextureatIndex = "setObjectTexture:atIndex:";
+        private static readonly Selector sel_setObjectTextureswithRange = "setObjectTextures:withRange:";
         private static readonly Selector sel_setObjectThreadgroupMemoryLengthatIndex = "setObjectThreadgroupMemoryLength:atIndex:";
-        private static readonly Selector sel_setMeshByteslengthatIndex = "setMeshBytes:length:atIndex:";
-        private static readonly Selector sel_setMeshBufferoffsetatIndex = "setMeshBuffer:offset:atIndex:";
-        private static readonly Selector sel_setMeshBufferOffsetatIndex = "setMeshBufferOffset:atIndex:";
-        private static readonly Selector sel_setMeshBuffersoffsetswithRange = "setMeshBuffers:offsets:withRange:";
-        private static readonly Selector sel_setMeshTextureatIndex = "setMeshTexture:atIndex:";
-        private static readonly Selector sel_setMeshTextureswithRange = "setMeshTextures:withRange:";
-        private static readonly Selector sel_setMeshSamplerStateatIndex = "setMeshSamplerState:atIndex:";
-        private static readonly Selector sel_setMeshSamplerStateswithRange = "setMeshSamplerStates:withRange:";
-        private static readonly Selector sel_setMeshSamplerStatelodMinClamplodMaxClampatIndex = "setMeshSamplerState:lodMinClamp:lodMaxClamp:atIndex:";
-        private static readonly Selector sel_setMeshSamplerStateslodMinClampslodMaxClampswithRange = "setMeshSamplerStates:lodMinClamps:lodMaxClamps:withRange:";
-        private static readonly Selector sel_drawMeshThreadgroupsthreadsPerObjectThreadgroupthreadsPerMeshThreadgroup = "drawMeshThreadgroups:threadsPerObjectThreadgroup:threadsPerMeshThreadgroup:";
-        private static readonly Selector sel_drawMeshThreadsthreadsPerObjectThreadgroupthreadsPerMeshThreadgroup = "drawMeshThreads:threadsPerObjectThreadgroup:threadsPerMeshThreadgroup:";
-        private static readonly Selector sel_drawMeshThreadgroupsWithIndirectBufferindirectBufferOffsetthreadsPerObjectThreadgroupthreadsPerMeshThreadgroup = "drawMeshThreadgroupsWithIndirectBuffer:indirectBufferOffset:threadsPerObjectThreadgroup:threadsPerMeshThreadgroup:";
-        private static readonly Selector sel_drawPrimitivesvertexStartvertexCountinstanceCount = "drawPrimitives:vertexStart:vertexCount:instanceCount:";
-        private static readonly Selector sel_drawPrimitivesvertexStartvertexCount = "drawPrimitives:vertexStart:vertexCount:";
-        private static readonly Selector sel_drawIndexedPrimitivesindexCountindexTypeindexBufferindexBufferOffsetinstanceCount = "drawIndexedPrimitives:indexCount:indexType:indexBuffer:indexBufferOffset:instanceCount:";
-        private static readonly Selector sel_drawIndexedPrimitivesindexCountindexTypeindexBufferindexBufferOffset = "drawIndexedPrimitives:indexCount:indexType:indexBuffer:indexBufferOffset:";
-        private static readonly Selector sel_drawPrimitivesvertexStartvertexCountinstanceCountbaseInstance = "drawPrimitives:vertexStart:vertexCount:instanceCount:baseInstance:";
-        private static readonly Selector sel_drawIndexedPrimitivesindexCountindexTypeindexBufferindexBufferOffsetinstanceCountbaseVertexbaseInstance = "drawIndexedPrimitives:indexCount:indexType:indexBuffer:indexBufferOffset:instanceCount:baseVertex:baseInstance:";
-        private static readonly Selector sel_drawPrimitivesindirectBufferindirectBufferOffset = "drawPrimitives:indirectBuffer:indirectBufferOffset:";
-        private static readonly Selector sel_drawIndexedPrimitivesindexTypeindexBufferindexBufferOffsetindirectBufferindirectBufferOffset = "drawIndexedPrimitives:indexType:indexBuffer:indexBufferOffset:indirectBuffer:indirectBufferOffset:";
-        private static readonly Selector sel_textureBarrier = "textureBarrier";
-        private static readonly Selector sel_updateFenceafterStages = "updateFence:afterStages:";
-        private static readonly Selector sel_waitForFencebeforeStages = "waitForFence:beforeStages:";
+        private static readonly Selector sel_setRenderPipelineState = "setRenderPipelineState:";
+        private static readonly Selector sel_setScissorRect = "setScissorRect:";
+        private static readonly Selector sel_setScissorRectscount = "setScissorRects:count:";
+        private static readonly Selector sel_setStencilFrontReferenceValuebackReferenceValue = "setStencilFrontReferenceValue:backReferenceValue:";
+        private static readonly Selector sel_setStencilReferenceValue = "setStencilReferenceValue:";
+        private static readonly Selector sel_setStencilStoreAction = "setStencilStoreAction:";
+        private static readonly Selector sel_setStencilStoreActionOptions = "setStencilStoreActionOptions:";
         private static readonly Selector sel_setTessellationFactorBufferoffsetinstanceStride = "setTessellationFactorBuffer:offset:instanceStride:";
         private static readonly Selector sel_setTessellationFactorScale = "setTessellationFactorScale:";
-        private static readonly Selector sel_drawPatchespatchStartpatchCountpatchIndexBufferpatchIndexBufferOffsetinstanceCountbaseInstance = "drawPatches:patchStart:patchCount:patchIndexBuffer:patchIndexBufferOffset:instanceCount:baseInstance:";
-        private static readonly Selector sel_drawPatchespatchIndexBufferpatchIndexBufferOffsetindirectBufferindirectBufferOffset = "drawPatches:patchIndexBuffer:patchIndexBufferOffset:indirectBuffer:indirectBufferOffset:";
-        private static readonly Selector sel_drawIndexedPatchespatchStartpatchCountpatchIndexBufferpatchIndexBufferOffsetcontrolPointIndexBuffercontrolPointIndexBufferOffsetinstanceCountbaseInstance = "drawIndexedPatches:patchStart:patchCount:patchIndexBuffer:patchIndexBufferOffset:controlPointIndexBuffer:controlPointIndexBufferOffset:instanceCount:baseInstance:";
-        private static readonly Selector sel_drawIndexedPatchespatchIndexBufferpatchIndexBufferOffsetcontrolPointIndexBuffercontrolPointIndexBufferOffsetindirectBufferindirectBufferOffset = "drawIndexedPatches:patchIndexBuffer:patchIndexBufferOffset:controlPointIndexBuffer:controlPointIndexBufferOffset:indirectBuffer:indirectBufferOffset:";
-        private static readonly Selector sel_tileWidth = "tileWidth";
-        private static readonly Selector sel_tileHeight = "tileHeight";
-        private static readonly Selector sel_setTileByteslengthatIndex = "setTileBytes:length:atIndex:";
-        private static readonly Selector sel_setTileBufferoffsetatIndex = "setTileBuffer:offset:atIndex:";
+        private static readonly Selector sel_setThreadgroupMemoryLengthoffsetatIndex = "setThreadgroupMemoryLength:offset:atIndex:";
+        private static readonly Selector sel_setTileAccelerationStructureatBufferIndex = "setTileAccelerationStructure:atBufferIndex:";
         private static readonly Selector sel_setTileBufferOffsetatIndex = "setTileBufferOffset:atIndex:";
+        private static readonly Selector sel_setTileBufferoffsetatIndex = "setTileBuffer:offset:atIndex:";
         private static readonly Selector sel_setTileBuffersoffsetswithRange = "setTileBuffers:offsets:withRange:";
-        private static readonly Selector sel_setTileTextureatIndex = "setTileTexture:atIndex:";
-        private static readonly Selector sel_setTileTextureswithRange = "setTileTextures:withRange:";
-        private static readonly Selector sel_setTileSamplerStateatIndex = "setTileSamplerState:atIndex:";
-        private static readonly Selector sel_setTileSamplerStateswithRange = "setTileSamplerStates:withRange:";
-        private static readonly Selector sel_setTileSamplerStatelodMinClamplodMaxClampatIndex = "setTileSamplerState:lodMinClamp:lodMaxClamp:atIndex:";
-        private static readonly Selector sel_setTileSamplerStateslodMinClampslodMaxClampswithRange = "setTileSamplerStates:lodMinClamps:lodMaxClamps:withRange:";
-        private static readonly Selector sel_setTileVisibleFunctionTableatBufferIndex = "setTileVisibleFunctionTable:atBufferIndex:";
-        private static readonly Selector sel_setTileVisibleFunctionTableswithBufferRange = "setTileVisibleFunctionTables:withBufferRange:";
+        private static readonly Selector sel_setTileByteslengthatIndex = "setTileBytes:length:atIndex:";
         private static readonly Selector sel_setTileIntersectionFunctionTableatBufferIndex = "setTileIntersectionFunctionTable:atBufferIndex:";
         private static readonly Selector sel_setTileIntersectionFunctionTableswithBufferRange = "setTileIntersectionFunctionTables:withBufferRange:";
-        private static readonly Selector sel_setTileAccelerationStructureatBufferIndex = "setTileAccelerationStructure:atBufferIndex:";
-        private static readonly Selector sel_dispatchThreadsPerTile = "dispatchThreadsPerTile:";
-        private static readonly Selector sel_setThreadgroupMemoryLengthoffsetatIndex = "setThreadgroupMemoryLength:offset:atIndex:";
-        private static readonly Selector sel_useResourceusage = "useResource:usage:";
-        private static readonly Selector sel_useResourcescountusage = "useResources:count:usage:";
-        private static readonly Selector sel_useResourceusagestages = "useResource:usage:stages:";
-        private static readonly Selector sel_useResourcescountusagestages = "useResources:count:usage:stages:";
+        private static readonly Selector sel_setTileSamplerStateatIndex = "setTileSamplerState:atIndex:";
+        private static readonly Selector sel_setTileSamplerStatelodMinClamplodMaxClampatIndex = "setTileSamplerState:lodMinClamp:lodMaxClamp:atIndex:";
+        private static readonly Selector sel_setTileSamplerStateslodMinClampslodMaxClampswithRange = "setTileSamplerStates:lodMinClamps:lodMaxClamps:withRange:";
+        private static readonly Selector sel_setTileSamplerStateswithRange = "setTileSamplerStates:withRange:";
+        private static readonly Selector sel_setTileTextureatIndex = "setTileTexture:atIndex:";
+        private static readonly Selector sel_setTileTextureswithRange = "setTileTextures:withRange:";
+        private static readonly Selector sel_setTileVisibleFunctionTableatBufferIndex = "setTileVisibleFunctionTable:atBufferIndex:";
+        private static readonly Selector sel_setTileVisibleFunctionTableswithBufferRange = "setTileVisibleFunctionTables:withBufferRange:";
+        private static readonly Selector sel_setTriangleFillMode = "setTriangleFillMode:";
+        private static readonly Selector sel_setVertexAccelerationStructureatBufferIndex = "setVertexAccelerationStructure:atBufferIndex:";
+        private static readonly Selector sel_setVertexAmplificationCountviewMappings = "setVertexAmplificationCount:viewMappings:";
+        private static readonly Selector sel_setVertexBufferOffsetatIndex = "setVertexBufferOffset:atIndex:";
+        private static readonly Selector sel_setVertexBufferoffsetatIndex = "setVertexBuffer:offset:atIndex:";
+        private static readonly Selector sel_setVertexBufferoffsetattributeStrideatIndex = "setVertexBuffer:offset:attributeStride:atIndex:";
+        private static readonly Selector sel_setVertexBufferOffsetattributeStrideatIndex = "setVertexBufferOffset:attributeStride:atIndex:";
+        private static readonly Selector sel_setVertexBuffersoffsetsattributeStrideswithRange = "setVertexBuffers:offsets:attributeStrides:withRange:";
+        private static readonly Selector sel_setVertexBuffersoffsetswithRange = "setVertexBuffers:offsets:withRange:";
+        private static readonly Selector sel_setVertexByteslengthatIndex = "setVertexBytes:length:atIndex:";
+        private static readonly Selector sel_setVertexByteslengthattributeStrideatIndex = "setVertexBytes:length:attributeStride:atIndex:";
+        private static readonly Selector sel_setVertexIntersectionFunctionTableatBufferIndex = "setVertexIntersectionFunctionTable:atBufferIndex:";
+        private static readonly Selector sel_setVertexIntersectionFunctionTableswithBufferRange = "setVertexIntersectionFunctionTables:withBufferRange:";
+        private static readonly Selector sel_setVertexSamplerStateatIndex = "setVertexSamplerState:atIndex:";
+        private static readonly Selector sel_setVertexSamplerStatelodMinClamplodMaxClampatIndex = "setVertexSamplerState:lodMinClamp:lodMaxClamp:atIndex:";
+        private static readonly Selector sel_setVertexSamplerStateslodMinClampslodMaxClampswithRange = "setVertexSamplerStates:lodMinClamps:lodMaxClamps:withRange:";
+        private static readonly Selector sel_setVertexSamplerStateswithRange = "setVertexSamplerStates:withRange:";
+        private static readonly Selector sel_setVertexTextureatIndex = "setVertexTexture:atIndex:";
+        private static readonly Selector sel_setVertexTextureswithRange = "setVertexTextures:withRange:";
+        private static readonly Selector sel_setVertexVisibleFunctionTableatBufferIndex = "setVertexVisibleFunctionTable:atBufferIndex:";
+        private static readonly Selector sel_setVertexVisibleFunctionTableswithBufferRange = "setVertexVisibleFunctionTables:withBufferRange:";
+        private static readonly Selector sel_setViewport = "setViewport:";
+        private static readonly Selector sel_setViewportscount = "setViewports:count:";
+        private static readonly Selector sel_setVisibilityResultModeoffset = "setVisibilityResultMode:offset:";
+        private static readonly Selector sel_textureBarrier = "textureBarrier";
+        private static readonly Selector sel_tileHeight = "tileHeight";
+        private static readonly Selector sel_tileWidth = "tileWidth";
+        private static readonly Selector sel_updateFenceafterStages = "updateFence:afterStages:";
         private static readonly Selector sel_useHeap = "useHeap:";
         private static readonly Selector sel_useHeapscount = "useHeaps:count:";
-        private static readonly Selector sel_useHeapstages = "useHeap:stages:";
         private static readonly Selector sel_useHeapscountstages = "useHeaps:count:stages:";
-        private static readonly Selector sel_executeCommandsInBufferwithRange = "executeCommandsInBuffer:withRange:";
-        private static readonly Selector sel_executeCommandsInBufferindirectBufferindirectBufferOffset = "executeCommandsInBuffer:indirectBuffer:indirectBufferOffset:";
-        private static readonly Selector sel_memoryBarrierWithScopeafterStagesbeforeStages = "memoryBarrierWithScope:afterStages:beforeStages:";
-        private static readonly Selector sel_memoryBarrierWithResourcescountafterStagesbeforeStages = "memoryBarrierWithResources:count:afterStages:beforeStages:";
-        private static readonly Selector sel_sampleCountersInBufferatSampleIndexwithBarrier = "sampleCountersInBuffer:atSampleIndex:withBarrier:";
-        private static readonly Selector sel_device = "device";
-        private static readonly Selector sel_label = "label";
-        private static readonly Selector sel_setLabel = "setLabel:";
-        private static readonly Selector sel_endEncoding = "endEncoding";
-        private static readonly Selector sel_insertDebugSignpost = "insertDebugSignpost:";
-        private static readonly Selector sel_pushDebugGroup = "pushDebugGroup:";
-        private static readonly Selector sel_popDebugGroup = "popDebugGroup";
+        private static readonly Selector sel_useHeapstages = "useHeap:stages:";
+        private static readonly Selector sel_useResourcescountusage = "useResources:count:usage:";
+        private static readonly Selector sel_useResourcescountusagestages = "useResources:count:usage:stages:";
+        private static readonly Selector sel_useResourceusage = "useResource:usage:";
+        private static readonly Selector sel_useResourceusagestages = "useResource:usage:stages:";
+        private static readonly Selector sel_waitForFencebeforeStages = "waitForFence:beforeStages:";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLRenderPass.cs
+++ b/src/SharpMetal/Metal/MTLRenderPass.cs
@@ -14,6 +14,21 @@ namespace SharpMetal.Metal
     }
 
     [SupportedOSPlatform("macos")]
+    public enum MTLMultisampleDepthResolveFilter : ulong
+    {
+        Sample0 = 0,
+        Min = 1,
+        Max = 2,
+    }
+
+    [SupportedOSPlatform("macos")]
+    public enum MTLMultisampleStencilResolveFilter : ulong
+    {
+        Sample0 = 0,
+        DepthResolvedSample = 1,
+    }
+
+    [SupportedOSPlatform("macos")]
     public enum MTLStoreAction : ulong
     {
         DontCare = 0,
@@ -31,21 +46,6 @@ namespace SharpMetal.Metal
         None = 0,
         CustomSamplePositions = 1,
         ValidMask = 1,
-    }
-
-    [SupportedOSPlatform("macos")]
-    public enum MTLMultisampleDepthResolveFilter : ulong
-    {
-        Sample0 = 0,
-        Min = 1,
-        Max = 2,
-    }
-
-    [SupportedOSPlatform("macos")]
-    public enum MTLMultisampleStencilResolveFilter : ulong
-    {
-        Sample0 = 0,
-        DepthResolvedSample = 1,
     }
 
     [SupportedOSPlatform("macos")]
@@ -76,10 +76,10 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public MTLTexture Texture
+        public ulong DepthPlane
         {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_texture));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTexture, value);
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_depthPlane);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDepthPlane, value);
         }
 
         public ulong Level
@@ -88,22 +88,16 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLevel, value);
         }
 
-        public ulong Slice
+        public MTLLoadAction LoadAction
         {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_slice);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSlice, value);
+            get => (MTLLoadAction)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_loadAction);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLoadAction, (ulong)value);
         }
 
-        public ulong DepthPlane
+        public ulong ResolveDepthPlane
         {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_depthPlane);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDepthPlane, value);
-        }
-
-        public MTLTexture ResolveTexture
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_resolveTexture));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setResolveTexture, value);
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_resolveDepthPlane);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setResolveDepthPlane, value);
         }
 
         public ulong ResolveLevel
@@ -118,16 +112,16 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setResolveSlice, value);
         }
 
-        public ulong ResolveDepthPlane
+        public MTLTexture ResolveTexture
         {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_resolveDepthPlane);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setResolveDepthPlane, value);
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_resolveTexture));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setResolveTexture, value);
         }
 
-        public MTLLoadAction LoadAction
+        public ulong Slice
         {
-            get => (MTLLoadAction)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_loadAction);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLoadAction, (ulong)value);
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_slice);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSlice, value);
         }
 
         public MTLStoreAction StoreAction
@@ -142,28 +136,34 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStoreActionOptions, (ulong)value);
         }
 
-        private static readonly Selector sel_texture = "texture";
-        private static readonly Selector sel_setTexture = "setTexture:";
-        private static readonly Selector sel_level = "level";
-        private static readonly Selector sel_setLevel = "setLevel:";
-        private static readonly Selector sel_slice = "slice";
-        private static readonly Selector sel_setSlice = "setSlice:";
+        public MTLTexture Texture
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_texture));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTexture, value);
+        }
+
         private static readonly Selector sel_depthPlane = "depthPlane";
-        private static readonly Selector sel_setDepthPlane = "setDepthPlane:";
-        private static readonly Selector sel_resolveTexture = "resolveTexture";
-        private static readonly Selector sel_setResolveTexture = "setResolveTexture:";
-        private static readonly Selector sel_resolveLevel = "resolveLevel";
-        private static readonly Selector sel_setResolveLevel = "setResolveLevel:";
-        private static readonly Selector sel_resolveSlice = "resolveSlice";
-        private static readonly Selector sel_setResolveSlice = "setResolveSlice:";
-        private static readonly Selector sel_resolveDepthPlane = "resolveDepthPlane";
-        private static readonly Selector sel_setResolveDepthPlane = "setResolveDepthPlane:";
+        private static readonly Selector sel_level = "level";
         private static readonly Selector sel_loadAction = "loadAction";
+        private static readonly Selector sel_resolveDepthPlane = "resolveDepthPlane";
+        private static readonly Selector sel_resolveLevel = "resolveLevel";
+        private static readonly Selector sel_resolveSlice = "resolveSlice";
+        private static readonly Selector sel_resolveTexture = "resolveTexture";
+        private static readonly Selector sel_setDepthPlane = "setDepthPlane:";
+        private static readonly Selector sel_setLevel = "setLevel:";
         private static readonly Selector sel_setLoadAction = "setLoadAction:";
-        private static readonly Selector sel_storeAction = "storeAction";
+        private static readonly Selector sel_setResolveDepthPlane = "setResolveDepthPlane:";
+        private static readonly Selector sel_setResolveLevel = "setResolveLevel:";
+        private static readonly Selector sel_setResolveSlice = "setResolveSlice:";
+        private static readonly Selector sel_setResolveTexture = "setResolveTexture:";
+        private static readonly Selector sel_setSlice = "setSlice:";
         private static readonly Selector sel_setStoreAction = "setStoreAction:";
-        private static readonly Selector sel_storeActionOptions = "storeActionOptions";
         private static readonly Selector sel_setStoreActionOptions = "setStoreActionOptions:";
+        private static readonly Selector sel_setTexture = "setTexture:";
+        private static readonly Selector sel_slice = "slice";
+        private static readonly Selector sel_storeAction = "storeAction";
+        private static readonly Selector sel_storeActionOptions = "storeActionOptions";
+        private static readonly Selector sel_texture = "texture";
         private static readonly Selector sel_release = "release";
     }
 
@@ -192,10 +192,10 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setClearColor, value);
         }
 
-        public MTLTexture Texture
+        public ulong DepthPlane
         {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_texture));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTexture, value);
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_depthPlane);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDepthPlane, value);
         }
 
         public ulong Level
@@ -204,22 +204,16 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLevel, value);
         }
 
-        public ulong Slice
+        public MTLLoadAction LoadAction
         {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_slice);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSlice, value);
+            get => (MTLLoadAction)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_loadAction);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLoadAction, (ulong)value);
         }
 
-        public ulong DepthPlane
+        public ulong ResolveDepthPlane
         {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_depthPlane);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDepthPlane, value);
-        }
-
-        public MTLTexture ResolveTexture
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_resolveTexture));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setResolveTexture, value);
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_resolveDepthPlane);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setResolveDepthPlane, value);
         }
 
         public ulong ResolveLevel
@@ -234,16 +228,16 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setResolveSlice, value);
         }
 
-        public ulong ResolveDepthPlane
+        public MTLTexture ResolveTexture
         {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_resolveDepthPlane);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setResolveDepthPlane, value);
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_resolveTexture));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setResolveTexture, value);
         }
 
-        public MTLLoadAction LoadAction
+        public ulong Slice
         {
-            get => (MTLLoadAction)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_loadAction);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLoadAction, (ulong)value);
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_slice);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSlice, value);
         }
 
         public MTLStoreAction StoreAction
@@ -256,284 +250,38 @@ namespace SharpMetal.Metal
         {
             get => (MTLStoreActionOptions)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_storeActionOptions);
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStoreActionOptions, (ulong)value);
+        }
+
+        public MTLTexture Texture
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_texture));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTexture, value);
         }
 
         private static readonly Selector sel_clearColor = "clearColor";
+        private static readonly Selector sel_depthPlane = "depthPlane";
+        private static readonly Selector sel_level = "level";
+        private static readonly Selector sel_loadAction = "loadAction";
+        private static readonly Selector sel_resolveDepthPlane = "resolveDepthPlane";
+        private static readonly Selector sel_resolveLevel = "resolveLevel";
+        private static readonly Selector sel_resolveSlice = "resolveSlice";
+        private static readonly Selector sel_resolveTexture = "resolveTexture";
         private static readonly Selector sel_setClearColor = "setClearColor:";
-        private static readonly Selector sel_texture = "texture";
-        private static readonly Selector sel_setTexture = "setTexture:";
-        private static readonly Selector sel_level = "level";
-        private static readonly Selector sel_setLevel = "setLevel:";
-        private static readonly Selector sel_slice = "slice";
-        private static readonly Selector sel_setSlice = "setSlice:";
-        private static readonly Selector sel_depthPlane = "depthPlane";
         private static readonly Selector sel_setDepthPlane = "setDepthPlane:";
-        private static readonly Selector sel_resolveTexture = "resolveTexture";
-        private static readonly Selector sel_setResolveTexture = "setResolveTexture:";
-        private static readonly Selector sel_resolveLevel = "resolveLevel";
-        private static readonly Selector sel_setResolveLevel = "setResolveLevel:";
-        private static readonly Selector sel_resolveSlice = "resolveSlice";
-        private static readonly Selector sel_setResolveSlice = "setResolveSlice:";
-        private static readonly Selector sel_resolveDepthPlane = "resolveDepthPlane";
-        private static readonly Selector sel_setResolveDepthPlane = "setResolveDepthPlane:";
-        private static readonly Selector sel_loadAction = "loadAction";
-        private static readonly Selector sel_setLoadAction = "setLoadAction:";
-        private static readonly Selector sel_storeAction = "storeAction";
-        private static readonly Selector sel_setStoreAction = "setStoreAction:";
-        private static readonly Selector sel_storeActionOptions = "storeActionOptions";
-        private static readonly Selector sel_setStoreActionOptions = "setStoreActionOptions:";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLRenderPassDepthAttachmentDescriptor : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLRenderPassDepthAttachmentDescriptor obj) => obj.NativePtr;
-        public static implicit operator MTLRenderPassAttachmentDescriptor(MTLRenderPassDepthAttachmentDescriptor obj) => new(obj.NativePtr);
-        public MTLRenderPassDepthAttachmentDescriptor(IntPtr ptr) => NativePtr = ptr;
-
-        public MTLRenderPassDepthAttachmentDescriptor()
-        {
-            var cls = new ObjectiveCClass("MTLRenderPassDepthAttachmentDescriptor");
-            NativePtr = cls.AllocInit();
-        }
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public double ClearDepth
-        {
-            get => ObjectiveCRuntime.double_objc_msgSend(NativePtr, sel_clearDepth);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setClearDepth, value);
-        }
-
-        public MTLMultisampleDepthResolveFilter DepthResolveFilter
-        {
-            get => (MTLMultisampleDepthResolveFilter)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_depthResolveFilter);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDepthResolveFilter, (ulong)value);
-        }
-
-        public MTLTexture Texture
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_texture));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTexture, value);
-        }
-
-        public ulong Level
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_level);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLevel, value);
-        }
-
-        public ulong Slice
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_slice);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSlice, value);
-        }
-
-        public ulong DepthPlane
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_depthPlane);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDepthPlane, value);
-        }
-
-        public MTLTexture ResolveTexture
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_resolveTexture));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setResolveTexture, value);
-        }
-
-        public ulong ResolveLevel
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_resolveLevel);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setResolveLevel, value);
-        }
-
-        public ulong ResolveSlice
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_resolveSlice);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setResolveSlice, value);
-        }
-
-        public ulong ResolveDepthPlane
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_resolveDepthPlane);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setResolveDepthPlane, value);
-        }
-
-        public MTLLoadAction LoadAction
-        {
-            get => (MTLLoadAction)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_loadAction);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLoadAction, (ulong)value);
-        }
-
-        public MTLStoreAction StoreAction
-        {
-            get => (MTLStoreAction)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_storeAction);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStoreAction, (ulong)value);
-        }
-
-        public MTLStoreActionOptions StoreActionOptions
-        {
-            get => (MTLStoreActionOptions)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_storeActionOptions);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStoreActionOptions, (ulong)value);
-        }
-
-        private static readonly Selector sel_clearDepth = "clearDepth";
-        private static readonly Selector sel_setClearDepth = "setClearDepth:";
-        private static readonly Selector sel_depthResolveFilter = "depthResolveFilter";
-        private static readonly Selector sel_setDepthResolveFilter = "setDepthResolveFilter:";
-        private static readonly Selector sel_texture = "texture";
-        private static readonly Selector sel_setTexture = "setTexture:";
-        private static readonly Selector sel_level = "level";
         private static readonly Selector sel_setLevel = "setLevel:";
-        private static readonly Selector sel_slice = "slice";
-        private static readonly Selector sel_setSlice = "setSlice:";
-        private static readonly Selector sel_depthPlane = "depthPlane";
-        private static readonly Selector sel_setDepthPlane = "setDepthPlane:";
-        private static readonly Selector sel_resolveTexture = "resolveTexture";
-        private static readonly Selector sel_setResolveTexture = "setResolveTexture:";
-        private static readonly Selector sel_resolveLevel = "resolveLevel";
-        private static readonly Selector sel_setResolveLevel = "setResolveLevel:";
-        private static readonly Selector sel_resolveSlice = "resolveSlice";
-        private static readonly Selector sel_setResolveSlice = "setResolveSlice:";
-        private static readonly Selector sel_resolveDepthPlane = "resolveDepthPlane";
-        private static readonly Selector sel_setResolveDepthPlane = "setResolveDepthPlane:";
-        private static readonly Selector sel_loadAction = "loadAction";
         private static readonly Selector sel_setLoadAction = "setLoadAction:";
-        private static readonly Selector sel_storeAction = "storeAction";
+        private static readonly Selector sel_setResolveDepthPlane = "setResolveDepthPlane:";
+        private static readonly Selector sel_setResolveLevel = "setResolveLevel:";
+        private static readonly Selector sel_setResolveSlice = "setResolveSlice:";
+        private static readonly Selector sel_setResolveTexture = "setResolveTexture:";
+        private static readonly Selector sel_setSlice = "setSlice:";
         private static readonly Selector sel_setStoreAction = "setStoreAction:";
-        private static readonly Selector sel_storeActionOptions = "storeActionOptions";
         private static readonly Selector sel_setStoreActionOptions = "setStoreActionOptions:";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLRenderPassStencilAttachmentDescriptor : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLRenderPassStencilAttachmentDescriptor obj) => obj.NativePtr;
-        public static implicit operator MTLRenderPassAttachmentDescriptor(MTLRenderPassStencilAttachmentDescriptor obj) => new(obj.NativePtr);
-        public MTLRenderPassStencilAttachmentDescriptor(IntPtr ptr) => NativePtr = ptr;
-
-        public MTLRenderPassStencilAttachmentDescriptor()
-        {
-            var cls = new ObjectiveCClass("MTLRenderPassStencilAttachmentDescriptor");
-            NativePtr = cls.AllocInit();
-        }
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public uint ClearStencil
-        {
-            get => ObjectiveCRuntime.uint_objc_msgSend(NativePtr, sel_clearStencil);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setClearStencil, value);
-        }
-
-        public MTLMultisampleStencilResolveFilter StencilResolveFilter
-        {
-            get => (MTLMultisampleStencilResolveFilter)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_stencilResolveFilter);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStencilResolveFilter, (ulong)value);
-        }
-
-        public MTLTexture Texture
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_texture));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTexture, value);
-        }
-
-        public ulong Level
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_level);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLevel, value);
-        }
-
-        public ulong Slice
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_slice);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSlice, value);
-        }
-
-        public ulong DepthPlane
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_depthPlane);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDepthPlane, value);
-        }
-
-        public MTLTexture ResolveTexture
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_resolveTexture));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setResolveTexture, value);
-        }
-
-        public ulong ResolveLevel
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_resolveLevel);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setResolveLevel, value);
-        }
-
-        public ulong ResolveSlice
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_resolveSlice);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setResolveSlice, value);
-        }
-
-        public ulong ResolveDepthPlane
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_resolveDepthPlane);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setResolveDepthPlane, value);
-        }
-
-        public MTLLoadAction LoadAction
-        {
-            get => (MTLLoadAction)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_loadAction);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLoadAction, (ulong)value);
-        }
-
-        public MTLStoreAction StoreAction
-        {
-            get => (MTLStoreAction)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_storeAction);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStoreAction, (ulong)value);
-        }
-
-        public MTLStoreActionOptions StoreActionOptions
-        {
-            get => (MTLStoreActionOptions)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_storeActionOptions);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStoreActionOptions, (ulong)value);
-        }
-
-        private static readonly Selector sel_clearStencil = "clearStencil";
-        private static readonly Selector sel_setClearStencil = "setClearStencil:";
-        private static readonly Selector sel_stencilResolveFilter = "stencilResolveFilter";
-        private static readonly Selector sel_setStencilResolveFilter = "setStencilResolveFilter:";
-        private static readonly Selector sel_texture = "texture";
         private static readonly Selector sel_setTexture = "setTexture:";
-        private static readonly Selector sel_level = "level";
-        private static readonly Selector sel_setLevel = "setLevel:";
         private static readonly Selector sel_slice = "slice";
-        private static readonly Selector sel_setSlice = "setSlice:";
-        private static readonly Selector sel_depthPlane = "depthPlane";
-        private static readonly Selector sel_setDepthPlane = "setDepthPlane:";
-        private static readonly Selector sel_resolveTexture = "resolveTexture";
-        private static readonly Selector sel_setResolveTexture = "setResolveTexture:";
-        private static readonly Selector sel_resolveLevel = "resolveLevel";
-        private static readonly Selector sel_setResolveLevel = "setResolveLevel:";
-        private static readonly Selector sel_resolveSlice = "resolveSlice";
-        private static readonly Selector sel_setResolveSlice = "setResolveSlice:";
-        private static readonly Selector sel_resolveDepthPlane = "resolveDepthPlane";
-        private static readonly Selector sel_setResolveDepthPlane = "setResolveDepthPlane:";
-        private static readonly Selector sel_loadAction = "loadAction";
-        private static readonly Selector sel_setLoadAction = "setLoadAction:";
         private static readonly Selector sel_storeAction = "storeAction";
-        private static readonly Selector sel_setStoreAction = "setStoreAction:";
         private static readonly Selector sel_storeActionOptions = "storeActionOptions";
-        private static readonly Selector sel_setStoreActionOptions = "setStoreActionOptions:";
+        private static readonly Selector sel_texture = "texture";
         private static readonly Selector sel_release = "release";
     }
 
@@ -571,6 +319,268 @@ namespace SharpMetal.Metal
     }
 
     [SupportedOSPlatform("macos")]
+    public struct MTLRenderPassDepthAttachmentDescriptor : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLRenderPassDepthAttachmentDescriptor obj) => obj.NativePtr;
+        public static implicit operator MTLRenderPassAttachmentDescriptor(MTLRenderPassDepthAttachmentDescriptor obj) => new(obj.NativePtr);
+        public MTLRenderPassDepthAttachmentDescriptor(IntPtr ptr) => NativePtr = ptr;
+
+        public MTLRenderPassDepthAttachmentDescriptor()
+        {
+            var cls = new ObjectiveCClass("MTLRenderPassDepthAttachmentDescriptor");
+            NativePtr = cls.AllocInit();
+        }
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public double ClearDepth
+        {
+            get => ObjectiveCRuntime.double_objc_msgSend(NativePtr, sel_clearDepth);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setClearDepth, value);
+        }
+
+        public ulong DepthPlane
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_depthPlane);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDepthPlane, value);
+        }
+
+        public MTLMultisampleDepthResolveFilter DepthResolveFilter
+        {
+            get => (MTLMultisampleDepthResolveFilter)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_depthResolveFilter);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDepthResolveFilter, (ulong)value);
+        }
+
+        public ulong Level
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_level);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLevel, value);
+        }
+
+        public MTLLoadAction LoadAction
+        {
+            get => (MTLLoadAction)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_loadAction);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLoadAction, (ulong)value);
+        }
+
+        public ulong ResolveDepthPlane
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_resolveDepthPlane);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setResolveDepthPlane, value);
+        }
+
+        public ulong ResolveLevel
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_resolveLevel);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setResolveLevel, value);
+        }
+
+        public ulong ResolveSlice
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_resolveSlice);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setResolveSlice, value);
+        }
+
+        public MTLTexture ResolveTexture
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_resolveTexture));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setResolveTexture, value);
+        }
+
+        public ulong Slice
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_slice);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSlice, value);
+        }
+
+        public MTLStoreAction StoreAction
+        {
+            get => (MTLStoreAction)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_storeAction);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStoreAction, (ulong)value);
+        }
+
+        public MTLStoreActionOptions StoreActionOptions
+        {
+            get => (MTLStoreActionOptions)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_storeActionOptions);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStoreActionOptions, (ulong)value);
+        }
+
+        public MTLTexture Texture
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_texture));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTexture, value);
+        }
+
+        private static readonly Selector sel_clearDepth = "clearDepth";
+        private static readonly Selector sel_depthPlane = "depthPlane";
+        private static readonly Selector sel_depthResolveFilter = "depthResolveFilter";
+        private static readonly Selector sel_level = "level";
+        private static readonly Selector sel_loadAction = "loadAction";
+        private static readonly Selector sel_resolveDepthPlane = "resolveDepthPlane";
+        private static readonly Selector sel_resolveLevel = "resolveLevel";
+        private static readonly Selector sel_resolveSlice = "resolveSlice";
+        private static readonly Selector sel_resolveTexture = "resolveTexture";
+        private static readonly Selector sel_setClearDepth = "setClearDepth:";
+        private static readonly Selector sel_setDepthPlane = "setDepthPlane:";
+        private static readonly Selector sel_setDepthResolveFilter = "setDepthResolveFilter:";
+        private static readonly Selector sel_setLevel = "setLevel:";
+        private static readonly Selector sel_setLoadAction = "setLoadAction:";
+        private static readonly Selector sel_setResolveDepthPlane = "setResolveDepthPlane:";
+        private static readonly Selector sel_setResolveLevel = "setResolveLevel:";
+        private static readonly Selector sel_setResolveSlice = "setResolveSlice:";
+        private static readonly Selector sel_setResolveTexture = "setResolveTexture:";
+        private static readonly Selector sel_setSlice = "setSlice:";
+        private static readonly Selector sel_setStoreAction = "setStoreAction:";
+        private static readonly Selector sel_setStoreActionOptions = "setStoreActionOptions:";
+        private static readonly Selector sel_setTexture = "setTexture:";
+        private static readonly Selector sel_slice = "slice";
+        private static readonly Selector sel_storeAction = "storeAction";
+        private static readonly Selector sel_storeActionOptions = "storeActionOptions";
+        private static readonly Selector sel_texture = "texture";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
+    public struct MTLRenderPassDescriptor : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLRenderPassDescriptor obj) => obj.NativePtr;
+        public MTLRenderPassDescriptor(IntPtr ptr) => NativePtr = ptr;
+
+        public MTLRenderPassDescriptor()
+        {
+            var cls = new ObjectiveCClass("MTLRenderPassDescriptor");
+            NativePtr = cls.AllocInit();
+        }
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public MTLRenderPassColorAttachmentDescriptorArray ColorAttachments => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_colorAttachments));
+
+        public ulong DefaultRasterSampleCount
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_defaultRasterSampleCount);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDefaultRasterSampleCount, value);
+        }
+
+        public MTLRenderPassDepthAttachmentDescriptor DepthAttachment
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_depthAttachment));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDepthAttachment, value);
+        }
+
+        public ulong ImageblockSampleLength
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_imageblockSampleLength);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setImageblockSampleLength, value);
+        }
+
+        public MTLRasterizationRateMap RasterizationRateMap
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_rasterizationRateMap));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRasterizationRateMap, value);
+        }
+
+        public ulong RenderTargetArrayLength
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_renderTargetArrayLength);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRenderTargetArrayLength, value);
+        }
+
+        public ulong RenderTargetHeight
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_renderTargetHeight);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRenderTargetHeight, value);
+        }
+
+        public ulong RenderTargetWidth
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_renderTargetWidth);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRenderTargetWidth, value);
+        }
+
+        public MTLRenderPassSampleBufferAttachmentDescriptorArray SampleBufferAttachments => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_sampleBufferAttachments));
+
+        public MTLRenderPassStencilAttachmentDescriptor StencilAttachment
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_stencilAttachment));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStencilAttachment, value);
+        }
+
+        public ulong ThreadgroupMemoryLength
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_threadgroupMemoryLength);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setThreadgroupMemoryLength, value);
+        }
+
+        public ulong TileHeight
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_tileHeight);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTileHeight, value);
+        }
+
+        public ulong TileWidth
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_tileWidth);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTileWidth, value);
+        }
+
+        public MTLBuffer VisibilityResultBuffer
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_visibilityResultBuffer));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVisibilityResultBuffer, value);
+        }
+
+        public ulong GetSamplePositions(MTLSamplePosition positions, ulong count)
+        {
+            return ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_getSamplePositionscount, positions, count);
+        }
+
+        public void SetSamplePositions(MTLSamplePosition positions, ulong count)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSamplePositionscount, positions, count);
+        }
+
+        private static readonly Selector sel_colorAttachments = "colorAttachments";
+        private static readonly Selector sel_defaultRasterSampleCount = "defaultRasterSampleCount";
+        private static readonly Selector sel_depthAttachment = "depthAttachment";
+        private static readonly Selector sel_getSamplePositionscount = "getSamplePositions:count:";
+        private static readonly Selector sel_imageblockSampleLength = "imageblockSampleLength";
+        private static readonly Selector sel_rasterizationRateMap = "rasterizationRateMap";
+        private static readonly Selector sel_renderPassDescriptor = "renderPassDescriptor";
+        private static readonly Selector sel_renderTargetArrayLength = "renderTargetArrayLength";
+        private static readonly Selector sel_renderTargetHeight = "renderTargetHeight";
+        private static readonly Selector sel_renderTargetWidth = "renderTargetWidth";
+        private static readonly Selector sel_sampleBufferAttachments = "sampleBufferAttachments";
+        private static readonly Selector sel_setDefaultRasterSampleCount = "setDefaultRasterSampleCount:";
+        private static readonly Selector sel_setDepthAttachment = "setDepthAttachment:";
+        private static readonly Selector sel_setImageblockSampleLength = "setImageblockSampleLength:";
+        private static readonly Selector sel_setRasterizationRateMap = "setRasterizationRateMap:";
+        private static readonly Selector sel_setRenderTargetArrayLength = "setRenderTargetArrayLength:";
+        private static readonly Selector sel_setRenderTargetHeight = "setRenderTargetHeight:";
+        private static readonly Selector sel_setRenderTargetWidth = "setRenderTargetWidth:";
+        private static readonly Selector sel_setSamplePositionscount = "setSamplePositions:count:";
+        private static readonly Selector sel_setStencilAttachment = "setStencilAttachment:";
+        private static readonly Selector sel_setThreadgroupMemoryLength = "setThreadgroupMemoryLength:";
+        private static readonly Selector sel_setTileHeight = "setTileHeight:";
+        private static readonly Selector sel_setTileWidth = "setTileWidth:";
+        private static readonly Selector sel_setVisibilityResultBuffer = "setVisibilityResultBuffer:";
+        private static readonly Selector sel_stencilAttachment = "stencilAttachment";
+        private static readonly Selector sel_threadgroupMemoryLength = "threadgroupMemoryLength";
+        private static readonly Selector sel_tileHeight = "tileHeight";
+        private static readonly Selector sel_tileWidth = "tileWidth";
+        private static readonly Selector sel_visibilityResultBuffer = "visibilityResultBuffer";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
     public struct MTLRenderPassSampleBufferAttachmentDescriptor : IDisposable
     {
         public IntPtr NativePtr;
@@ -588,16 +598,10 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public MTLCounterSampleBuffer SampleBuffer
+        public ulong EndOfFragmentSampleIndex
         {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_sampleBuffer));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSampleBuffer, value);
-        }
-
-        public ulong StartOfVertexSampleIndex
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_startOfVertexSampleIndex);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStartOfVertexSampleIndex, value);
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_endOfFragmentSampleIndex);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setEndOfFragmentSampleIndex, value);
         }
 
         public ulong EndOfVertexSampleIndex
@@ -606,28 +610,34 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setEndOfVertexSampleIndex, value);
         }
 
+        public MTLCounterSampleBuffer SampleBuffer
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_sampleBuffer));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSampleBuffer, value);
+        }
+
         public ulong StartOfFragmentSampleIndex
         {
             get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_startOfFragmentSampleIndex);
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStartOfFragmentSampleIndex, value);
         }
 
-        public ulong EndOfFragmentSampleIndex
+        public ulong StartOfVertexSampleIndex
         {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_endOfFragmentSampleIndex);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setEndOfFragmentSampleIndex, value);
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_startOfVertexSampleIndex);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStartOfVertexSampleIndex, value);
         }
 
-        private static readonly Selector sel_sampleBuffer = "sampleBuffer";
-        private static readonly Selector sel_setSampleBuffer = "setSampleBuffer:";
-        private static readonly Selector sel_startOfVertexSampleIndex = "startOfVertexSampleIndex";
-        private static readonly Selector sel_setStartOfVertexSampleIndex = "setStartOfVertexSampleIndex:";
-        private static readonly Selector sel_endOfVertexSampleIndex = "endOfVertexSampleIndex";
-        private static readonly Selector sel_setEndOfVertexSampleIndex = "setEndOfVertexSampleIndex:";
-        private static readonly Selector sel_startOfFragmentSampleIndex = "startOfFragmentSampleIndex";
-        private static readonly Selector sel_setStartOfFragmentSampleIndex = "setStartOfFragmentSampleIndex:";
         private static readonly Selector sel_endOfFragmentSampleIndex = "endOfFragmentSampleIndex";
+        private static readonly Selector sel_endOfVertexSampleIndex = "endOfVertexSampleIndex";
+        private static readonly Selector sel_sampleBuffer = "sampleBuffer";
         private static readonly Selector sel_setEndOfFragmentSampleIndex = "setEndOfFragmentSampleIndex:";
+        private static readonly Selector sel_setEndOfVertexSampleIndex = "setEndOfVertexSampleIndex:";
+        private static readonly Selector sel_setSampleBuffer = "setSampleBuffer:";
+        private static readonly Selector sel_setStartOfFragmentSampleIndex = "setStartOfFragmentSampleIndex:";
+        private static readonly Selector sel_setStartOfVertexSampleIndex = "setStartOfVertexSampleIndex:";
+        private static readonly Selector sel_startOfFragmentSampleIndex = "startOfFragmentSampleIndex";
+        private static readonly Selector sel_startOfVertexSampleIndex = "startOfVertexSampleIndex";
         private static readonly Selector sel_release = "release";
     }
 
@@ -665,15 +675,16 @@ namespace SharpMetal.Metal
     }
 
     [SupportedOSPlatform("macos")]
-    public struct MTLRenderPassDescriptor : IDisposable
+    public struct MTLRenderPassStencilAttachmentDescriptor : IDisposable
     {
         public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLRenderPassDescriptor obj) => obj.NativePtr;
-        public MTLRenderPassDescriptor(IntPtr ptr) => NativePtr = ptr;
+        public static implicit operator IntPtr(MTLRenderPassStencilAttachmentDescriptor obj) => obj.NativePtr;
+        public static implicit operator MTLRenderPassAttachmentDescriptor(MTLRenderPassStencilAttachmentDescriptor obj) => new(obj.NativePtr);
+        public MTLRenderPassStencilAttachmentDescriptor(IntPtr ptr) => NativePtr = ptr;
 
-        public MTLRenderPassDescriptor()
+        public MTLRenderPassStencilAttachmentDescriptor()
         {
-            var cls = new ObjectiveCClass("MTLRenderPassDescriptor");
+            var cls = new ObjectiveCClass("MTLRenderPassStencilAttachmentDescriptor");
             NativePtr = cls.AllocInit();
         }
 
@@ -682,121 +693,110 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public MTLRenderPassColorAttachmentDescriptorArray ColorAttachments => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_colorAttachments));
-
-        public MTLRenderPassDepthAttachmentDescriptor DepthAttachment
+        public uint ClearStencil
         {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_depthAttachment));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDepthAttachment, value);
+            get => ObjectiveCRuntime.uint_objc_msgSend(NativePtr, sel_clearStencil);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setClearStencil, value);
         }
 
-        public MTLRenderPassStencilAttachmentDescriptor StencilAttachment
+        public ulong DepthPlane
         {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_stencilAttachment));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStencilAttachment, value);
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_depthPlane);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDepthPlane, value);
         }
 
-        public MTLBuffer VisibilityResultBuffer
+        public ulong Level
         {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_visibilityResultBuffer));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVisibilityResultBuffer, value);
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_level);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLevel, value);
         }
 
-        public ulong RenderTargetArrayLength
+        public MTLLoadAction LoadAction
         {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_renderTargetArrayLength);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRenderTargetArrayLength, value);
+            get => (MTLLoadAction)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_loadAction);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLoadAction, (ulong)value);
         }
 
-        public ulong ImageblockSampleLength
+        public ulong ResolveDepthPlane
         {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_imageblockSampleLength);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setImageblockSampleLength, value);
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_resolveDepthPlane);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setResolveDepthPlane, value);
         }
 
-        public ulong ThreadgroupMemoryLength
+        public ulong ResolveLevel
         {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_threadgroupMemoryLength);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setThreadgroupMemoryLength, value);
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_resolveLevel);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setResolveLevel, value);
         }
 
-        public ulong TileWidth
+        public ulong ResolveSlice
         {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_tileWidth);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTileWidth, value);
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_resolveSlice);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setResolveSlice, value);
         }
 
-        public ulong TileHeight
+        public MTLTexture ResolveTexture
         {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_tileHeight);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTileHeight, value);
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_resolveTexture));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setResolveTexture, value);
         }
 
-        public ulong DefaultRasterSampleCount
+        public ulong Slice
         {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_defaultRasterSampleCount);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDefaultRasterSampleCount, value);
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_slice);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSlice, value);
         }
 
-        public ulong RenderTargetWidth
+        public MTLMultisampleStencilResolveFilter StencilResolveFilter
         {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_renderTargetWidth);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRenderTargetWidth, value);
+            get => (MTLMultisampleStencilResolveFilter)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_stencilResolveFilter);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStencilResolveFilter, (ulong)value);
         }
 
-        public ulong RenderTargetHeight
+        public MTLStoreAction StoreAction
         {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_renderTargetHeight);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRenderTargetHeight, value);
+            get => (MTLStoreAction)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_storeAction);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStoreAction, (ulong)value);
         }
 
-        public MTLRasterizationRateMap RasterizationRateMap
+        public MTLStoreActionOptions StoreActionOptions
         {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_rasterizationRateMap));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRasterizationRateMap, value);
+            get => (MTLStoreActionOptions)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_storeActionOptions);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStoreActionOptions, (ulong)value);
         }
 
-        public MTLRenderPassSampleBufferAttachmentDescriptorArray SampleBufferAttachments => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_sampleBufferAttachments));
-
-        public void SetSamplePositions(MTLSamplePosition positions, ulong count)
+        public MTLTexture Texture
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSamplePositionscount, positions, count);
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_texture));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTexture, value);
         }
 
-        public ulong GetSamplePositions(MTLSamplePosition positions, ulong count)
-        {
-            return ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_getSamplePositionscount, positions, count);
-        }
-
-        private static readonly Selector sel_renderPassDescriptor = "renderPassDescriptor";
-        private static readonly Selector sel_colorAttachments = "colorAttachments";
-        private static readonly Selector sel_depthAttachment = "depthAttachment";
-        private static readonly Selector sel_setDepthAttachment = "setDepthAttachment:";
-        private static readonly Selector sel_stencilAttachment = "stencilAttachment";
-        private static readonly Selector sel_setStencilAttachment = "setStencilAttachment:";
-        private static readonly Selector sel_visibilityResultBuffer = "visibilityResultBuffer";
-        private static readonly Selector sel_setVisibilityResultBuffer = "setVisibilityResultBuffer:";
-        private static readonly Selector sel_renderTargetArrayLength = "renderTargetArrayLength";
-        private static readonly Selector sel_setRenderTargetArrayLength = "setRenderTargetArrayLength:";
-        private static readonly Selector sel_imageblockSampleLength = "imageblockSampleLength";
-        private static readonly Selector sel_setImageblockSampleLength = "setImageblockSampleLength:";
-        private static readonly Selector sel_threadgroupMemoryLength = "threadgroupMemoryLength";
-        private static readonly Selector sel_setThreadgroupMemoryLength = "setThreadgroupMemoryLength:";
-        private static readonly Selector sel_tileWidth = "tileWidth";
-        private static readonly Selector sel_setTileWidth = "setTileWidth:";
-        private static readonly Selector sel_tileHeight = "tileHeight";
-        private static readonly Selector sel_setTileHeight = "setTileHeight:";
-        private static readonly Selector sel_defaultRasterSampleCount = "defaultRasterSampleCount";
-        private static readonly Selector sel_setDefaultRasterSampleCount = "setDefaultRasterSampleCount:";
-        private static readonly Selector sel_renderTargetWidth = "renderTargetWidth";
-        private static readonly Selector sel_setRenderTargetWidth = "setRenderTargetWidth:";
-        private static readonly Selector sel_renderTargetHeight = "renderTargetHeight";
-        private static readonly Selector sel_setRenderTargetHeight = "setRenderTargetHeight:";
-        private static readonly Selector sel_setSamplePositionscount = "setSamplePositions:count:";
-        private static readonly Selector sel_getSamplePositionscount = "getSamplePositions:count:";
-        private static readonly Selector sel_rasterizationRateMap = "rasterizationRateMap";
-        private static readonly Selector sel_setRasterizationRateMap = "setRasterizationRateMap:";
-        private static readonly Selector sel_sampleBufferAttachments = "sampleBufferAttachments";
+        private static readonly Selector sel_clearStencil = "clearStencil";
+        private static readonly Selector sel_depthPlane = "depthPlane";
+        private static readonly Selector sel_level = "level";
+        private static readonly Selector sel_loadAction = "loadAction";
+        private static readonly Selector sel_resolveDepthPlane = "resolveDepthPlane";
+        private static readonly Selector sel_resolveLevel = "resolveLevel";
+        private static readonly Selector sel_resolveSlice = "resolveSlice";
+        private static readonly Selector sel_resolveTexture = "resolveTexture";
+        private static readonly Selector sel_setClearStencil = "setClearStencil:";
+        private static readonly Selector sel_setDepthPlane = "setDepthPlane:";
+        private static readonly Selector sel_setLevel = "setLevel:";
+        private static readonly Selector sel_setLoadAction = "setLoadAction:";
+        private static readonly Selector sel_setResolveDepthPlane = "setResolveDepthPlane:";
+        private static readonly Selector sel_setResolveLevel = "setResolveLevel:";
+        private static readonly Selector sel_setResolveSlice = "setResolveSlice:";
+        private static readonly Selector sel_setResolveTexture = "setResolveTexture:";
+        private static readonly Selector sel_setSlice = "setSlice:";
+        private static readonly Selector sel_setStencilResolveFilter = "setStencilResolveFilter:";
+        private static readonly Selector sel_setStoreAction = "setStoreAction:";
+        private static readonly Selector sel_setStoreActionOptions = "setStoreActionOptions:";
+        private static readonly Selector sel_setTexture = "setTexture:";
+        private static readonly Selector sel_slice = "slice";
+        private static readonly Selector sel_stencilResolveFilter = "stencilResolveFilter";
+        private static readonly Selector sel_storeAction = "storeAction";
+        private static readonly Selector sel_storeActionOptions = "storeActionOptions";
+        private static readonly Selector sel_texture = "texture";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLRenderPipeline.cs
+++ b/src/SharpMetal/Metal/MTLRenderPipeline.cs
@@ -50,186 +50,6 @@ namespace SharpMetal.Metal
         All = 15,
     }
 
-    [SupportedOSPlatform("macos")]
-    public enum MTLPrimitiveTopologyClass : ulong
-    {
-        Unspecified = 0,
-        Point = 1,
-        Line = 2,
-        Triangle = 3,
-    }
-
-    [SupportedOSPlatform("macos")]
-    public enum MTLTessellationPartitionMode : ulong
-    {
-        Pow2 = 0,
-        Integer = 1,
-        FractionalOdd = 2,
-        FractionalEven = 3,
-    }
-
-    [SupportedOSPlatform("macos")]
-    public enum MTLTessellationFactorStepFunction : ulong
-    {
-        Constant = 0,
-        PerPatch = 1,
-        PerInstance = 2,
-        PerPatchAndPerInstance = 3,
-    }
-
-    [SupportedOSPlatform("macos")]
-    public enum MTLTessellationFactorFormat : ulong
-    {
-        Half = 0,
-    }
-
-    [SupportedOSPlatform("macos")]
-    public enum MTLTessellationControlPointIndexType : ulong
-    {
-        None = 0,
-        UInt16 = 1,
-        UInt32 = 2,
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLRenderPipelineColorAttachmentDescriptor : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLRenderPipelineColorAttachmentDescriptor obj) => obj.NativePtr;
-        public MTLRenderPipelineColorAttachmentDescriptor(IntPtr ptr) => NativePtr = ptr;
-
-        public MTLRenderPipelineColorAttachmentDescriptor()
-        {
-            var cls = new ObjectiveCClass("MTLRenderPipelineColorAttachmentDescriptor");
-            NativePtr = cls.AllocInit();
-        }
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public MTLPixelFormat PixelFormat
-        {
-            get => (MTLPixelFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_pixelFormat);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPixelFormat, (ulong)value);
-        }
-
-        public bool BlendingEnabled => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isBlendingEnabled);
-
-        public MTLBlendFactor SourceRGBBlendFactor
-        {
-            get => (MTLBlendFactor)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_sourceRGBBlendFactor);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSourceRGBBlendFactor, (ulong)value);
-        }
-
-        public MTLBlendFactor DestinationRGBBlendFactor
-        {
-            get => (MTLBlendFactor)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_destinationRGBBlendFactor);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDestinationRGBBlendFactor, (ulong)value);
-        }
-
-        public MTLBlendOperation RgbBlendOperation
-        {
-            get => (MTLBlendOperation)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_rgbBlendOperation);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRgbBlendOperation, (ulong)value);
-        }
-
-        public MTLBlendFactor SourceAlphaBlendFactor
-        {
-            get => (MTLBlendFactor)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_sourceAlphaBlendFactor);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSourceAlphaBlendFactor, (ulong)value);
-        }
-
-        public MTLBlendFactor DestinationAlphaBlendFactor
-        {
-            get => (MTLBlendFactor)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_destinationAlphaBlendFactor);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDestinationAlphaBlendFactor, (ulong)value);
-        }
-
-        public MTLBlendOperation AlphaBlendOperation
-        {
-            get => (MTLBlendOperation)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_alphaBlendOperation);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setAlphaBlendOperation, (ulong)value);
-        }
-
-        public MTLColorWriteMask WriteMask
-        {
-            get => (MTLColorWriteMask)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_writeMask);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setWriteMask, (ulong)value);
-        }
-
-        public void SetBlendingEnabled(bool blendingEnabled)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBlendingEnabled, blendingEnabled);
-        }
-
-        private static readonly Selector sel_pixelFormat = "pixelFormat";
-        private static readonly Selector sel_setPixelFormat = "setPixelFormat:";
-        private static readonly Selector sel_isBlendingEnabled = "isBlendingEnabled";
-        private static readonly Selector sel_setBlendingEnabled = "setBlendingEnabled:";
-        private static readonly Selector sel_sourceRGBBlendFactor = "sourceRGBBlendFactor";
-        private static readonly Selector sel_setSourceRGBBlendFactor = "setSourceRGBBlendFactor:";
-        private static readonly Selector sel_destinationRGBBlendFactor = "destinationRGBBlendFactor";
-        private static readonly Selector sel_setDestinationRGBBlendFactor = "setDestinationRGBBlendFactor:";
-        private static readonly Selector sel_rgbBlendOperation = "rgbBlendOperation";
-        private static readonly Selector sel_setRgbBlendOperation = "setRgbBlendOperation:";
-        private static readonly Selector sel_sourceAlphaBlendFactor = "sourceAlphaBlendFactor";
-        private static readonly Selector sel_setSourceAlphaBlendFactor = "setSourceAlphaBlendFactor:";
-        private static readonly Selector sel_destinationAlphaBlendFactor = "destinationAlphaBlendFactor";
-        private static readonly Selector sel_setDestinationAlphaBlendFactor = "setDestinationAlphaBlendFactor:";
-        private static readonly Selector sel_alphaBlendOperation = "alphaBlendOperation";
-        private static readonly Selector sel_setAlphaBlendOperation = "setAlphaBlendOperation:";
-        private static readonly Selector sel_writeMask = "writeMask";
-        private static readonly Selector sel_setWriteMask = "setWriteMask:";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLRenderPipelineReflection : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLRenderPipelineReflection obj) => obj.NativePtr;
-        public MTLRenderPipelineReflection(IntPtr ptr) => NativePtr = ptr;
-
-        public MTLRenderPipelineReflection()
-        {
-            var cls = new ObjectiveCClass("MTLRenderPipelineReflection");
-            NativePtr = cls.AllocInit();
-        }
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public NSArray VertexBindings => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_vertexBindings));
-
-        public NSArray FragmentBindings => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_fragmentBindings));
-
-        public NSArray TileBindings => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_tileBindings));
-
-        public NSArray ObjectBindings => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_objectBindings));
-
-        public NSArray MeshBindings => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_meshBindings));
-
-        public NSArray VertexArguments => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_vertexArguments));
-
-        public NSArray FragmentArguments => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_fragmentArguments));
-
-        public NSArray TileArguments => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_tileArguments));
-
-        private static readonly Selector sel_vertexBindings = "vertexBindings";
-        private static readonly Selector sel_fragmentBindings = "fragmentBindings";
-        private static readonly Selector sel_tileBindings = "tileBindings";
-        private static readonly Selector sel_objectBindings = "objectBindings";
-        private static readonly Selector sel_meshBindings = "meshBindings";
-        private static readonly Selector sel_vertexArguments = "vertexArguments";
-        private static readonly Selector sel_fragmentArguments = "fragmentArguments";
-        private static readonly Selector sel_tileArguments = "tileArguments";
-        private static readonly Selector sel_release = "release";
-    }
-
     /// <summary>
     /// This is a private Metal API.
     /// It is not recommended for use in any production applications,
@@ -257,15 +77,56 @@ namespace SharpMetal.Metal
     }
 
     [SupportedOSPlatform("macos")]
-    public struct MTLRenderPipelineDescriptor : IDisposable
+    public enum MTLPrimitiveTopologyClass : ulong
+    {
+        Unspecified = 0,
+        Point = 1,
+        Line = 2,
+        Triangle = 3,
+    }
+
+    [SupportedOSPlatform("macos")]
+    public enum MTLTessellationControlPointIndexType : ulong
+    {
+        None = 0,
+        UInt16 = 1,
+        UInt32 = 2,
+    }
+
+    [SupportedOSPlatform("macos")]
+    public enum MTLTessellationFactorFormat : ulong
+    {
+        Half = 0,
+    }
+
+    [SupportedOSPlatform("macos")]
+    public enum MTLTessellationFactorStepFunction : ulong
+    {
+        Constant = 0,
+        PerPatch = 1,
+        PerInstance = 2,
+        PerPatchAndPerInstance = 3,
+    }
+
+    [SupportedOSPlatform("macos")]
+    public enum MTLTessellationPartitionMode : ulong
+    {
+        Pow2 = 0,
+        Integer = 1,
+        FractionalOdd = 2,
+        FractionalEven = 3,
+    }
+
+    [SupportedOSPlatform("macos")]
+    public struct MTLMeshRenderPipelineDescriptor : IDisposable
     {
         public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLRenderPipelineDescriptor obj) => obj.NativePtr;
-        public MTLRenderPipelineDescriptor(IntPtr ptr) => NativePtr = ptr;
+        public static implicit operator IntPtr(MTLMeshRenderPipelineDescriptor obj) => obj.NativePtr;
+        public MTLMeshRenderPipelineDescriptor(IntPtr ptr) => NativePtr = ptr;
 
-        public MTLRenderPipelineDescriptor()
+        public MTLMeshRenderPipelineDescriptor()
         {
-            var cls = new ObjectiveCClass("MTLRenderPipelineDescriptor");
+            var cls = new ObjectiveCClass("MTLMeshRenderPipelineDescriptor");
             NativePtr = cls.AllocInit();
         }
 
@@ -274,65 +135,9 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public NSString Label
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
-        }
+        public bool AlphaToCoverageEnabled => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isAlphaToCoverageEnabled);
 
-        public MTLFunction VertexFunction
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_vertexFunction));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexFunction, value);
-        }
-
-        public MTLFunction FragmentFunction
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_fragmentFunction));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFragmentFunction, value);
-        }
-
-        public MTLVertexDescriptor VertexDescriptor
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_vertexDescriptor));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexDescriptor, value);
-        }
-
-        public ulong SampleCount
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_sampleCount);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSampleCount, value);
-        }
-
-        public ulong RasterSampleCount
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_rasterSampleCount);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRasterSampleCount, value);
-        }
-
-        public bool AlphaToCoverageEnabled
-        {
-            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isAlphaToCoverageEnabled);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setAlphaToCoverageEnabled, value);
-        }
-
-        public bool AlphaToOneEnabled
-        {
-            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isAlphaToOneEnabled);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setAlphaToOneEnabled, value);
-        }
-
-        public bool RasterizationEnabled
-        {
-            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isRasterizationEnabled);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRasterizationEnabled, value);
-        }
-
-        public ulong MaxVertexAmplificationCount
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxVertexAmplificationCount);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxVertexAmplificationCount, value);
-        }
+        public bool AlphaToOneEnabled => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isAlphaToOneEnabled);
 
         public MTLRenderPipelineColorAttachmentDescriptorArray ColorAttachments => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_colorAttachments));
 
@@ -342,92 +147,12 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDepthAttachmentPixelFormat, (ulong)value);
         }
 
-        public MTLPixelFormat StencilAttachmentPixelFormat
-        {
-            get => (MTLPixelFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_stencilAttachmentPixelFormat);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStencilAttachmentPixelFormat, (ulong)value);
-        }
-
-        public MTLPrimitiveTopologyClass InputPrimitiveTopology
-        {
-            get => (MTLPrimitiveTopologyClass)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_inputPrimitiveTopology);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setInputPrimitiveTopology, (ulong)value);
-        }
-
-        public MTLTessellationPartitionMode TessellationPartitionMode
-        {
-            get => (MTLTessellationPartitionMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_tessellationPartitionMode);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTessellationPartitionMode, (ulong)value);
-        }
-
-        public ulong MaxTessellationFactor
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxTessellationFactor);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxTessellationFactor, value);
-        }
-
-        public bool TessellationFactorScaleEnabled
-        {
-            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isTessellationFactorScaleEnabled);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTessellationFactorScaleEnabled, value);
-        }
-
-        public MTLTessellationFactorFormat TessellationFactorFormat
-        {
-            get => (MTLTessellationFactorFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_tessellationFactorFormat);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTessellationFactorFormat, (ulong)value);
-        }
-
-        public MTLTessellationControlPointIndexType TessellationControlPointIndexType
-        {
-            get => (MTLTessellationControlPointIndexType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_tessellationControlPointIndexType);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTessellationControlPointIndexType, (ulong)value);
-        }
-
-        public MTLTessellationFactorStepFunction TessellationFactorStepFunction
-        {
-            get => (MTLTessellationFactorStepFunction)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_tessellationFactorStepFunction);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTessellationFactorStepFunction, (ulong)value);
-        }
-
-        public MTLWinding TessellationOutputWindingOrder
-        {
-            get => (MTLWinding)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_tessellationOutputWindingOrder);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTessellationOutputWindingOrder, (ulong)value);
-        }
-
-        public MTLPipelineBufferDescriptorArray VertexBuffers => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_vertexBuffers));
-
         public MTLPipelineBufferDescriptorArray FragmentBuffers => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_fragmentBuffers));
 
-        public bool SupportIndirectCommandBuffers
+        public MTLFunction FragmentFunction
         {
-            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportIndirectCommandBuffers);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSupportIndirectCommandBuffers, value);
-        }
-
-        public NSArray BinaryArchives
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_binaryArchives));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBinaryArchives, value);
-        }
-
-        public NSArray VertexPreloadedLibraries
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_vertexPreloadedLibraries));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexPreloadedLibraries, value);
-        }
-
-        public NSArray FragmentPreloadedLibraries
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_fragmentPreloadedLibraries));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFragmentPreloadedLibraries, value);
-        }
-
-        public MTLLinkedFunctions VertexLinkedFunctions
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_vertexLinkedFunctions));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexLinkedFunctions, value);
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_fragmentFunction));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFragmentFunction, value);
         }
 
         public MTLLinkedFunctions FragmentLinkedFunctions
@@ -436,50 +161,100 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFragmentLinkedFunctions, value);
         }
 
-        public bool SupportAddingVertexBinaryFunctions
+        public NSString Label
         {
-            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportAddingVertexBinaryFunctions);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSupportAddingVertexBinaryFunctions, value);
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
         }
 
-        public bool SupportAddingFragmentBinaryFunctions
+        public ulong MaxTotalThreadgroupsPerMeshGrid
         {
-            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportAddingFragmentBinaryFunctions);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSupportAddingFragmentBinaryFunctions, value);
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxTotalThreadgroupsPerMeshGrid);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxTotalThreadgroupsPerMeshGrid, value);
         }
 
-        public ulong MaxVertexCallStackDepth
+        public ulong MaxTotalThreadsPerMeshThreadgroup
         {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxVertexCallStackDepth);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxVertexCallStackDepth, value);
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxTotalThreadsPerMeshThreadgroup);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxTotalThreadsPerMeshThreadgroup, value);
         }
 
-        public ulong MaxFragmentCallStackDepth
+        public ulong MaxTotalThreadsPerObjectThreadgroup
         {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxFragmentCallStackDepth);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxFragmentCallStackDepth, value);
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxTotalThreadsPerObjectThreadgroup);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxTotalThreadsPerObjectThreadgroup, value);
         }
 
-        /// <summary>
-        /// This is a private Metal API.
-        /// It is not recommended for use in any production applications,
-        /// and may break at any time without warning. Hic sunt dracones.
-        /// </summary>
-        public bool LogicOperationEnabled
+        public ulong MaxVertexAmplificationCount
         {
-            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isLogicOperationEnabled);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLogicOperationEnabled, value);
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxVertexAmplificationCount);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxVertexAmplificationCount, value);
         }
 
-        /// <summary>
-        /// This is a private Metal API.
-        /// It is not recommended for use in any production applications,
-        /// and may break at any time without warning. Hic sunt dracones.
-        /// </summary>
-        public MTLLogicOperation LogicOperation
+        public MTLPipelineBufferDescriptorArray MeshBuffers => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_meshBuffers));
+
+        public MTLFunction MeshFunction
         {
-            get => (MTLLogicOperation)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_logicOperation);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLogicOperation, (ulong)value);
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_meshFunction));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMeshFunction, value);
+        }
+
+        public MTLLinkedFunctions MeshLinkedFunctions
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_meshLinkedFunctions));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMeshLinkedFunctions, value);
+        }
+
+        public bool MeshThreadgroupSizeIsMultipleOfThreadExecutionWidth
+        {
+            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_meshThreadgroupSizeIsMultipleOfThreadExecutionWidth);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMeshThreadgroupSizeIsMultipleOfThreadExecutionWidth, value);
+        }
+
+        public MTLPipelineBufferDescriptorArray ObjectBuffers => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_objectBuffers));
+
+        public MTLFunction ObjectFunction
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_objectFunction));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setObjectFunction, value);
+        }
+
+        public MTLLinkedFunctions ObjectLinkedFunctions
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_objectLinkedFunctions));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setObjectLinkedFunctions, value);
+        }
+
+        public bool ObjectThreadgroupSizeIsMultipleOfThreadExecutionWidth
+        {
+            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_objectThreadgroupSizeIsMultipleOfThreadExecutionWidth);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setObjectThreadgroupSizeIsMultipleOfThreadExecutionWidth, value);
+        }
+
+        public ulong PayloadMemoryLength
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_payloadMemoryLength);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPayloadMemoryLength, value);
+        }
+
+        public bool RasterizationEnabled => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isRasterizationEnabled);
+
+        public ulong RasterSampleCount
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_rasterSampleCount);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRasterSampleCount, value);
+        }
+
+        public MTLPixelFormat StencilAttachmentPixelFormat
+        {
+            get => (MTLPixelFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_stencilAttachmentPixelFormat);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStencilAttachmentPixelFormat, (ulong)value);
+        }
+
+        public bool SupportIndirectCommandBuffers
+        {
+            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportIndirectCommandBuffers);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSupportIndirectCommandBuffers, value);
         }
 
         public void Reset()
@@ -487,87 +262,81 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_reset);
         }
 
-        private static readonly Selector sel_label = "label";
-        private static readonly Selector sel_setLabel = "setLabel:";
-        private static readonly Selector sel_vertexFunction = "vertexFunction";
-        private static readonly Selector sel_setVertexFunction = "setVertexFunction:";
-        private static readonly Selector sel_fragmentFunction = "fragmentFunction";
-        private static readonly Selector sel_setFragmentFunction = "setFragmentFunction:";
-        private static readonly Selector sel_vertexDescriptor = "vertexDescriptor";
-        private static readonly Selector sel_setVertexDescriptor = "setVertexDescriptor:";
-        private static readonly Selector sel_sampleCount = "sampleCount";
-        private static readonly Selector sel_setSampleCount = "setSampleCount:";
-        private static readonly Selector sel_rasterSampleCount = "rasterSampleCount";
-        private static readonly Selector sel_setRasterSampleCount = "setRasterSampleCount:";
-        private static readonly Selector sel_isAlphaToCoverageEnabled = "isAlphaToCoverageEnabled";
-        private static readonly Selector sel_setAlphaToCoverageEnabled = "setAlphaToCoverageEnabled:";
-        private static readonly Selector sel_isAlphaToOneEnabled = "isAlphaToOneEnabled";
-        private static readonly Selector sel_setAlphaToOneEnabled = "setAlphaToOneEnabled:";
-        private static readonly Selector sel_isRasterizationEnabled = "isRasterizationEnabled";
-        private static readonly Selector sel_setRasterizationEnabled = "setRasterizationEnabled:";
-        private static readonly Selector sel_maxVertexAmplificationCount = "maxVertexAmplificationCount";
-        private static readonly Selector sel_setMaxVertexAmplificationCount = "setMaxVertexAmplificationCount:";
+        public void SetAlphaToCoverageEnabled(bool alphaToCoverageEnabled)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setAlphaToCoverageEnabled, alphaToCoverageEnabled);
+        }
+
+        public void SetAlphaToOneEnabled(bool alphaToOneEnabled)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setAlphaToOneEnabled, alphaToOneEnabled);
+        }
+
+        public void SetRasterizationEnabled(bool rasterizationEnabled)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRasterizationEnabled, rasterizationEnabled);
+        }
+
         private static readonly Selector sel_colorAttachments = "colorAttachments";
         private static readonly Selector sel_depthAttachmentPixelFormat = "depthAttachmentPixelFormat";
-        private static readonly Selector sel_setDepthAttachmentPixelFormat = "setDepthAttachmentPixelFormat:";
-        private static readonly Selector sel_stencilAttachmentPixelFormat = "stencilAttachmentPixelFormat";
-        private static readonly Selector sel_setStencilAttachmentPixelFormat = "setStencilAttachmentPixelFormat:";
-        private static readonly Selector sel_inputPrimitiveTopology = "inputPrimitiveTopology";
-        private static readonly Selector sel_setInputPrimitiveTopology = "setInputPrimitiveTopology:";
-        private static readonly Selector sel_tessellationPartitionMode = "tessellationPartitionMode";
-        private static readonly Selector sel_setTessellationPartitionMode = "setTessellationPartitionMode:";
-        private static readonly Selector sel_maxTessellationFactor = "maxTessellationFactor";
-        private static readonly Selector sel_setMaxTessellationFactor = "setMaxTessellationFactor:";
-        private static readonly Selector sel_isTessellationFactorScaleEnabled = "isTessellationFactorScaleEnabled";
-        private static readonly Selector sel_setTessellationFactorScaleEnabled = "setTessellationFactorScaleEnabled:";
-        private static readonly Selector sel_tessellationFactorFormat = "tessellationFactorFormat";
-        private static readonly Selector sel_setTessellationFactorFormat = "setTessellationFactorFormat:";
-        private static readonly Selector sel_tessellationControlPointIndexType = "tessellationControlPointIndexType";
-        private static readonly Selector sel_setTessellationControlPointIndexType = "setTessellationControlPointIndexType:";
-        private static readonly Selector sel_tessellationFactorStepFunction = "tessellationFactorStepFunction";
-        private static readonly Selector sel_setTessellationFactorStepFunction = "setTessellationFactorStepFunction:";
-        private static readonly Selector sel_tessellationOutputWindingOrder = "tessellationOutputWindingOrder";
-        private static readonly Selector sel_setTessellationOutputWindingOrder = "setTessellationOutputWindingOrder:";
-        private static readonly Selector sel_vertexBuffers = "vertexBuffers";
         private static readonly Selector sel_fragmentBuffers = "fragmentBuffers";
-        private static readonly Selector sel_supportIndirectCommandBuffers = "supportIndirectCommandBuffers";
-        private static readonly Selector sel_setSupportIndirectCommandBuffers = "setSupportIndirectCommandBuffers:";
-        private static readonly Selector sel_binaryArchives = "binaryArchives";
-        private static readonly Selector sel_setBinaryArchives = "setBinaryArchives:";
-        private static readonly Selector sel_vertexPreloadedLibraries = "vertexPreloadedLibraries";
-        private static readonly Selector sel_setVertexPreloadedLibraries = "setVertexPreloadedLibraries:";
-        private static readonly Selector sel_fragmentPreloadedLibraries = "fragmentPreloadedLibraries";
-        private static readonly Selector sel_setFragmentPreloadedLibraries = "setFragmentPreloadedLibraries:";
-        private static readonly Selector sel_vertexLinkedFunctions = "vertexLinkedFunctions";
-        private static readonly Selector sel_setVertexLinkedFunctions = "setVertexLinkedFunctions:";
+        private static readonly Selector sel_fragmentFunction = "fragmentFunction";
         private static readonly Selector sel_fragmentLinkedFunctions = "fragmentLinkedFunctions";
-        private static readonly Selector sel_setFragmentLinkedFunctions = "setFragmentLinkedFunctions:";
-        private static readonly Selector sel_supportAddingVertexBinaryFunctions = "supportAddingVertexBinaryFunctions";
-        private static readonly Selector sel_setSupportAddingVertexBinaryFunctions = "setSupportAddingVertexBinaryFunctions:";
-        private static readonly Selector sel_supportAddingFragmentBinaryFunctions = "supportAddingFragmentBinaryFunctions";
-        private static readonly Selector sel_setSupportAddingFragmentBinaryFunctions = "setSupportAddingFragmentBinaryFunctions:";
-        private static readonly Selector sel_maxVertexCallStackDepth = "maxVertexCallStackDepth";
-        private static readonly Selector sel_setMaxVertexCallStackDepth = "setMaxVertexCallStackDepth:";
-        private static readonly Selector sel_maxFragmentCallStackDepth = "maxFragmentCallStackDepth";
-        private static readonly Selector sel_setMaxFragmentCallStackDepth = "setMaxFragmentCallStackDepth:";
-        private static readonly Selector sel_isLogicOperationEnabled = "isLogicOperationEnabled";
-        private static readonly Selector sel_setLogicOperationEnabled = "setLogicOperationEnabled:";
-        private static readonly Selector sel_logicOperation = "logicOperation";
-        private static readonly Selector sel_setLogicOperation = "setLogicOperation:";
+        private static readonly Selector sel_isAlphaToCoverageEnabled = "isAlphaToCoverageEnabled";
+        private static readonly Selector sel_isAlphaToOneEnabled = "isAlphaToOneEnabled";
+        private static readonly Selector sel_isRasterizationEnabled = "isRasterizationEnabled";
+        private static readonly Selector sel_label = "label";
+        private static readonly Selector sel_maxTotalThreadgroupsPerMeshGrid = "maxTotalThreadgroupsPerMeshGrid";
+        private static readonly Selector sel_maxTotalThreadsPerMeshThreadgroup = "maxTotalThreadsPerMeshThreadgroup";
+        private static readonly Selector sel_maxTotalThreadsPerObjectThreadgroup = "maxTotalThreadsPerObjectThreadgroup";
+        private static readonly Selector sel_maxVertexAmplificationCount = "maxVertexAmplificationCount";
+        private static readonly Selector sel_meshBuffers = "meshBuffers";
+        private static readonly Selector sel_meshFunction = "meshFunction";
+        private static readonly Selector sel_meshLinkedFunctions = "meshLinkedFunctions";
+        private static readonly Selector sel_meshThreadgroupSizeIsMultipleOfThreadExecutionWidth = "meshThreadgroupSizeIsMultipleOfThreadExecutionWidth";
+        private static readonly Selector sel_objectBuffers = "objectBuffers";
+        private static readonly Selector sel_objectFunction = "objectFunction";
+        private static readonly Selector sel_objectLinkedFunctions = "objectLinkedFunctions";
+        private static readonly Selector sel_objectThreadgroupSizeIsMultipleOfThreadExecutionWidth = "objectThreadgroupSizeIsMultipleOfThreadExecutionWidth";
+        private static readonly Selector sel_payloadMemoryLength = "payloadMemoryLength";
+        private static readonly Selector sel_rasterSampleCount = "rasterSampleCount";
         private static readonly Selector sel_reset = "reset";
+        private static readonly Selector sel_setAlphaToCoverageEnabled = "setAlphaToCoverageEnabled:";
+        private static readonly Selector sel_setAlphaToOneEnabled = "setAlphaToOneEnabled:";
+        private static readonly Selector sel_setDepthAttachmentPixelFormat = "setDepthAttachmentPixelFormat:";
+        private static readonly Selector sel_setFragmentFunction = "setFragmentFunction:";
+        private static readonly Selector sel_setFragmentLinkedFunctions = "setFragmentLinkedFunctions:";
+        private static readonly Selector sel_setLabel = "setLabel:";
+        private static readonly Selector sel_setMaxTotalThreadgroupsPerMeshGrid = "setMaxTotalThreadgroupsPerMeshGrid:";
+        private static readonly Selector sel_setMaxTotalThreadsPerMeshThreadgroup = "setMaxTotalThreadsPerMeshThreadgroup:";
+        private static readonly Selector sel_setMaxTotalThreadsPerObjectThreadgroup = "setMaxTotalThreadsPerObjectThreadgroup:";
+        private static readonly Selector sel_setMaxVertexAmplificationCount = "setMaxVertexAmplificationCount:";
+        private static readonly Selector sel_setMeshFunction = "setMeshFunction:";
+        private static readonly Selector sel_setMeshLinkedFunctions = "setMeshLinkedFunctions:";
+        private static readonly Selector sel_setMeshThreadgroupSizeIsMultipleOfThreadExecutionWidth = "setMeshThreadgroupSizeIsMultipleOfThreadExecutionWidth:";
+        private static readonly Selector sel_setObjectFunction = "setObjectFunction:";
+        private static readonly Selector sel_setObjectLinkedFunctions = "setObjectLinkedFunctions:";
+        private static readonly Selector sel_setObjectThreadgroupSizeIsMultipleOfThreadExecutionWidth = "setObjectThreadgroupSizeIsMultipleOfThreadExecutionWidth:";
+        private static readonly Selector sel_setPayloadMemoryLength = "setPayloadMemoryLength:";
+        private static readonly Selector sel_setRasterizationEnabled = "setRasterizationEnabled:";
+        private static readonly Selector sel_setRasterSampleCount = "setRasterSampleCount:";
+        private static readonly Selector sel_setStencilAttachmentPixelFormat = "setStencilAttachmentPixelFormat:";
+        private static readonly Selector sel_setSupportIndirectCommandBuffers = "setSupportIndirectCommandBuffers:";
+        private static readonly Selector sel_stencilAttachmentPixelFormat = "stencilAttachmentPixelFormat";
+        private static readonly Selector sel_supportIndirectCommandBuffers = "supportIndirectCommandBuffers";
         private static readonly Selector sel_release = "release";
     }
 
     [SupportedOSPlatform("macos")]
-    public struct MTLRenderPipelineFunctionsDescriptor : IDisposable
+    public struct MTLRenderPipelineColorAttachmentDescriptor : IDisposable
     {
         public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLRenderPipelineFunctionsDescriptor obj) => obj.NativePtr;
-        public MTLRenderPipelineFunctionsDescriptor(IntPtr ptr) => NativePtr = ptr;
+        public static implicit operator IntPtr(MTLRenderPipelineColorAttachmentDescriptor obj) => obj.NativePtr;
+        public MTLRenderPipelineColorAttachmentDescriptor(IntPtr ptr) => NativePtr = ptr;
 
-        public MTLRenderPipelineFunctionsDescriptor()
+        public MTLRenderPipelineColorAttachmentDescriptor()
         {
-            var cls = new ObjectiveCClass("MTLRenderPipelineFunctionsDescriptor");
+            var cls = new ObjectiveCClass("MTLRenderPipelineColorAttachmentDescriptor");
             NativePtr = cls.AllocInit();
         }
 
@@ -576,111 +345,79 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public NSArray VertexAdditionalBinaryFunctions
+        public MTLBlendOperation AlphaBlendOperation
         {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_vertexAdditionalBinaryFunctions));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexAdditionalBinaryFunctions, value);
+            get => (MTLBlendOperation)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_alphaBlendOperation);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setAlphaBlendOperation, (ulong)value);
         }
 
-        public NSArray FragmentAdditionalBinaryFunctions
+        public bool BlendingEnabled => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isBlendingEnabled);
+
+        public MTLBlendFactor DestinationAlphaBlendFactor
         {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_fragmentAdditionalBinaryFunctions));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFragmentAdditionalBinaryFunctions, value);
+            get => (MTLBlendFactor)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_destinationAlphaBlendFactor);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDestinationAlphaBlendFactor, (ulong)value);
         }
 
-        public NSArray TileAdditionalBinaryFunctions
+        public MTLBlendFactor DestinationRGBBlendFactor
         {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_tileAdditionalBinaryFunctions));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTileAdditionalBinaryFunctions, value);
+            get => (MTLBlendFactor)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_destinationRGBBlendFactor);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDestinationRGBBlendFactor, (ulong)value);
         }
 
-        private static readonly Selector sel_vertexAdditionalBinaryFunctions = "vertexAdditionalBinaryFunctions";
-        private static readonly Selector sel_setVertexAdditionalBinaryFunctions = "setVertexAdditionalBinaryFunctions:";
-        private static readonly Selector sel_fragmentAdditionalBinaryFunctions = "fragmentAdditionalBinaryFunctions";
-        private static readonly Selector sel_setFragmentAdditionalBinaryFunctions = "setFragmentAdditionalBinaryFunctions:";
-        private static readonly Selector sel_tileAdditionalBinaryFunctions = "tileAdditionalBinaryFunctions";
-        private static readonly Selector sel_setTileAdditionalBinaryFunctions = "setTileAdditionalBinaryFunctions:";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLRenderPipelineState : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLRenderPipelineState obj) => obj.NativePtr;
-        public MTLRenderPipelineState(IntPtr ptr) => NativePtr = ptr;
-
-        public void Dispose()
+        public MTLPixelFormat PixelFormat
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+            get => (MTLPixelFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_pixelFormat);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPixelFormat, (ulong)value);
         }
 
-        public NSString Label => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
-
-        public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
-
-        public ulong MaxTotalThreadsPerThreadgroup => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxTotalThreadsPerThreadgroup);
-
-        public bool ThreadgroupSizeMatchesTileSize => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_threadgroupSizeMatchesTileSize);
-
-        public ulong ImageblockSampleLength => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_imageblockSampleLength);
-
-        public bool SupportIndirectCommandBuffers => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportIndirectCommandBuffers);
-
-        public ulong MaxTotalThreadsPerObjectThreadgroup => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxTotalThreadsPerObjectThreadgroup);
-
-        public ulong MaxTotalThreadsPerMeshThreadgroup => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxTotalThreadsPerMeshThreadgroup);
-
-        public ulong ObjectThreadExecutionWidth => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_objectThreadExecutionWidth);
-
-        public ulong MeshThreadExecutionWidth => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_meshThreadExecutionWidth);
-
-        public ulong MaxTotalThreadgroupsPerMeshGrid => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxTotalThreadgroupsPerMeshGrid);
-
-        public MTLResourceID GpuResourceID => ObjectiveCRuntime.MTLResourceID_objc_msgSend(NativePtr, sel_gpuResourceID);
-
-        public ulong ImageblockMemoryLength(MTLSize imageblockDimensions)
+        public MTLBlendOperation RgbBlendOperation
         {
-            return ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_imageblockMemoryLengthForDimensions, imageblockDimensions);
+            get => (MTLBlendOperation)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_rgbBlendOperation);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRgbBlendOperation, (ulong)value);
         }
 
-        public MTLFunctionHandle FunctionHandle(MTLFunction function, MTLRenderStages stage)
+        public MTLBlendFactor SourceAlphaBlendFactor
         {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_functionHandleWithFunctionstage, function, (ulong)stage));
+            get => (MTLBlendFactor)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_sourceAlphaBlendFactor);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSourceAlphaBlendFactor, (ulong)value);
         }
 
-        public MTLVisibleFunctionTable NewVisibleFunctionTable(MTLVisibleFunctionTableDescriptor descriptor, MTLRenderStages stage)
+        public MTLBlendFactor SourceRGBBlendFactor
         {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newVisibleFunctionTableWithDescriptorstage, descriptor, (ulong)stage));
+            get => (MTLBlendFactor)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_sourceRGBBlendFactor);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSourceRGBBlendFactor, (ulong)value);
         }
 
-        public MTLIntersectionFunctionTable NewIntersectionFunctionTable(MTLIntersectionFunctionTableDescriptor descriptor, MTLRenderStages stage)
+        public MTLColorWriteMask WriteMask
         {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newIntersectionFunctionTableWithDescriptorstage, descriptor, (ulong)stage));
+            get => (MTLColorWriteMask)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_writeMask);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setWriteMask, (ulong)value);
         }
 
-        public MTLRenderPipelineState NewRenderPipelineState(MTLRenderPipelineFunctionsDescriptor additionalBinaryFunctions, ref NSError error)
+        public void SetBlendingEnabled(bool blendingEnabled)
         {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newRenderPipelineStateWithAdditionalBinaryFunctionserror, additionalBinaryFunctions, ref error.NativePtr));
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBlendingEnabled, blendingEnabled);
         }
 
-        private static readonly Selector sel_label = "label";
-        private static readonly Selector sel_device = "device";
-        private static readonly Selector sel_maxTotalThreadsPerThreadgroup = "maxTotalThreadsPerThreadgroup";
-        private static readonly Selector sel_threadgroupSizeMatchesTileSize = "threadgroupSizeMatchesTileSize";
-        private static readonly Selector sel_imageblockSampleLength = "imageblockSampleLength";
-        private static readonly Selector sel_imageblockMemoryLengthForDimensions = "imageblockMemoryLengthForDimensions:";
-        private static readonly Selector sel_supportIndirectCommandBuffers = "supportIndirectCommandBuffers";
-        private static readonly Selector sel_maxTotalThreadsPerObjectThreadgroup = "maxTotalThreadsPerObjectThreadgroup";
-        private static readonly Selector sel_maxTotalThreadsPerMeshThreadgroup = "maxTotalThreadsPerMeshThreadgroup";
-        private static readonly Selector sel_objectThreadExecutionWidth = "objectThreadExecutionWidth";
-        private static readonly Selector sel_meshThreadExecutionWidth = "meshThreadExecutionWidth";
-        private static readonly Selector sel_maxTotalThreadgroupsPerMeshGrid = "maxTotalThreadgroupsPerMeshGrid";
-        private static readonly Selector sel_gpuResourceID = "gpuResourceID";
-        private static readonly Selector sel_functionHandleWithFunctionstage = "functionHandleWithFunction:stage:";
-        private static readonly Selector sel_newVisibleFunctionTableWithDescriptorstage = "newVisibleFunctionTableWithDescriptor:stage:";
-        private static readonly Selector sel_newIntersectionFunctionTableWithDescriptorstage = "newIntersectionFunctionTableWithDescriptor:stage:";
-        private static readonly Selector sel_newRenderPipelineStateWithAdditionalBinaryFunctionserror = "newRenderPipelineStateWithAdditionalBinaryFunctions:error:";
+        private static readonly Selector sel_alphaBlendOperation = "alphaBlendOperation";
+        private static readonly Selector sel_destinationAlphaBlendFactor = "destinationAlphaBlendFactor";
+        private static readonly Selector sel_destinationRGBBlendFactor = "destinationRGBBlendFactor";
+        private static readonly Selector sel_isBlendingEnabled = "isBlendingEnabled";
+        private static readonly Selector sel_pixelFormat = "pixelFormat";
+        private static readonly Selector sel_rgbBlendOperation = "rgbBlendOperation";
+        private static readonly Selector sel_setAlphaBlendOperation = "setAlphaBlendOperation:";
+        private static readonly Selector sel_setBlendingEnabled = "setBlendingEnabled:";
+        private static readonly Selector sel_setDestinationAlphaBlendFactor = "setDestinationAlphaBlendFactor:";
+        private static readonly Selector sel_setDestinationRGBBlendFactor = "setDestinationRGBBlendFactor:";
+        private static readonly Selector sel_setPixelFormat = "setPixelFormat:";
+        private static readonly Selector sel_setRgbBlendOperation = "setRgbBlendOperation:";
+        private static readonly Selector sel_setSourceAlphaBlendFactor = "setSourceAlphaBlendFactor:";
+        private static readonly Selector sel_setSourceRGBBlendFactor = "setSourceRGBBlendFactor:";
+        private static readonly Selector sel_setWriteMask = "setWriteMask:";
+        private static readonly Selector sel_sourceAlphaBlendFactor = "sourceAlphaBlendFactor";
+        private static readonly Selector sel_sourceRGBBlendFactor = "sourceRGBBlendFactor";
+        private static readonly Selector sel_writeMask = "writeMask";
         private static readonly Selector sel_release = "release";
     }
 
@@ -714,6 +451,479 @@ namespace SharpMetal.Metal
 
         private static readonly Selector sel_objectAtIndexedSubscript = "objectAtIndexedSubscript:";
         private static readonly Selector sel_setObjectatIndexedSubscript = "setObject:atIndexedSubscript:";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
+    public struct MTLRenderPipelineDescriptor : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLRenderPipelineDescriptor obj) => obj.NativePtr;
+        public MTLRenderPipelineDescriptor(IntPtr ptr) => NativePtr = ptr;
+
+        public MTLRenderPipelineDescriptor()
+        {
+            var cls = new ObjectiveCClass("MTLRenderPipelineDescriptor");
+            NativePtr = cls.AllocInit();
+        }
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public bool AlphaToCoverageEnabled
+        {
+            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isAlphaToCoverageEnabled);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setAlphaToCoverageEnabled, value);
+        }
+
+        public bool AlphaToOneEnabled
+        {
+            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isAlphaToOneEnabled);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setAlphaToOneEnabled, value);
+        }
+
+        public NSArray BinaryArchives
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_binaryArchives));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBinaryArchives, value);
+        }
+
+        public MTLRenderPipelineColorAttachmentDescriptorArray ColorAttachments => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_colorAttachments));
+
+        public MTLPixelFormat DepthAttachmentPixelFormat
+        {
+            get => (MTLPixelFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_depthAttachmentPixelFormat);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDepthAttachmentPixelFormat, (ulong)value);
+        }
+
+        public MTLPipelineBufferDescriptorArray FragmentBuffers => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_fragmentBuffers));
+
+        public MTLFunction FragmentFunction
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_fragmentFunction));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFragmentFunction, value);
+        }
+
+        public MTLLinkedFunctions FragmentLinkedFunctions
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_fragmentLinkedFunctions));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFragmentLinkedFunctions, value);
+        }
+
+        public NSArray FragmentPreloadedLibraries
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_fragmentPreloadedLibraries));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFragmentPreloadedLibraries, value);
+        }
+
+        public MTLPrimitiveTopologyClass InputPrimitiveTopology
+        {
+            get => (MTLPrimitiveTopologyClass)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_inputPrimitiveTopology);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setInputPrimitiveTopology, (ulong)value);
+        }
+
+        public NSString Label
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
+        }
+
+        /// <summary>
+        /// This is a private Metal API.
+        /// It is not recommended for use in any production applications,
+        /// and may break at any time without warning. Hic sunt dracones.
+        /// </summary>
+        public MTLLogicOperation LogicOperation
+        {
+            get => (MTLLogicOperation)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_logicOperation);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLogicOperation, (ulong)value);
+        }
+
+        /// <summary>
+        /// This is a private Metal API.
+        /// It is not recommended for use in any production applications,
+        /// and may break at any time without warning. Hic sunt dracones.
+        /// </summary>
+        public bool LogicOperationEnabled
+        {
+            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isLogicOperationEnabled);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLogicOperationEnabled, value);
+        }
+
+        public ulong MaxFragmentCallStackDepth
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxFragmentCallStackDepth);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxFragmentCallStackDepth, value);
+        }
+
+        public ulong MaxTessellationFactor
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxTessellationFactor);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxTessellationFactor, value);
+        }
+
+        public ulong MaxVertexAmplificationCount
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxVertexAmplificationCount);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxVertexAmplificationCount, value);
+        }
+
+        public ulong MaxVertexCallStackDepth
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxVertexCallStackDepth);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxVertexCallStackDepth, value);
+        }
+
+        public bool RasterizationEnabled
+        {
+            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isRasterizationEnabled);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRasterizationEnabled, value);
+        }
+
+        public ulong RasterSampleCount
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_rasterSampleCount);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRasterSampleCount, value);
+        }
+
+        public ulong SampleCount
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_sampleCount);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSampleCount, value);
+        }
+
+        public MTLPixelFormat StencilAttachmentPixelFormat
+        {
+            get => (MTLPixelFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_stencilAttachmentPixelFormat);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStencilAttachmentPixelFormat, (ulong)value);
+        }
+
+        public bool SupportAddingFragmentBinaryFunctions
+        {
+            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportAddingFragmentBinaryFunctions);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSupportAddingFragmentBinaryFunctions, value);
+        }
+
+        public bool SupportAddingVertexBinaryFunctions
+        {
+            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportAddingVertexBinaryFunctions);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSupportAddingVertexBinaryFunctions, value);
+        }
+
+        public bool SupportIndirectCommandBuffers
+        {
+            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportIndirectCommandBuffers);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSupportIndirectCommandBuffers, value);
+        }
+
+        public MTLTessellationControlPointIndexType TessellationControlPointIndexType
+        {
+            get => (MTLTessellationControlPointIndexType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_tessellationControlPointIndexType);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTessellationControlPointIndexType, (ulong)value);
+        }
+
+        public MTLTessellationFactorFormat TessellationFactorFormat
+        {
+            get => (MTLTessellationFactorFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_tessellationFactorFormat);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTessellationFactorFormat, (ulong)value);
+        }
+
+        public bool TessellationFactorScaleEnabled
+        {
+            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isTessellationFactorScaleEnabled);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTessellationFactorScaleEnabled, value);
+        }
+
+        public MTLTessellationFactorStepFunction TessellationFactorStepFunction
+        {
+            get => (MTLTessellationFactorStepFunction)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_tessellationFactorStepFunction);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTessellationFactorStepFunction, (ulong)value);
+        }
+
+        public MTLWinding TessellationOutputWindingOrder
+        {
+            get => (MTLWinding)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_tessellationOutputWindingOrder);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTessellationOutputWindingOrder, (ulong)value);
+        }
+
+        public MTLTessellationPartitionMode TessellationPartitionMode
+        {
+            get => (MTLTessellationPartitionMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_tessellationPartitionMode);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTessellationPartitionMode, (ulong)value);
+        }
+
+        public MTLPipelineBufferDescriptorArray VertexBuffers => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_vertexBuffers));
+
+        public MTLVertexDescriptor VertexDescriptor
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_vertexDescriptor));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexDescriptor, value);
+        }
+
+        public MTLFunction VertexFunction
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_vertexFunction));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexFunction, value);
+        }
+
+        public MTLLinkedFunctions VertexLinkedFunctions
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_vertexLinkedFunctions));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexLinkedFunctions, value);
+        }
+
+        public NSArray VertexPreloadedLibraries
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_vertexPreloadedLibraries));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexPreloadedLibraries, value);
+        }
+
+        public void Reset()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_reset);
+        }
+
+        private static readonly Selector sel_binaryArchives = "binaryArchives";
+        private static readonly Selector sel_colorAttachments = "colorAttachments";
+        private static readonly Selector sel_depthAttachmentPixelFormat = "depthAttachmentPixelFormat";
+        private static readonly Selector sel_fragmentBuffers = "fragmentBuffers";
+        private static readonly Selector sel_fragmentFunction = "fragmentFunction";
+        private static readonly Selector sel_fragmentLinkedFunctions = "fragmentLinkedFunctions";
+        private static readonly Selector sel_fragmentPreloadedLibraries = "fragmentPreloadedLibraries";
+        private static readonly Selector sel_inputPrimitiveTopology = "inputPrimitiveTopology";
+        private static readonly Selector sel_isAlphaToCoverageEnabled = "isAlphaToCoverageEnabled";
+        private static readonly Selector sel_isAlphaToOneEnabled = "isAlphaToOneEnabled";
+        private static readonly Selector sel_isLogicOperationEnabled = "isLogicOperationEnabled";
+        private static readonly Selector sel_isRasterizationEnabled = "isRasterizationEnabled";
+        private static readonly Selector sel_isTessellationFactorScaleEnabled = "isTessellationFactorScaleEnabled";
+        private static readonly Selector sel_label = "label";
+        private static readonly Selector sel_logicOperation = "logicOperation";
+        private static readonly Selector sel_maxFragmentCallStackDepth = "maxFragmentCallStackDepth";
+        private static readonly Selector sel_maxTessellationFactor = "maxTessellationFactor";
+        private static readonly Selector sel_maxVertexAmplificationCount = "maxVertexAmplificationCount";
+        private static readonly Selector sel_maxVertexCallStackDepth = "maxVertexCallStackDepth";
+        private static readonly Selector sel_rasterSampleCount = "rasterSampleCount";
+        private static readonly Selector sel_reset = "reset";
+        private static readonly Selector sel_sampleCount = "sampleCount";
+        private static readonly Selector sel_setAlphaToCoverageEnabled = "setAlphaToCoverageEnabled:";
+        private static readonly Selector sel_setAlphaToOneEnabled = "setAlphaToOneEnabled:";
+        private static readonly Selector sel_setBinaryArchives = "setBinaryArchives:";
+        private static readonly Selector sel_setDepthAttachmentPixelFormat = "setDepthAttachmentPixelFormat:";
+        private static readonly Selector sel_setFragmentFunction = "setFragmentFunction:";
+        private static readonly Selector sel_setFragmentLinkedFunctions = "setFragmentLinkedFunctions:";
+        private static readonly Selector sel_setFragmentPreloadedLibraries = "setFragmentPreloadedLibraries:";
+        private static readonly Selector sel_setInputPrimitiveTopology = "setInputPrimitiveTopology:";
+        private static readonly Selector sel_setLabel = "setLabel:";
+        private static readonly Selector sel_setLogicOperation = "setLogicOperation:";
+        private static readonly Selector sel_setLogicOperationEnabled = "setLogicOperationEnabled:";
+        private static readonly Selector sel_setMaxFragmentCallStackDepth = "setMaxFragmentCallStackDepth:";
+        private static readonly Selector sel_setMaxTessellationFactor = "setMaxTessellationFactor:";
+        private static readonly Selector sel_setMaxVertexAmplificationCount = "setMaxVertexAmplificationCount:";
+        private static readonly Selector sel_setMaxVertexCallStackDepth = "setMaxVertexCallStackDepth:";
+        private static readonly Selector sel_setRasterizationEnabled = "setRasterizationEnabled:";
+        private static readonly Selector sel_setRasterSampleCount = "setRasterSampleCount:";
+        private static readonly Selector sel_setSampleCount = "setSampleCount:";
+        private static readonly Selector sel_setStencilAttachmentPixelFormat = "setStencilAttachmentPixelFormat:";
+        private static readonly Selector sel_setSupportAddingFragmentBinaryFunctions = "setSupportAddingFragmentBinaryFunctions:";
+        private static readonly Selector sel_setSupportAddingVertexBinaryFunctions = "setSupportAddingVertexBinaryFunctions:";
+        private static readonly Selector sel_setSupportIndirectCommandBuffers = "setSupportIndirectCommandBuffers:";
+        private static readonly Selector sel_setTessellationControlPointIndexType = "setTessellationControlPointIndexType:";
+        private static readonly Selector sel_setTessellationFactorFormat = "setTessellationFactorFormat:";
+        private static readonly Selector sel_setTessellationFactorScaleEnabled = "setTessellationFactorScaleEnabled:";
+        private static readonly Selector sel_setTessellationFactorStepFunction = "setTessellationFactorStepFunction:";
+        private static readonly Selector sel_setTessellationOutputWindingOrder = "setTessellationOutputWindingOrder:";
+        private static readonly Selector sel_setTessellationPartitionMode = "setTessellationPartitionMode:";
+        private static readonly Selector sel_setVertexDescriptor = "setVertexDescriptor:";
+        private static readonly Selector sel_setVertexFunction = "setVertexFunction:";
+        private static readonly Selector sel_setVertexLinkedFunctions = "setVertexLinkedFunctions:";
+        private static readonly Selector sel_setVertexPreloadedLibraries = "setVertexPreloadedLibraries:";
+        private static readonly Selector sel_stencilAttachmentPixelFormat = "stencilAttachmentPixelFormat";
+        private static readonly Selector sel_supportAddingFragmentBinaryFunctions = "supportAddingFragmentBinaryFunctions";
+        private static readonly Selector sel_supportAddingVertexBinaryFunctions = "supportAddingVertexBinaryFunctions";
+        private static readonly Selector sel_supportIndirectCommandBuffers = "supportIndirectCommandBuffers";
+        private static readonly Selector sel_tessellationControlPointIndexType = "tessellationControlPointIndexType";
+        private static readonly Selector sel_tessellationFactorFormat = "tessellationFactorFormat";
+        private static readonly Selector sel_tessellationFactorStepFunction = "tessellationFactorStepFunction";
+        private static readonly Selector sel_tessellationOutputWindingOrder = "tessellationOutputWindingOrder";
+        private static readonly Selector sel_tessellationPartitionMode = "tessellationPartitionMode";
+        private static readonly Selector sel_vertexBuffers = "vertexBuffers";
+        private static readonly Selector sel_vertexDescriptor = "vertexDescriptor";
+        private static readonly Selector sel_vertexFunction = "vertexFunction";
+        private static readonly Selector sel_vertexLinkedFunctions = "vertexLinkedFunctions";
+        private static readonly Selector sel_vertexPreloadedLibraries = "vertexPreloadedLibraries";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
+    public struct MTLRenderPipelineFunctionsDescriptor : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLRenderPipelineFunctionsDescriptor obj) => obj.NativePtr;
+        public MTLRenderPipelineFunctionsDescriptor(IntPtr ptr) => NativePtr = ptr;
+
+        public MTLRenderPipelineFunctionsDescriptor()
+        {
+            var cls = new ObjectiveCClass("MTLRenderPipelineFunctionsDescriptor");
+            NativePtr = cls.AllocInit();
+        }
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public NSArray FragmentAdditionalBinaryFunctions
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_fragmentAdditionalBinaryFunctions));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFragmentAdditionalBinaryFunctions, value);
+        }
+
+        public NSArray TileAdditionalBinaryFunctions
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_tileAdditionalBinaryFunctions));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTileAdditionalBinaryFunctions, value);
+        }
+
+        public NSArray VertexAdditionalBinaryFunctions
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_vertexAdditionalBinaryFunctions));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setVertexAdditionalBinaryFunctions, value);
+        }
+
+        private static readonly Selector sel_fragmentAdditionalBinaryFunctions = "fragmentAdditionalBinaryFunctions";
+        private static readonly Selector sel_setFragmentAdditionalBinaryFunctions = "setFragmentAdditionalBinaryFunctions:";
+        private static readonly Selector sel_setTileAdditionalBinaryFunctions = "setTileAdditionalBinaryFunctions:";
+        private static readonly Selector sel_setVertexAdditionalBinaryFunctions = "setVertexAdditionalBinaryFunctions:";
+        private static readonly Selector sel_tileAdditionalBinaryFunctions = "tileAdditionalBinaryFunctions";
+        private static readonly Selector sel_vertexAdditionalBinaryFunctions = "vertexAdditionalBinaryFunctions";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
+    public struct MTLRenderPipelineReflection : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLRenderPipelineReflection obj) => obj.NativePtr;
+        public MTLRenderPipelineReflection(IntPtr ptr) => NativePtr = ptr;
+
+        public MTLRenderPipelineReflection()
+        {
+            var cls = new ObjectiveCClass("MTLRenderPipelineReflection");
+            NativePtr = cls.AllocInit();
+        }
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public NSArray FragmentArguments => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_fragmentArguments));
+
+        public NSArray FragmentBindings => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_fragmentBindings));
+
+        public NSArray MeshBindings => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_meshBindings));
+
+        public NSArray ObjectBindings => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_objectBindings));
+
+        public NSArray TileArguments => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_tileArguments));
+
+        public NSArray TileBindings => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_tileBindings));
+
+        public NSArray VertexArguments => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_vertexArguments));
+
+        public NSArray VertexBindings => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_vertexBindings));
+
+        private static readonly Selector sel_fragmentArguments = "fragmentArguments";
+        private static readonly Selector sel_fragmentBindings = "fragmentBindings";
+        private static readonly Selector sel_meshBindings = "meshBindings";
+        private static readonly Selector sel_objectBindings = "objectBindings";
+        private static readonly Selector sel_tileArguments = "tileArguments";
+        private static readonly Selector sel_tileBindings = "tileBindings";
+        private static readonly Selector sel_vertexArguments = "vertexArguments";
+        private static readonly Selector sel_vertexBindings = "vertexBindings";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
+    public struct MTLRenderPipelineState : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLRenderPipelineState obj) => obj.NativePtr;
+        public MTLRenderPipelineState(IntPtr ptr) => NativePtr = ptr;
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
+
+        public MTLResourceID GpuResourceID => ObjectiveCRuntime.MTLResourceID_objc_msgSend(NativePtr, sel_gpuResourceID);
+
+        public ulong ImageblockSampleLength => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_imageblockSampleLength);
+
+        public NSString Label => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
+
+        public ulong MaxTotalThreadgroupsPerMeshGrid => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxTotalThreadgroupsPerMeshGrid);
+
+        public ulong MaxTotalThreadsPerMeshThreadgroup => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxTotalThreadsPerMeshThreadgroup);
+
+        public ulong MaxTotalThreadsPerObjectThreadgroup => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxTotalThreadsPerObjectThreadgroup);
+
+        public ulong MaxTotalThreadsPerThreadgroup => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxTotalThreadsPerThreadgroup);
+
+        public ulong MeshThreadExecutionWidth => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_meshThreadExecutionWidth);
+
+        public ulong ObjectThreadExecutionWidth => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_objectThreadExecutionWidth);
+
+        public bool SupportIndirectCommandBuffers => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportIndirectCommandBuffers);
+
+        public bool ThreadgroupSizeMatchesTileSize => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_threadgroupSizeMatchesTileSize);
+
+        public MTLFunctionHandle FunctionHandle(MTLFunction function, MTLRenderStages stage)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_functionHandleWithFunctionstage, function, (ulong)stage));
+        }
+
+        public ulong ImageblockMemoryLength(MTLSize imageblockDimensions)
+        {
+            return ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_imageblockMemoryLengthForDimensions, imageblockDimensions);
+        }
+
+        public MTLIntersectionFunctionTable NewIntersectionFunctionTable(MTLIntersectionFunctionTableDescriptor descriptor, MTLRenderStages stage)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newIntersectionFunctionTableWithDescriptorstage, descriptor, (ulong)stage));
+        }
+
+        public MTLRenderPipelineState NewRenderPipelineState(MTLRenderPipelineFunctionsDescriptor additionalBinaryFunctions, ref NSError error)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newRenderPipelineStateWithAdditionalBinaryFunctionserror, additionalBinaryFunctions, ref error.NativePtr));
+        }
+
+        public MTLVisibleFunctionTable NewVisibleFunctionTable(MTLVisibleFunctionTableDescriptor descriptor, MTLRenderStages stage)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newVisibleFunctionTableWithDescriptorstage, descriptor, (ulong)stage));
+        }
+
+        private static readonly Selector sel_device = "device";
+        private static readonly Selector sel_functionHandleWithFunctionstage = "functionHandleWithFunction:stage:";
+        private static readonly Selector sel_gpuResourceID = "gpuResourceID";
+        private static readonly Selector sel_imageblockMemoryLengthForDimensions = "imageblockMemoryLengthForDimensions:";
+        private static readonly Selector sel_imageblockSampleLength = "imageblockSampleLength";
+        private static readonly Selector sel_label = "label";
+        private static readonly Selector sel_maxTotalThreadgroupsPerMeshGrid = "maxTotalThreadgroupsPerMeshGrid";
+        private static readonly Selector sel_maxTotalThreadsPerMeshThreadgroup = "maxTotalThreadsPerMeshThreadgroup";
+        private static readonly Selector sel_maxTotalThreadsPerObjectThreadgroup = "maxTotalThreadsPerObjectThreadgroup";
+        private static readonly Selector sel_maxTotalThreadsPerThreadgroup = "maxTotalThreadsPerThreadgroup";
+        private static readonly Selector sel_meshThreadExecutionWidth = "meshThreadExecutionWidth";
+        private static readonly Selector sel_newIntersectionFunctionTableWithDescriptorstage = "newIntersectionFunctionTableWithDescriptor:stage:";
+        private static readonly Selector sel_newRenderPipelineStateWithAdditionalBinaryFunctionserror = "newRenderPipelineStateWithAdditionalBinaryFunctions:error:";
+        private static readonly Selector sel_newVisibleFunctionTableWithDescriptorstage = "newVisibleFunctionTableWithDescriptor:stage:";
+        private static readonly Selector sel_objectThreadExecutionWidth = "objectThreadExecutionWidth";
+        private static readonly Selector sel_supportIndirectCommandBuffers = "supportIndirectCommandBuffers";
+        private static readonly Selector sel_threadgroupSizeMatchesTileSize = "threadgroupSizeMatchesTileSize";
         private static readonly Selector sel_release = "release";
     }
 
@@ -797,16 +1007,42 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
+        public NSArray BinaryArchives
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_binaryArchives));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBinaryArchives, value);
+        }
+
+        public MTLTileRenderPipelineColorAttachmentDescriptorArray ColorAttachments => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_colorAttachments));
+
         public NSString Label
         {
             get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
         }
 
-        public MTLFunction TileFunction
+        public MTLLinkedFunctions LinkedFunctions
         {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_tileFunction));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTileFunction, value);
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_linkedFunctions));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLinkedFunctions, value);
+        }
+
+        public ulong MaxCallStackDepth
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxCallStackDepth);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxCallStackDepth, value);
+        }
+
+        public ulong MaxTotalThreadsPerThreadgroup
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxTotalThreadsPerThreadgroup);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxTotalThreadsPerThreadgroup, value);
+        }
+
+        public NSArray PreloadedLibraries
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_preloadedLibraries));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPreloadedLibraries, value);
         }
 
         public ulong RasterSampleCount
@@ -815,7 +1051,11 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRasterSampleCount, value);
         }
 
-        public MTLTileRenderPipelineColorAttachmentDescriptorArray ColorAttachments => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_colorAttachments));
+        public bool SupportAddingBinaryFunctions
+        {
+            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportAddingBinaryFunctions);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSupportAddingBinaryFunctions, value);
+        }
 
         public bool ThreadgroupSizeMatchesTileSize
         {
@@ -825,40 +1065,10 @@ namespace SharpMetal.Metal
 
         public MTLPipelineBufferDescriptorArray TileBuffers => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_tileBuffers));
 
-        public ulong MaxTotalThreadsPerThreadgroup
+        public MTLFunction TileFunction
         {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxTotalThreadsPerThreadgroup);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxTotalThreadsPerThreadgroup, value);
-        }
-
-        public NSArray BinaryArchives
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_binaryArchives));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBinaryArchives, value);
-        }
-
-        public NSArray PreloadedLibraries
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_preloadedLibraries));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPreloadedLibraries, value);
-        }
-
-        public MTLLinkedFunctions LinkedFunctions
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_linkedFunctions));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLinkedFunctions, value);
-        }
-
-        public bool SupportAddingBinaryFunctions
-        {
-            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportAddingBinaryFunctions);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSupportAddingBinaryFunctions, value);
-        }
-
-        public ulong MaxCallStackDepth
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxCallStackDepth);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxCallStackDepth, value);
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_tileFunction));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTileFunction, value);
         }
 
         public void Reset()
@@ -866,239 +1076,29 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_reset);
         }
 
-        private static readonly Selector sel_label = "label";
-        private static readonly Selector sel_setLabel = "setLabel:";
-        private static readonly Selector sel_tileFunction = "tileFunction";
-        private static readonly Selector sel_setTileFunction = "setTileFunction:";
-        private static readonly Selector sel_rasterSampleCount = "rasterSampleCount";
-        private static readonly Selector sel_setRasterSampleCount = "setRasterSampleCount:";
-        private static readonly Selector sel_colorAttachments = "colorAttachments";
-        private static readonly Selector sel_threadgroupSizeMatchesTileSize = "threadgroupSizeMatchesTileSize";
-        private static readonly Selector sel_setThreadgroupSizeMatchesTileSize = "setThreadgroupSizeMatchesTileSize:";
-        private static readonly Selector sel_tileBuffers = "tileBuffers";
-        private static readonly Selector sel_maxTotalThreadsPerThreadgroup = "maxTotalThreadsPerThreadgroup";
-        private static readonly Selector sel_setMaxTotalThreadsPerThreadgroup = "setMaxTotalThreadsPerThreadgroup:";
         private static readonly Selector sel_binaryArchives = "binaryArchives";
-        private static readonly Selector sel_setBinaryArchives = "setBinaryArchives:";
-        private static readonly Selector sel_preloadedLibraries = "preloadedLibraries";
-        private static readonly Selector sel_setPreloadedLibraries = "setPreloadedLibraries:";
-        private static readonly Selector sel_linkedFunctions = "linkedFunctions";
-        private static readonly Selector sel_setLinkedFunctions = "setLinkedFunctions:";
-        private static readonly Selector sel_supportAddingBinaryFunctions = "supportAddingBinaryFunctions";
-        private static readonly Selector sel_setSupportAddingBinaryFunctions = "setSupportAddingBinaryFunctions:";
-        private static readonly Selector sel_maxCallStackDepth = "maxCallStackDepth";
-        private static readonly Selector sel_setMaxCallStackDepth = "setMaxCallStackDepth:";
-        private static readonly Selector sel_reset = "reset";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLMeshRenderPipelineDescriptor : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLMeshRenderPipelineDescriptor obj) => obj.NativePtr;
-        public MTLMeshRenderPipelineDescriptor(IntPtr ptr) => NativePtr = ptr;
-
-        public MTLMeshRenderPipelineDescriptor()
-        {
-            var cls = new ObjectiveCClass("MTLMeshRenderPipelineDescriptor");
-            NativePtr = cls.AllocInit();
-        }
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public NSString Label
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
-        }
-
-        public MTLFunction ObjectFunction
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_objectFunction));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setObjectFunction, value);
-        }
-
-        public MTLFunction MeshFunction
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_meshFunction));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMeshFunction, value);
-        }
-
-        public MTLFunction FragmentFunction
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_fragmentFunction));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFragmentFunction, value);
-        }
-
-        public ulong MaxTotalThreadsPerObjectThreadgroup
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxTotalThreadsPerObjectThreadgroup);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxTotalThreadsPerObjectThreadgroup, value);
-        }
-
-        public ulong MaxTotalThreadsPerMeshThreadgroup
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxTotalThreadsPerMeshThreadgroup);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxTotalThreadsPerMeshThreadgroup, value);
-        }
-
-        public bool ObjectThreadgroupSizeIsMultipleOfThreadExecutionWidth
-        {
-            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_objectThreadgroupSizeIsMultipleOfThreadExecutionWidth);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setObjectThreadgroupSizeIsMultipleOfThreadExecutionWidth, value);
-        }
-
-        public bool MeshThreadgroupSizeIsMultipleOfThreadExecutionWidth
-        {
-            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_meshThreadgroupSizeIsMultipleOfThreadExecutionWidth);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMeshThreadgroupSizeIsMultipleOfThreadExecutionWidth, value);
-        }
-
-        public ulong PayloadMemoryLength
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_payloadMemoryLength);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPayloadMemoryLength, value);
-        }
-
-        public ulong MaxTotalThreadgroupsPerMeshGrid
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxTotalThreadgroupsPerMeshGrid);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxTotalThreadgroupsPerMeshGrid, value);
-        }
-
-        public MTLPipelineBufferDescriptorArray ObjectBuffers => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_objectBuffers));
-
-        public MTLPipelineBufferDescriptorArray MeshBuffers => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_meshBuffers));
-
-        public MTLPipelineBufferDescriptorArray FragmentBuffers => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_fragmentBuffers));
-
-        public ulong RasterSampleCount
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_rasterSampleCount);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRasterSampleCount, value);
-        }
-
-        public bool AlphaToCoverageEnabled => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isAlphaToCoverageEnabled);
-
-        public bool AlphaToOneEnabled => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isAlphaToOneEnabled);
-
-        public bool RasterizationEnabled => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isRasterizationEnabled);
-
-        public ulong MaxVertexAmplificationCount
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxVertexAmplificationCount);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxVertexAmplificationCount, value);
-        }
-
-        public MTLRenderPipelineColorAttachmentDescriptorArray ColorAttachments => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_colorAttachments));
-
-        public MTLPixelFormat DepthAttachmentPixelFormat
-        {
-            get => (MTLPixelFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_depthAttachmentPixelFormat);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDepthAttachmentPixelFormat, (ulong)value);
-        }
-
-        public MTLPixelFormat StencilAttachmentPixelFormat
-        {
-            get => (MTLPixelFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_stencilAttachmentPixelFormat);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStencilAttachmentPixelFormat, (ulong)value);
-        }
-
-        public bool SupportIndirectCommandBuffers
-        {
-            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_supportIndirectCommandBuffers);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSupportIndirectCommandBuffers, value);
-        }
-
-        public MTLLinkedFunctions ObjectLinkedFunctions
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_objectLinkedFunctions));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setObjectLinkedFunctions, value);
-        }
-
-        public MTLLinkedFunctions MeshLinkedFunctions
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_meshLinkedFunctions));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMeshLinkedFunctions, value);
-        }
-
-        public MTLLinkedFunctions FragmentLinkedFunctions
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_fragmentLinkedFunctions));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFragmentLinkedFunctions, value);
-        }
-
-        public void SetAlphaToCoverageEnabled(bool alphaToCoverageEnabled)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setAlphaToCoverageEnabled, alphaToCoverageEnabled);
-        }
-
-        public void SetAlphaToOneEnabled(bool alphaToOneEnabled)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setAlphaToOneEnabled, alphaToOneEnabled);
-        }
-
-        public void SetRasterizationEnabled(bool rasterizationEnabled)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRasterizationEnabled, rasterizationEnabled);
-        }
-
-        public void Reset()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_reset);
-        }
-
-        private static readonly Selector sel_label = "label";
-        private static readonly Selector sel_setLabel = "setLabel:";
-        private static readonly Selector sel_objectFunction = "objectFunction";
-        private static readonly Selector sel_setObjectFunction = "setObjectFunction:";
-        private static readonly Selector sel_meshFunction = "meshFunction";
-        private static readonly Selector sel_setMeshFunction = "setMeshFunction:";
-        private static readonly Selector sel_fragmentFunction = "fragmentFunction";
-        private static readonly Selector sel_setFragmentFunction = "setFragmentFunction:";
-        private static readonly Selector sel_maxTotalThreadsPerObjectThreadgroup = "maxTotalThreadsPerObjectThreadgroup";
-        private static readonly Selector sel_setMaxTotalThreadsPerObjectThreadgroup = "setMaxTotalThreadsPerObjectThreadgroup:";
-        private static readonly Selector sel_maxTotalThreadsPerMeshThreadgroup = "maxTotalThreadsPerMeshThreadgroup";
-        private static readonly Selector sel_setMaxTotalThreadsPerMeshThreadgroup = "setMaxTotalThreadsPerMeshThreadgroup:";
-        private static readonly Selector sel_objectThreadgroupSizeIsMultipleOfThreadExecutionWidth = "objectThreadgroupSizeIsMultipleOfThreadExecutionWidth";
-        private static readonly Selector sel_setObjectThreadgroupSizeIsMultipleOfThreadExecutionWidth = "setObjectThreadgroupSizeIsMultipleOfThreadExecutionWidth:";
-        private static readonly Selector sel_meshThreadgroupSizeIsMultipleOfThreadExecutionWidth = "meshThreadgroupSizeIsMultipleOfThreadExecutionWidth";
-        private static readonly Selector sel_setMeshThreadgroupSizeIsMultipleOfThreadExecutionWidth = "setMeshThreadgroupSizeIsMultipleOfThreadExecutionWidth:";
-        private static readonly Selector sel_payloadMemoryLength = "payloadMemoryLength";
-        private static readonly Selector sel_setPayloadMemoryLength = "setPayloadMemoryLength:";
-        private static readonly Selector sel_maxTotalThreadgroupsPerMeshGrid = "maxTotalThreadgroupsPerMeshGrid";
-        private static readonly Selector sel_setMaxTotalThreadgroupsPerMeshGrid = "setMaxTotalThreadgroupsPerMeshGrid:";
-        private static readonly Selector sel_objectBuffers = "objectBuffers";
-        private static readonly Selector sel_meshBuffers = "meshBuffers";
-        private static readonly Selector sel_fragmentBuffers = "fragmentBuffers";
-        private static readonly Selector sel_rasterSampleCount = "rasterSampleCount";
-        private static readonly Selector sel_setRasterSampleCount = "setRasterSampleCount:";
-        private static readonly Selector sel_isAlphaToCoverageEnabled = "isAlphaToCoverageEnabled";
-        private static readonly Selector sel_setAlphaToCoverageEnabled = "setAlphaToCoverageEnabled:";
-        private static readonly Selector sel_isAlphaToOneEnabled = "isAlphaToOneEnabled";
-        private static readonly Selector sel_setAlphaToOneEnabled = "setAlphaToOneEnabled:";
-        private static readonly Selector sel_isRasterizationEnabled = "isRasterizationEnabled";
-        private static readonly Selector sel_setRasterizationEnabled = "setRasterizationEnabled:";
-        private static readonly Selector sel_maxVertexAmplificationCount = "maxVertexAmplificationCount";
-        private static readonly Selector sel_setMaxVertexAmplificationCount = "setMaxVertexAmplificationCount:";
         private static readonly Selector sel_colorAttachments = "colorAttachments";
-        private static readonly Selector sel_depthAttachmentPixelFormat = "depthAttachmentPixelFormat";
-        private static readonly Selector sel_setDepthAttachmentPixelFormat = "setDepthAttachmentPixelFormat:";
-        private static readonly Selector sel_stencilAttachmentPixelFormat = "stencilAttachmentPixelFormat";
-        private static readonly Selector sel_setStencilAttachmentPixelFormat = "setStencilAttachmentPixelFormat:";
-        private static readonly Selector sel_supportIndirectCommandBuffers = "supportIndirectCommandBuffers";
-        private static readonly Selector sel_setSupportIndirectCommandBuffers = "setSupportIndirectCommandBuffers:";
-        private static readonly Selector sel_objectLinkedFunctions = "objectLinkedFunctions";
-        private static readonly Selector sel_setObjectLinkedFunctions = "setObjectLinkedFunctions:";
-        private static readonly Selector sel_meshLinkedFunctions = "meshLinkedFunctions";
-        private static readonly Selector sel_setMeshLinkedFunctions = "setMeshLinkedFunctions:";
-        private static readonly Selector sel_fragmentLinkedFunctions = "fragmentLinkedFunctions";
-        private static readonly Selector sel_setFragmentLinkedFunctions = "setFragmentLinkedFunctions:";
+        private static readonly Selector sel_label = "label";
+        private static readonly Selector sel_linkedFunctions = "linkedFunctions";
+        private static readonly Selector sel_maxCallStackDepth = "maxCallStackDepth";
+        private static readonly Selector sel_maxTotalThreadsPerThreadgroup = "maxTotalThreadsPerThreadgroup";
+        private static readonly Selector sel_preloadedLibraries = "preloadedLibraries";
+        private static readonly Selector sel_rasterSampleCount = "rasterSampleCount";
         private static readonly Selector sel_reset = "reset";
+        private static readonly Selector sel_setBinaryArchives = "setBinaryArchives:";
+        private static readonly Selector sel_setLabel = "setLabel:";
+        private static readonly Selector sel_setLinkedFunctions = "setLinkedFunctions:";
+        private static readonly Selector sel_setMaxCallStackDepth = "setMaxCallStackDepth:";
+        private static readonly Selector sel_setMaxTotalThreadsPerThreadgroup = "setMaxTotalThreadsPerThreadgroup:";
+        private static readonly Selector sel_setPreloadedLibraries = "setPreloadedLibraries:";
+        private static readonly Selector sel_setRasterSampleCount = "setRasterSampleCount:";
+        private static readonly Selector sel_setSupportAddingBinaryFunctions = "setSupportAddingBinaryFunctions:";
+        private static readonly Selector sel_setThreadgroupSizeMatchesTileSize = "setThreadgroupSizeMatchesTileSize:";
+        private static readonly Selector sel_setTileFunction = "setTileFunction:";
+        private static readonly Selector sel_supportAddingBinaryFunctions = "supportAddingBinaryFunctions";
+        private static readonly Selector sel_threadgroupSizeMatchesTileSize = "threadgroupSizeMatchesTileSize";
+        private static readonly Selector sel_tileBuffers = "tileBuffers";
+        private static readonly Selector sel_tileFunction = "tileFunction";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLResource.cs
+++ b/src/SharpMetal/Metal/MTLResource.cs
@@ -5,28 +5,10 @@ using SharpMetal.Foundation;
 namespace SharpMetal.Metal
 {
     [SupportedOSPlatform("macos")]
-    public enum MTLPurgeableState : ulong
-    {
-        KeepCurrent = 1,
-        NonVolatile = 2,
-        Volatile = 3,
-        Empty = 4,
-    }
-
-    [SupportedOSPlatform("macos")]
     public enum MTLCPUCacheMode : ulong
     {
         DefaultCache = 0,
         WriteCombined = 1,
-    }
-
-    [SupportedOSPlatform("macos")]
-    public enum MTLStorageMode : ulong
-    {
-        Shared = 0,
-        Managed = 1,
-        Private = 2,
-        Memoryless = 3,
     }
 
     [SupportedOSPlatform("macos")]
@@ -35,6 +17,15 @@ namespace SharpMetal.Metal
         Default = 0,
         Untracked = 1,
         Tracked = 2,
+    }
+
+    [SupportedOSPlatform("macos")]
+    public enum MTLPurgeableState : ulong
+    {
+        KeepCurrent = 1,
+        NonVolatile = 2,
+        Volatile = 3,
+        Empty = 4,
     }
 
     [SupportedOSPlatform("macos")]
@@ -55,6 +46,15 @@ namespace SharpMetal.Metal
     }
 
     [SupportedOSPlatform("macos")]
+    public enum MTLStorageMode : ulong
+    {
+        Shared = 0,
+        Managed = 1,
+        Private = 2,
+        Memoryless = 3,
+    }
+
+    [SupportedOSPlatform("macos")]
     public struct MTLResource : IDisposable
     {
         public IntPtr NativePtr;
@@ -66,53 +66,53 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
+        public ulong AllocatedSize => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_allocatedSize);
+
+        public MTLCPUCacheMode CpuCacheMode => (MTLCPUCacheMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_cpuCacheMode);
+
+        public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
+
+        public MTLHazardTrackingMode HazardTrackingMode => (MTLHazardTrackingMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_hazardTrackingMode);
+
+        public MTLHeap Heap => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_heap));
+
+        public ulong HeapOffset => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_heapOffset);
+
+        public bool IsAliasable => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isAliasable);
+
         public NSString Label
         {
             get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
         }
 
-        public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
-
-        public MTLCPUCacheMode CpuCacheMode => (MTLCPUCacheMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_cpuCacheMode);
-
-        public MTLStorageMode StorageMode => (MTLStorageMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_storageMode);
-
-        public MTLHazardTrackingMode HazardTrackingMode => (MTLHazardTrackingMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_hazardTrackingMode);
-
         public MTLResourceOptions ResourceOptions => (MTLResourceOptions)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_resourceOptions);
 
-        public MTLHeap Heap => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_heap));
-
-        public ulong HeapOffset => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_heapOffset);
-
-        public ulong AllocatedSize => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_allocatedSize);
-
-        public bool IsAliasable => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isAliasable);
-
-        public MTLPurgeableState SetPurgeableState(MTLPurgeableState state)
-        {
-            return (MTLPurgeableState)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_setPurgeableState, (ulong)state);
-        }
+        public MTLStorageMode StorageMode => (MTLStorageMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_storageMode);
 
         public void MakeAliasable()
         {
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_makeAliasable);
         }
 
-        private static readonly Selector sel_label = "label";
-        private static readonly Selector sel_setLabel = "setLabel:";
-        private static readonly Selector sel_device = "device";
+        public MTLPurgeableState SetPurgeableState(MTLPurgeableState state)
+        {
+            return (MTLPurgeableState)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_setPurgeableState, (ulong)state);
+        }
+
+        private static readonly Selector sel_allocatedSize = "allocatedSize";
         private static readonly Selector sel_cpuCacheMode = "cpuCacheMode";
-        private static readonly Selector sel_storageMode = "storageMode";
+        private static readonly Selector sel_device = "device";
         private static readonly Selector sel_hazardTrackingMode = "hazardTrackingMode";
-        private static readonly Selector sel_resourceOptions = "resourceOptions";
-        private static readonly Selector sel_setPurgeableState = "setPurgeableState:";
         private static readonly Selector sel_heap = "heap";
         private static readonly Selector sel_heapOffset = "heapOffset";
-        private static readonly Selector sel_allocatedSize = "allocatedSize";
-        private static readonly Selector sel_makeAliasable = "makeAliasable";
         private static readonly Selector sel_isAliasable = "isAliasable";
+        private static readonly Selector sel_label = "label";
+        private static readonly Selector sel_makeAliasable = "makeAliasable";
+        private static readonly Selector sel_resourceOptions = "resourceOptions";
+        private static readonly Selector sel_setLabel = "setLabel:";
+        private static readonly Selector sel_setPurgeableState = "setPurgeableState:";
+        private static readonly Selector sel_storageMode = "storageMode";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLResourceStateCommandEncoder.cs
+++ b/src/SharpMetal/Metal/MTLResourceStateCommandEncoder.cs
@@ -47,9 +47,34 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
         }
 
-        public void UpdateTextureMappings(MTLTexture texture, MTLSparseTextureMappingMode mode, MTLRegion regions, ulong mipLevels, ulong slices, ulong numRegions)
+        public void EndEncoding()
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_updateTextureMappingsmoderegionsmipLevelsslicesnumRegions, texture, (ulong)mode, regions, mipLevels, slices, numRegions);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_endEncoding);
+        }
+
+        public void InsertDebugSignpost(NSString nsString)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_insertDebugSignpost, nsString);
+        }
+
+        public void MoveTextureMappingsFromTexture(MTLTexture sourceTexture, ulong sourceSlice, ulong sourceLevel, MTLOrigin sourceOrigin, MTLSize sourceSize, MTLTexture destinationTexture, ulong destinationSlice, ulong destinationLevel, MTLOrigin destinationOrigin)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_moveTextureMappingsFromTexturesourceSlicesourceLevelsourceOriginsourceSizetoTexturedestinationSlicedestinationLeveldestinationOrigin, sourceTexture, sourceSlice, sourceLevel, sourceOrigin, sourceSize, destinationTexture, destinationSlice, destinationLevel, destinationOrigin);
+        }
+
+        public void PopDebugGroup()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_popDebugGroup);
+        }
+
+        public void PushDebugGroup(NSString nsString)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_pushDebugGroup, nsString);
+        }
+
+        public void UpdateFence(MTLFence fence)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_updateFence, fence);
         }
 
         public void UpdateTextureMapping(MTLTexture texture, MTLSparseTextureMappingMode mode, MTLRegion region, ulong mipLevel, ulong slice)
@@ -62,9 +87,9 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_updateTextureMappingmodeindirectBufferindirectBufferOffset, texture, (ulong)mode, indirectBuffer, indirectBufferOffset);
         }
 
-        public void UpdateFence(MTLFence fence)
+        public void UpdateTextureMappings(MTLTexture texture, MTLSparseTextureMappingMode mode, MTLRegion regions, ulong mipLevels, ulong slices, ulong numRegions)
         {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_updateFence, fence);
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_updateTextureMappingsmoderegionsmipLevelsslicesnumRegions, texture, (ulong)mode, regions, mipLevels, slices, numRegions);
         }
 
         public void WaitForFence(MTLFence fence)
@@ -72,44 +97,19 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_waitForFence, fence);
         }
 
-        public void MoveTextureMappingsFromTexture(MTLTexture sourceTexture, ulong sourceSlice, ulong sourceLevel, MTLOrigin sourceOrigin, MTLSize sourceSize, MTLTexture destinationTexture, ulong destinationSlice, ulong destinationLevel, MTLOrigin destinationOrigin)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_moveTextureMappingsFromTexturesourceSlicesourceLevelsourceOriginsourceSizetoTexturedestinationSlicedestinationLeveldestinationOrigin, sourceTexture, sourceSlice, sourceLevel, sourceOrigin, sourceSize, destinationTexture, destinationSlice, destinationLevel, destinationOrigin);
-        }
-
-        public void EndEncoding()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_endEncoding);
-        }
-
-        public void InsertDebugSignpost(NSString nsString)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_insertDebugSignpost, nsString);
-        }
-
-        public void PushDebugGroup(NSString nsString)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_pushDebugGroup, nsString);
-        }
-
-        public void PopDebugGroup()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_popDebugGroup);
-        }
-
-        private static readonly Selector sel_updateTextureMappingsmoderegionsmipLevelsslicesnumRegions = "updateTextureMappings:mode:regions:mipLevels:slices:numRegions:";
-        private static readonly Selector sel_updateTextureMappingmoderegionmipLevelslice = "updateTextureMapping:mode:region:mipLevel:slice:";
-        private static readonly Selector sel_updateTextureMappingmodeindirectBufferindirectBufferOffset = "updateTextureMapping:mode:indirectBuffer:indirectBufferOffset:";
-        private static readonly Selector sel_updateFence = "updateFence:";
-        private static readonly Selector sel_waitForFence = "waitForFence:";
-        private static readonly Selector sel_moveTextureMappingsFromTexturesourceSlicesourceLevelsourceOriginsourceSizetoTexturedestinationSlicedestinationLeveldestinationOrigin = "moveTextureMappingsFromTexture:sourceSlice:sourceLevel:sourceOrigin:sourceSize:toTexture:destinationSlice:destinationLevel:destinationOrigin:";
         private static readonly Selector sel_device = "device";
-        private static readonly Selector sel_label = "label";
-        private static readonly Selector sel_setLabel = "setLabel:";
         private static readonly Selector sel_endEncoding = "endEncoding";
         private static readonly Selector sel_insertDebugSignpost = "insertDebugSignpost:";
-        private static readonly Selector sel_pushDebugGroup = "pushDebugGroup:";
+        private static readonly Selector sel_label = "label";
+        private static readonly Selector sel_moveTextureMappingsFromTexturesourceSlicesourceLevelsourceOriginsourceSizetoTexturedestinationSlicedestinationLeveldestinationOrigin = "moveTextureMappingsFromTexture:sourceSlice:sourceLevel:sourceOrigin:sourceSize:toTexture:destinationSlice:destinationLevel:destinationOrigin:";
         private static readonly Selector sel_popDebugGroup = "popDebugGroup";
+        private static readonly Selector sel_pushDebugGroup = "pushDebugGroup:";
+        private static readonly Selector sel_setLabel = "setLabel:";
+        private static readonly Selector sel_updateFence = "updateFence:";
+        private static readonly Selector sel_updateTextureMappingmodeindirectBufferindirectBufferOffset = "updateTextureMapping:mode:indirectBuffer:indirectBufferOffset:";
+        private static readonly Selector sel_updateTextureMappingmoderegionmipLevelslice = "updateTextureMapping:mode:region:mipLevel:slice:";
+        private static readonly Selector sel_updateTextureMappingsmoderegionsmipLevelsslicesnumRegions = "updateTextureMappings:mode:regions:mipLevels:slices:numRegions:";
+        private static readonly Selector sel_waitForFence = "waitForFence:";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLResourceStatePass.cs
+++ b/src/SharpMetal/Metal/MTLResourceStatePass.cs
@@ -5,6 +5,31 @@ using SharpMetal.Foundation;
 namespace SharpMetal.Metal
 {
     [SupportedOSPlatform("macos")]
+    public struct MTLResourceStatePassDescriptor : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLResourceStatePassDescriptor obj) => obj.NativePtr;
+        public MTLResourceStatePassDescriptor(IntPtr ptr) => NativePtr = ptr;
+
+        public MTLResourceStatePassDescriptor()
+        {
+            var cls = new ObjectiveCClass("MTLResourceStatePassDescriptor");
+            NativePtr = cls.AllocInit();
+        }
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public MTLResourceStatePassSampleBufferAttachmentDescriptorArray SampleBufferAttachments => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_sampleBufferAttachments));
+
+        private static readonly Selector sel_resourceStatePassDescriptor = "resourceStatePassDescriptor";
+        private static readonly Selector sel_sampleBufferAttachments = "sampleBufferAttachments";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
     public struct MTLResourceStatePassSampleBufferAttachmentDescriptor : IDisposable
     {
         public IntPtr NativePtr;
@@ -22,6 +47,12 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
+        public ulong EndOfEncoderSampleIndex
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_endOfEncoderSampleIndex);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setEndOfEncoderSampleIndex, value);
+        }
+
         public MTLCounterSampleBuffer SampleBuffer
         {
             get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_sampleBuffer));
@@ -34,18 +65,12 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStartOfEncoderSampleIndex, value);
         }
 
-        public ulong EndOfEncoderSampleIndex
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_endOfEncoderSampleIndex);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setEndOfEncoderSampleIndex, value);
-        }
-
-        private static readonly Selector sel_sampleBuffer = "sampleBuffer";
-        private static readonly Selector sel_setSampleBuffer = "setSampleBuffer:";
-        private static readonly Selector sel_startOfEncoderSampleIndex = "startOfEncoderSampleIndex";
-        private static readonly Selector sel_setStartOfEncoderSampleIndex = "setStartOfEncoderSampleIndex:";
         private static readonly Selector sel_endOfEncoderSampleIndex = "endOfEncoderSampleIndex";
+        private static readonly Selector sel_sampleBuffer = "sampleBuffer";
         private static readonly Selector sel_setEndOfEncoderSampleIndex = "setEndOfEncoderSampleIndex:";
+        private static readonly Selector sel_setSampleBuffer = "setSampleBuffer:";
+        private static readonly Selector sel_setStartOfEncoderSampleIndex = "setStartOfEncoderSampleIndex:";
+        private static readonly Selector sel_startOfEncoderSampleIndex = "startOfEncoderSampleIndex";
         private static readonly Selector sel_release = "release";
     }
 
@@ -79,31 +104,6 @@ namespace SharpMetal.Metal
 
         private static readonly Selector sel_objectAtIndexedSubscript = "objectAtIndexedSubscript:";
         private static readonly Selector sel_setObjectatIndexedSubscript = "setObject:atIndexedSubscript:";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLResourceStatePassDescriptor : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLResourceStatePassDescriptor obj) => obj.NativePtr;
-        public MTLResourceStatePassDescriptor(IntPtr ptr) => NativePtr = ptr;
-
-        public MTLResourceStatePassDescriptor()
-        {
-            var cls = new ObjectiveCClass("MTLResourceStatePassDescriptor");
-            NativePtr = cls.AllocInit();
-        }
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public MTLResourceStatePassSampleBufferAttachmentDescriptorArray SampleBufferAttachments => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_sampleBufferAttachments));
-
-        private static readonly Selector sel_resourceStatePassDescriptor = "resourceStatePassDescriptor";
-        private static readonly Selector sel_sampleBufferAttachments = "sampleBufferAttachments";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLSampler.cs
+++ b/src/SharpMetal/Metal/MTLSampler.cs
@@ -5,21 +5,6 @@ using SharpMetal.Foundation;
 namespace SharpMetal.Metal
 {
     [SupportedOSPlatform("macos")]
-    public enum MTLSamplerMinMagFilter : ulong
-    {
-        Nearest = 0,
-        Linear = 1,
-    }
-
-    [SupportedOSPlatform("macos")]
-    public enum MTLSamplerMipFilter : ulong
-    {
-        NotMipmapped = 0,
-        Nearest = 1,
-        Linear = 2,
-    }
-
-    [SupportedOSPlatform("macos")]
     public enum MTLSamplerAddressMode : ulong
     {
         ClampToEdge = 0,
@@ -36,6 +21,21 @@ namespace SharpMetal.Metal
         TransparentBlack = 0,
         OpaqueBlack = 1,
         OpaqueWhite = 2,
+    }
+
+    [SupportedOSPlatform("macos")]
+    public enum MTLSamplerMinMagFilter : ulong
+    {
+        Nearest = 0,
+        Linear = 1,
+    }
+
+    [SupportedOSPlatform("macos")]
+    public enum MTLSamplerMipFilter : ulong
+    {
+        NotMipmapped = 0,
+        Nearest = 1,
+        Linear = 2,
     }
 
     [SupportedOSPlatform("macos")]
@@ -56,70 +56,22 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public MTLSamplerMinMagFilter MinFilter
-        {
-            get => (MTLSamplerMinMagFilter)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_minFilter);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMinFilter, (ulong)value);
-        }
-
-        public MTLSamplerMinMagFilter MagFilter
-        {
-            get => (MTLSamplerMinMagFilter)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_magFilter);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMagFilter, (ulong)value);
-        }
-
-        public MTLSamplerMipFilter MipFilter
-        {
-            get => (MTLSamplerMipFilter)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_mipFilter);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMipFilter, (ulong)value);
-        }
-
-        public ulong MaxAnisotropy
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxAnisotropy);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxAnisotropy, value);
-        }
-
-        public MTLSamplerAddressMode SAddressMode
-        {
-            get => (MTLSamplerAddressMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_sAddressMode);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSAddressMode, (ulong)value);
-        }
-
-        public MTLSamplerAddressMode TAddressMode
-        {
-            get => (MTLSamplerAddressMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_tAddressMode);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTAddressMode, (ulong)value);
-        }
-
-        public MTLSamplerAddressMode RAddressMode
-        {
-            get => (MTLSamplerAddressMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_rAddressMode);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRAddressMode, (ulong)value);
-        }
-
         public MTLSamplerBorderColor BorderColor
         {
             get => (MTLSamplerBorderColor)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_borderColor);
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBorderColor, (ulong)value);
         }
 
-        public bool NormalizedCoordinates
+        public MTLCompareFunction CompareFunction
         {
-            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_normalizedCoordinates);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setNormalizedCoordinates, value);
+            get => (MTLCompareFunction)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_compareFunction);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setCompareFunction, (ulong)value);
         }
 
-        public float LodMinClamp
+        public NSString Label
         {
-            get => ObjectiveCRuntime.float_objc_msgSend(NativePtr, sel_lodMinClamp);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLodMinClamp, value);
-        }
-
-        public float LodMaxClamp
-        {
-            get => ObjectiveCRuntime.float_objc_msgSend(NativePtr, sel_lodMaxClamp);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLodMaxClamp, value);
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
         }
 
         public bool LodAverage
@@ -139,10 +91,58 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLodBias, value);
         }
 
-        public MTLCompareFunction CompareFunction
+        public float LodMaxClamp
         {
-            get => (MTLCompareFunction)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_compareFunction);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setCompareFunction, (ulong)value);
+            get => ObjectiveCRuntime.float_objc_msgSend(NativePtr, sel_lodMaxClamp);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLodMaxClamp, value);
+        }
+
+        public float LodMinClamp
+        {
+            get => ObjectiveCRuntime.float_objc_msgSend(NativePtr, sel_lodMinClamp);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLodMinClamp, value);
+        }
+
+        public MTLSamplerMinMagFilter MagFilter
+        {
+            get => (MTLSamplerMinMagFilter)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_magFilter);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMagFilter, (ulong)value);
+        }
+
+        public ulong MaxAnisotropy
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_maxAnisotropy);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMaxAnisotropy, value);
+        }
+
+        public MTLSamplerMinMagFilter MinFilter
+        {
+            get => (MTLSamplerMinMagFilter)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_minFilter);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMinFilter, (ulong)value);
+        }
+
+        public MTLSamplerMipFilter MipFilter
+        {
+            get => (MTLSamplerMipFilter)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_mipFilter);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMipFilter, (ulong)value);
+        }
+
+        public bool NormalizedCoordinates
+        {
+            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_normalizedCoordinates);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setNormalizedCoordinates, value);
+        }
+
+        public MTLSamplerAddressMode RAddressMode
+        {
+            get => (MTLSamplerAddressMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_rAddressMode);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setRAddressMode, (ulong)value);
+        }
+
+        public MTLSamplerAddressMode SAddressMode
+        {
+            get => (MTLSamplerAddressMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_sAddressMode);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSAddressMode, (ulong)value);
         }
 
         public bool SupportArgumentBuffers
@@ -151,44 +151,44 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSupportArgumentBuffers, value);
         }
 
-        public NSString Label
+        public MTLSamplerAddressMode TAddressMode
         {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
+            get => (MTLSamplerAddressMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_tAddressMode);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTAddressMode, (ulong)value);
         }
 
-        private static readonly Selector sel_minFilter = "minFilter";
-        private static readonly Selector sel_setMinFilter = "setMinFilter:";
-        private static readonly Selector sel_magFilter = "magFilter";
-        private static readonly Selector sel_setMagFilter = "setMagFilter:";
-        private static readonly Selector sel_mipFilter = "mipFilter";
-        private static readonly Selector sel_setMipFilter = "setMipFilter:";
-        private static readonly Selector sel_maxAnisotropy = "maxAnisotropy";
-        private static readonly Selector sel_setMaxAnisotropy = "setMaxAnisotropy:";
-        private static readonly Selector sel_sAddressMode = "sAddressMode";
-        private static readonly Selector sel_setSAddressMode = "setSAddressMode:";
-        private static readonly Selector sel_tAddressMode = "tAddressMode";
-        private static readonly Selector sel_setTAddressMode = "setTAddressMode:";
-        private static readonly Selector sel_rAddressMode = "rAddressMode";
-        private static readonly Selector sel_setRAddressMode = "setRAddressMode:";
         private static readonly Selector sel_borderColor = "borderColor";
-        private static readonly Selector sel_setBorderColor = "setBorderColor:";
-        private static readonly Selector sel_normalizedCoordinates = "normalizedCoordinates";
-        private static readonly Selector sel_setNormalizedCoordinates = "setNormalizedCoordinates:";
-        private static readonly Selector sel_lodMinClamp = "lodMinClamp";
-        private static readonly Selector sel_setLodMinClamp = "setLodMinClamp:";
-        private static readonly Selector sel_lodMaxClamp = "lodMaxClamp";
-        private static readonly Selector sel_setLodMaxClamp = "setLodMaxClamp:";
-        private static readonly Selector sel_lodAverage = "lodAverage";
-        private static readonly Selector sel_setLodAverage = "setLodAverage:";
-        private static readonly Selector sel_lodBias = "lodBias";
-        private static readonly Selector sel_setLodBias = "setLodBias:";
         private static readonly Selector sel_compareFunction = "compareFunction";
-        private static readonly Selector sel_setCompareFunction = "setCompareFunction:";
-        private static readonly Selector sel_supportArgumentBuffers = "supportArgumentBuffers";
-        private static readonly Selector sel_setSupportArgumentBuffers = "setSupportArgumentBuffers:";
         private static readonly Selector sel_label = "label";
+        private static readonly Selector sel_lodAverage = "lodAverage";
+        private static readonly Selector sel_lodBias = "lodBias";
+        private static readonly Selector sel_lodMaxClamp = "lodMaxClamp";
+        private static readonly Selector sel_lodMinClamp = "lodMinClamp";
+        private static readonly Selector sel_magFilter = "magFilter";
+        private static readonly Selector sel_maxAnisotropy = "maxAnisotropy";
+        private static readonly Selector sel_minFilter = "minFilter";
+        private static readonly Selector sel_mipFilter = "mipFilter";
+        private static readonly Selector sel_normalizedCoordinates = "normalizedCoordinates";
+        private static readonly Selector sel_rAddressMode = "rAddressMode";
+        private static readonly Selector sel_sAddressMode = "sAddressMode";
+        private static readonly Selector sel_setBorderColor = "setBorderColor:";
+        private static readonly Selector sel_setCompareFunction = "setCompareFunction:";
         private static readonly Selector sel_setLabel = "setLabel:";
+        private static readonly Selector sel_setLodAverage = "setLodAverage:";
+        private static readonly Selector sel_setLodBias = "setLodBias:";
+        private static readonly Selector sel_setLodMaxClamp = "setLodMaxClamp:";
+        private static readonly Selector sel_setLodMinClamp = "setLodMinClamp:";
+        private static readonly Selector sel_setMagFilter = "setMagFilter:";
+        private static readonly Selector sel_setMaxAnisotropy = "setMaxAnisotropy:";
+        private static readonly Selector sel_setMinFilter = "setMinFilter:";
+        private static readonly Selector sel_setMipFilter = "setMipFilter:";
+        private static readonly Selector sel_setNormalizedCoordinates = "setNormalizedCoordinates:";
+        private static readonly Selector sel_setRAddressMode = "setRAddressMode:";
+        private static readonly Selector sel_setSAddressMode = "setSAddressMode:";
+        private static readonly Selector sel_setSupportArgumentBuffers = "setSupportArgumentBuffers:";
+        private static readonly Selector sel_setTAddressMode = "setTAddressMode:";
+        private static readonly Selector sel_supportArgumentBuffers = "supportArgumentBuffers";
+        private static readonly Selector sel_tAddressMode = "tAddressMode";
         private static readonly Selector sel_release = "release";
     }
 
@@ -204,15 +204,15 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public NSString Label => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
-
         public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
 
         public MTLResourceID GpuResourceID => ObjectiveCRuntime.MTLResourceID_objc_msgSend(NativePtr, sel_gpuResourceID);
 
-        private static readonly Selector sel_label = "label";
+        public NSString Label => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
+
         private static readonly Selector sel_device = "device";
         private static readonly Selector sel_gpuResourceID = "gpuResourceID";
+        private static readonly Selector sel_label = "label";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLStageInputOutputDescriptor.cs
+++ b/src/SharpMetal/Metal/MTLStageInputOutputDescriptor.cs
@@ -85,84 +85,6 @@ namespace SharpMetal.Metal
     }
 
     [SupportedOSPlatform("macos")]
-    public struct MTLBufferLayoutDescriptor : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLBufferLayoutDescriptor obj) => obj.NativePtr;
-        public MTLBufferLayoutDescriptor(IntPtr ptr) => NativePtr = ptr;
-
-        public MTLBufferLayoutDescriptor()
-        {
-            var cls = new ObjectiveCClass("MTLBufferLayoutDescriptor");
-            NativePtr = cls.AllocInit();
-        }
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public ulong Stride
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_stride);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStride, value);
-        }
-
-        public MTLStepFunction StepFunction
-        {
-            get => (MTLStepFunction)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_stepFunction);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStepFunction, (ulong)value);
-        }
-
-        public ulong StepRate
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_stepRate);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStepRate, value);
-        }
-
-        private static readonly Selector sel_stride = "stride";
-        private static readonly Selector sel_setStride = "setStride:";
-        private static readonly Selector sel_stepFunction = "stepFunction";
-        private static readonly Selector sel_setStepFunction = "setStepFunction:";
-        private static readonly Selector sel_stepRate = "stepRate";
-        private static readonly Selector sel_setStepRate = "setStepRate:";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLBufferLayoutDescriptorArray : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLBufferLayoutDescriptorArray obj) => obj.NativePtr;
-        public MTLBufferLayoutDescriptorArray(IntPtr ptr) => NativePtr = ptr;
-
-        public MTLBufferLayoutDescriptorArray()
-        {
-            var cls = new ObjectiveCClass("MTLBufferLayoutDescriptorArray");
-            NativePtr = cls.AllocInit();
-        }
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public MTLBufferLayoutDescriptor Object(ulong index)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_objectAtIndexedSubscript, index));
-        }
-
-        public void SetObject(MTLBufferLayoutDescriptor bufferDesc, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setObjectatIndexedSubscript, bufferDesc, index);
-        }
-
-        private static readonly Selector sel_objectAtIndexedSubscript = "objectAtIndexedSubscript:";
-        private static readonly Selector sel_setObjectatIndexedSubscript = "setObject:atIndexedSubscript:";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
     public struct MTLAttributeDescriptor : IDisposable
     {
         public IntPtr NativePtr;
@@ -180,6 +102,12 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
+        public ulong BufferIndex
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_bufferIndex);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBufferIndex, value);
+        }
+
         public MTLAttributeFormat Format
         {
             get => (MTLAttributeFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_format);
@@ -192,18 +120,12 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setOffset, value);
         }
 
-        public ulong BufferIndex
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_bufferIndex);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBufferIndex, value);
-        }
-
-        private static readonly Selector sel_format = "format";
-        private static readonly Selector sel_setFormat = "setFormat:";
-        private static readonly Selector sel_offset = "offset";
-        private static readonly Selector sel_setOffset = "setOffset:";
         private static readonly Selector sel_bufferIndex = "bufferIndex";
+        private static readonly Selector sel_format = "format";
+        private static readonly Selector sel_offset = "offset";
         private static readonly Selector sel_setBufferIndex = "setBufferIndex:";
+        private static readonly Selector sel_setFormat = "setFormat:";
+        private static readonly Selector sel_setOffset = "setOffset:";
         private static readonly Selector sel_release = "release";
     }
 
@@ -241,6 +163,84 @@ namespace SharpMetal.Metal
     }
 
     [SupportedOSPlatform("macos")]
+    public struct MTLBufferLayoutDescriptor : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLBufferLayoutDescriptor obj) => obj.NativePtr;
+        public MTLBufferLayoutDescriptor(IntPtr ptr) => NativePtr = ptr;
+
+        public MTLBufferLayoutDescriptor()
+        {
+            var cls = new ObjectiveCClass("MTLBufferLayoutDescriptor");
+            NativePtr = cls.AllocInit();
+        }
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public MTLStepFunction StepFunction
+        {
+            get => (MTLStepFunction)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_stepFunction);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStepFunction, (ulong)value);
+        }
+
+        public ulong StepRate
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_stepRate);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStepRate, value);
+        }
+
+        public ulong Stride
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_stride);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStride, value);
+        }
+
+        private static readonly Selector sel_setStepFunction = "setStepFunction:";
+        private static readonly Selector sel_setStepRate = "setStepRate:";
+        private static readonly Selector sel_setStride = "setStride:";
+        private static readonly Selector sel_stepFunction = "stepFunction";
+        private static readonly Selector sel_stepRate = "stepRate";
+        private static readonly Selector sel_stride = "stride";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
+    public struct MTLBufferLayoutDescriptorArray : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLBufferLayoutDescriptorArray obj) => obj.NativePtr;
+        public MTLBufferLayoutDescriptorArray(IntPtr ptr) => NativePtr = ptr;
+
+        public MTLBufferLayoutDescriptorArray()
+        {
+            var cls = new ObjectiveCClass("MTLBufferLayoutDescriptorArray");
+            NativePtr = cls.AllocInit();
+        }
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public MTLBufferLayoutDescriptor Object(ulong index)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_objectAtIndexedSubscript, index));
+        }
+
+        public void SetObject(MTLBufferLayoutDescriptor bufferDesc, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setObjectatIndexedSubscript, bufferDesc, index);
+        }
+
+        private static readonly Selector sel_objectAtIndexedSubscript = "objectAtIndexedSubscript:";
+        private static readonly Selector sel_setObjectatIndexedSubscript = "setObject:atIndexedSubscript:";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
     public struct MTLStageInputOutputDescriptor : IDisposable
     {
         public IntPtr NativePtr;
@@ -258,15 +258,7 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public MTLBufferLayoutDescriptorArray Layouts => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_layouts));
-
         public MTLAttributeDescriptorArray Attributes => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_attributes));
-
-        public MTLIndexType IndexType
-        {
-            get => (MTLIndexType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_indexType);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIndexType, (ulong)value);
-        }
 
         public ulong IndexBufferIndex
         {
@@ -274,19 +266,27 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIndexBufferIndex, value);
         }
 
+        public MTLIndexType IndexType
+        {
+            get => (MTLIndexType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_indexType);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setIndexType, (ulong)value);
+        }
+
+        public MTLBufferLayoutDescriptorArray Layouts => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_layouts));
+
         public void Reset()
         {
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_reset);
         }
 
-        private static readonly Selector sel_stageInputOutputDescriptor = "stageInputOutputDescriptor";
-        private static readonly Selector sel_layouts = "layouts";
         private static readonly Selector sel_attributes = "attributes";
-        private static readonly Selector sel_indexType = "indexType";
-        private static readonly Selector sel_setIndexType = "setIndexType:";
         private static readonly Selector sel_indexBufferIndex = "indexBufferIndex";
-        private static readonly Selector sel_setIndexBufferIndex = "setIndexBufferIndex:";
+        private static readonly Selector sel_indexType = "indexType";
+        private static readonly Selector sel_layouts = "layouts";
         private static readonly Selector sel_reset = "reset";
+        private static readonly Selector sel_setIndexBufferIndex = "setIndexBufferIndex:";
+        private static readonly Selector sel_setIndexType = "setIndexType:";
+        private static readonly Selector sel_stageInputOutputDescriptor = "stageInputOutputDescriptor";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLTexture.cs
+++ b/src/SharpMetal/Metal/MTLTexture.cs
@@ -6,6 +6,24 @@ using SharpMetal.Foundation;
 namespace SharpMetal.Metal
 {
     [SupportedOSPlatform("macos")]
+    public enum MTLTextureCompressionType : long
+    {
+        Lossless = 0,
+        Lossy = 1,
+    }
+
+    [SupportedOSPlatform("macos")]
+    public enum MTLTextureSwizzle : byte
+    {
+        Zero = 0,
+        One = 1,
+        Red = 2,
+        Green = 3,
+        Blue = 4,
+        Alpha = 5,
+    }
+
+    [SupportedOSPlatform("macos")]
     public enum MTLTextureType : ulong
     {
         Type1D = 0,
@@ -21,17 +39,6 @@ namespace SharpMetal.Metal
     }
 
     [SupportedOSPlatform("macos")]
-    public enum MTLTextureSwizzle : byte
-    {
-        Zero = 0,
-        One = 1,
-        Red = 2,
-        Green = 3,
-        Blue = 4,
-        Alpha = 5,
-    }
-
-    [SupportedOSPlatform("macos")]
     [Flags]
     public enum MTLTextureUsage : ulong
     {
@@ -41,13 +48,6 @@ namespace SharpMetal.Metal
         RenderTarget = 4,
         PixelFormatView = 16,
         ShaderAtomic = 32,
-    }
-
-    [SupportedOSPlatform("macos")]
-    public enum MTLTextureCompressionType : long
-    {
-        Lossless = 0,
-        Lossy = 1,
     }
 
     [SupportedOSPlatform("macos")]
@@ -88,6 +88,204 @@ namespace SharpMetal.Metal
     }
 
     [SupportedOSPlatform("macos")]
+    public struct MTLTexture : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLTexture obj) => obj.NativePtr;
+        public static implicit operator MTLResource(MTLTexture obj) => new(obj.NativePtr);
+        public MTLTexture(IntPtr ptr) => NativePtr = ptr;
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public ulong AllocatedSize => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_allocatedSize);
+
+        public bool AllowGPUOptimizedContents => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_allowGPUOptimizedContents);
+
+        public ulong ArrayLength => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_arrayLength);
+
+        public MTLBuffer Buffer => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_buffer));
+
+        public ulong BufferBytesPerRow => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_bufferBytesPerRow);
+
+        public ulong BufferOffset => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_bufferOffset);
+
+        public MTLTextureCompressionType CompressionType => (MTLTextureCompressionType)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_compressionType);
+
+        public MTLCPUCacheMode CpuCacheMode => (MTLCPUCacheMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_cpuCacheMode);
+
+        public ulong Depth => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_depth);
+
+        public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
+
+        public ulong FirstMipmapInTail => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_firstMipmapInTail);
+
+        public bool FramebufferOnly => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isFramebufferOnly);
+
+        public MTLResourceID GpuResourceID => ObjectiveCRuntime.MTLResourceID_objc_msgSend(NativePtr, sel_gpuResourceID);
+
+        public MTLHazardTrackingMode HazardTrackingMode => (MTLHazardTrackingMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_hazardTrackingMode);
+
+        public MTLHeap Heap => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_heap));
+
+        public ulong HeapOffset => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_heapOffset);
+
+        public ulong Height => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_height);
+
+        public IntPtr Iosurface => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_iosurface));
+
+        public ulong IosurfacePlane => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_iosurfacePlane);
+
+        public bool IsAliasable => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isAliasable);
+
+        public bool IsSparse => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isSparse);
+
+        public NSString Label
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
+        }
+
+        public ulong MipmapLevelCount => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_mipmapLevelCount);
+
+        public MTLSharedTextureHandle NewSharedTextureHandle => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newSharedTextureHandle));
+
+        public ulong ParentRelativeLevel => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_parentRelativeLevel);
+
+        public ulong ParentRelativeSlice => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_parentRelativeSlice);
+
+        public MTLTexture ParentTexture => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_parentTexture));
+
+        public MTLPixelFormat PixelFormat => (MTLPixelFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_pixelFormat);
+
+        public MTLTexture RemoteStorageTexture => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_remoteStorageTexture));
+
+        public MTLResourceOptions ResourceOptions => (MTLResourceOptions)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_resourceOptions);
+
+        public MTLResource RootResource => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_rootResource));
+
+        public ulong SampleCount => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_sampleCount);
+
+        public bool Shareable => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isShareable);
+
+        public MTLStorageMode StorageMode => (MTLStorageMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_storageMode);
+
+        public MTLTextureSwizzleChannels Swizzle => ObjectiveCRuntime.MTLTextureSwizzleChannels_objc_msgSend(NativePtr, sel_swizzle);
+
+        public ulong TailSizeInBytes => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_tailSizeInBytes);
+
+        public MTLTextureType TextureType => (MTLTextureType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_textureType);
+
+        public MTLTextureUsage Usage => (MTLTextureUsage)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_usage);
+
+        public ulong Width => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_width);
+
+        public void GetBytes(IntPtr pixelBytes, ulong bytesPerRow, ulong bytesPerImage, MTLRegion region, ulong level, ulong slice)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_getBytesbytesPerRowbytesPerImagefromRegionmipmapLevelslice, pixelBytes, bytesPerRow, bytesPerImage, region, level, slice);
+        }
+
+        public void GetBytes(IntPtr pixelBytes, ulong bytesPerRow, MTLRegion region, ulong level)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_getBytesbytesPerRowfromRegionmipmapLevel, pixelBytes, bytesPerRow, region, level);
+        }
+
+        public void MakeAliasable()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_makeAliasable);
+        }
+
+        public MTLTexture NewRemoteTextureViewForDevice(MTLDevice device)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newRemoteTextureViewForDevice, device));
+        }
+
+        public MTLTexture NewTextureView(MTLPixelFormat pixelFormat)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newTextureViewWithPixelFormat, (ulong)pixelFormat));
+        }
+
+        public MTLTexture NewTextureView(MTLPixelFormat pixelFormat, MTLTextureType textureType, NSRange levelRange, NSRange sliceRange)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newTextureViewWithPixelFormattextureTypelevelsslices, (ulong)pixelFormat, (ulong)textureType, levelRange, sliceRange));
+        }
+
+        public MTLTexture NewTextureView(MTLPixelFormat pixelFormat, MTLTextureType textureType, NSRange levelRange, NSRange sliceRange, MTLTextureSwizzleChannels swizzle)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newTextureViewWithPixelFormattextureTypelevelsslicesswizzle, (ulong)pixelFormat, (ulong)textureType, levelRange, sliceRange, swizzle));
+        }
+
+        public void ReplaceRegion(MTLRegion region, ulong level, ulong slice, IntPtr pixelBytes, ulong bytesPerRow, ulong bytesPerImage)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_replaceRegionmipmapLevelslicewithBytesbytesPerRowbytesPerImage, region, level, slice, pixelBytes, bytesPerRow, bytesPerImage);
+        }
+
+        public void ReplaceRegion(MTLRegion region, ulong level, IntPtr pixelBytes, ulong bytesPerRow)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_replaceRegionmipmapLevelwithBytesbytesPerRow, region, level, pixelBytes, bytesPerRow);
+        }
+
+        public MTLPurgeableState SetPurgeableState(MTLPurgeableState state)
+        {
+            return (MTLPurgeableState)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_setPurgeableState, (ulong)state);
+        }
+
+        private static readonly Selector sel_allocatedSize = "allocatedSize";
+        private static readonly Selector sel_allowGPUOptimizedContents = "allowGPUOptimizedContents";
+        private static readonly Selector sel_arrayLength = "arrayLength";
+        private static readonly Selector sel_buffer = "buffer";
+        private static readonly Selector sel_bufferBytesPerRow = "bufferBytesPerRow";
+        private static readonly Selector sel_bufferOffset = "bufferOffset";
+        private static readonly Selector sel_compressionType = "compressionType";
+        private static readonly Selector sel_cpuCacheMode = "cpuCacheMode";
+        private static readonly Selector sel_depth = "depth";
+        private static readonly Selector sel_device = "device";
+        private static readonly Selector sel_firstMipmapInTail = "firstMipmapInTail";
+        private static readonly Selector sel_getBytesbytesPerRowbytesPerImagefromRegionmipmapLevelslice = "getBytes:bytesPerRow:bytesPerImage:fromRegion:mipmapLevel:slice:";
+        private static readonly Selector sel_getBytesbytesPerRowfromRegionmipmapLevel = "getBytes:bytesPerRow:fromRegion:mipmapLevel:";
+        private static readonly Selector sel_gpuResourceID = "gpuResourceID";
+        private static readonly Selector sel_hazardTrackingMode = "hazardTrackingMode";
+        private static readonly Selector sel_heap = "heap";
+        private static readonly Selector sel_heapOffset = "heapOffset";
+        private static readonly Selector sel_height = "height";
+        private static readonly Selector sel_iosurface = "iosurface";
+        private static readonly Selector sel_iosurfacePlane = "iosurfacePlane";
+        private static readonly Selector sel_isAliasable = "isAliasable";
+        private static readonly Selector sel_isFramebufferOnly = "isFramebufferOnly";
+        private static readonly Selector sel_isShareable = "isShareable";
+        private static readonly Selector sel_isSparse = "isSparse";
+        private static readonly Selector sel_label = "label";
+        private static readonly Selector sel_makeAliasable = "makeAliasable";
+        private static readonly Selector sel_mipmapLevelCount = "mipmapLevelCount";
+        private static readonly Selector sel_newRemoteTextureViewForDevice = "newRemoteTextureViewForDevice:";
+        private static readonly Selector sel_newSharedTextureHandle = "newSharedTextureHandle";
+        private static readonly Selector sel_newTextureViewWithPixelFormat = "newTextureViewWithPixelFormat:";
+        private static readonly Selector sel_newTextureViewWithPixelFormattextureTypelevelsslices = "newTextureViewWithPixelFormat:textureType:levels:slices:";
+        private static readonly Selector sel_newTextureViewWithPixelFormattextureTypelevelsslicesswizzle = "newTextureViewWithPixelFormat:textureType:levels:slices:swizzle:";
+        private static readonly Selector sel_parentRelativeLevel = "parentRelativeLevel";
+        private static readonly Selector sel_parentRelativeSlice = "parentRelativeSlice";
+        private static readonly Selector sel_parentTexture = "parentTexture";
+        private static readonly Selector sel_pixelFormat = "pixelFormat";
+        private static readonly Selector sel_remoteStorageTexture = "remoteStorageTexture";
+        private static readonly Selector sel_replaceRegionmipmapLevelslicewithBytesbytesPerRowbytesPerImage = "replaceRegion:mipmapLevel:slice:withBytes:bytesPerRow:bytesPerImage:";
+        private static readonly Selector sel_replaceRegionmipmapLevelwithBytesbytesPerRow = "replaceRegion:mipmapLevel:withBytes:bytesPerRow:";
+        private static readonly Selector sel_resourceOptions = "resourceOptions";
+        private static readonly Selector sel_rootResource = "rootResource";
+        private static readonly Selector sel_sampleCount = "sampleCount";
+        private static readonly Selector sel_setLabel = "setLabel:";
+        private static readonly Selector sel_setPurgeableState = "setPurgeableState:";
+        private static readonly Selector sel_storageMode = "storageMode";
+        private static readonly Selector sel_swizzle = "swizzle";
+        private static readonly Selector sel_tailSizeInBytes = "tailSizeInBytes";
+        private static readonly Selector sel_textureType = "textureType";
+        private static readonly Selector sel_usage = "usage";
+        private static readonly Selector sel_width = "width";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
     public struct MTLTextureDescriptor : IDisposable
     {
         public IntPtr NativePtr;
@@ -105,46 +303,10 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public MTLTextureType TextureType
+        public bool AllowGPUOptimizedContents
         {
-            get => (MTLTextureType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_textureType);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTextureType, (ulong)value);
-        }
-
-        public MTLPixelFormat PixelFormat
-        {
-            get => (MTLPixelFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_pixelFormat);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPixelFormat, (ulong)value);
-        }
-
-        public ulong Width
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_width);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setWidth, value);
-        }
-
-        public ulong Height
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_height);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setHeight, value);
-        }
-
-        public ulong Depth
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_depth);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDepth, value);
-        }
-
-        public ulong MipmapLevelCount
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_mipmapLevelCount);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMipmapLevelCount, value);
-        }
-
-        public ulong SampleCount
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_sampleCount);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSampleCount, value);
+            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_allowGPUOptimizedContents);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setAllowGPUOptimizedContents, value);
         }
 
         public ulong ArrayLength
@@ -153,10 +315,10 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setArrayLength, value);
         }
 
-        public MTLResourceOptions ResourceOptions
+        public MTLTextureCompressionType CompressionType
         {
-            get => (MTLResourceOptions)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_resourceOptions);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setResourceOptions, (ulong)value);
+            get => (MTLTextureCompressionType)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_compressionType);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setCompressionType, (long)value);
         }
 
         public MTLCPUCacheMode CpuCacheMode
@@ -165,10 +327,10 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setCpuCacheMode, (ulong)value);
         }
 
-        public MTLStorageMode StorageMode
+        public ulong Depth
         {
-            get => (MTLStorageMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_storageMode);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStorageMode, (ulong)value);
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_depth);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDepth, value);
         }
 
         public MTLHazardTrackingMode HazardTrackingMode
@@ -177,22 +339,40 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setHazardTrackingMode, (ulong)value);
         }
 
-        public MTLTextureUsage Usage
+        public ulong Height
         {
-            get => (MTLTextureUsage)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_usage);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setUsage, (ulong)value);
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_height);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setHeight, value);
         }
 
-        public bool AllowGPUOptimizedContents
+        public ulong MipmapLevelCount
         {
-            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_allowGPUOptimizedContents);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setAllowGPUOptimizedContents, value);
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_mipmapLevelCount);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setMipmapLevelCount, value);
         }
 
-        public MTLTextureCompressionType CompressionType
+        public MTLPixelFormat PixelFormat
         {
-            get => (MTLTextureCompressionType)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_compressionType);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setCompressionType, (long)value);
+            get => (MTLPixelFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_pixelFormat);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPixelFormat, (ulong)value);
+        }
+
+        public MTLResourceOptions ResourceOptions
+        {
+            get => (MTLResourceOptions)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_resourceOptions);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setResourceOptions, (ulong)value);
+        }
+
+        public ulong SampleCount
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_sampleCount);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSampleCount, value);
+        }
+
+        public MTLStorageMode StorageMode
+        {
+            get => (MTLStorageMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_storageMode);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStorageMode, (ulong)value);
         }
 
         public MTLTextureSwizzleChannels Swizzle
@@ -201,14 +381,27 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setSwizzle, value);
         }
 
+        public MTLTextureType TextureType
+        {
+            get => (MTLTextureType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_textureType);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setTextureType, (ulong)value);
+        }
+
+        public MTLTextureUsage Usage
+        {
+            get => (MTLTextureUsage)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_usage);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setUsage, (ulong)value);
+        }
+
+        public ulong Width
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_width);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setWidth, value);
+        }
+
         public static MTLTextureDescriptor Texture2DDescriptor(MTLPixelFormat pixelFormat, ulong width, ulong height, bool mipmapped)
         {
             return new(ObjectiveCRuntime.IntPtr_objc_msgSend(new ObjectiveCClass("MTLTextureDescriptor"), sel_texture2DDescriptorWithPixelFormatwidthheightmipmapped, (ulong)pixelFormat, width, height, mipmapped));
-        }
-
-        public static MTLTextureDescriptor TextureCubeDescriptor(MTLPixelFormat pixelFormat, ulong size, bool mipmapped)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(new ObjectiveCClass("MTLTextureDescriptor"), sel_textureCubeDescriptorWithPixelFormatsizemipmapped, (ulong)pixelFormat, size, mipmapped));
         }
 
         public static MTLTextureDescriptor TextureBufferDescriptor(MTLPixelFormat pixelFormat, ulong width, MTLResourceOptions resourceOptions, MTLTextureUsage usage)
@@ -216,239 +409,46 @@ namespace SharpMetal.Metal
             return new(ObjectiveCRuntime.IntPtr_objc_msgSend(new ObjectiveCClass("MTLTextureDescriptor"), sel_textureBufferDescriptorWithPixelFormatwidthresourceOptionsusage, (ulong)pixelFormat, width, (ulong)resourceOptions, (ulong)usage));
         }
 
-        private static readonly Selector sel_texture2DDescriptorWithPixelFormatwidthheightmipmapped = "texture2DDescriptorWithPixelFormat:width:height:mipmapped:";
-        private static readonly Selector sel_textureCubeDescriptorWithPixelFormatsizemipmapped = "textureCubeDescriptorWithPixelFormat:size:mipmapped:";
-        private static readonly Selector sel_textureBufferDescriptorWithPixelFormatwidthresourceOptionsusage = "textureBufferDescriptorWithPixelFormat:width:resourceOptions:usage:";
-        private static readonly Selector sel_textureType = "textureType";
-        private static readonly Selector sel_setTextureType = "setTextureType:";
-        private static readonly Selector sel_pixelFormat = "pixelFormat";
-        private static readonly Selector sel_setPixelFormat = "setPixelFormat:";
-        private static readonly Selector sel_width = "width";
-        private static readonly Selector sel_setWidth = "setWidth:";
-        private static readonly Selector sel_height = "height";
-        private static readonly Selector sel_setHeight = "setHeight:";
-        private static readonly Selector sel_depth = "depth";
-        private static readonly Selector sel_setDepth = "setDepth:";
-        private static readonly Selector sel_mipmapLevelCount = "mipmapLevelCount";
-        private static readonly Selector sel_setMipmapLevelCount = "setMipmapLevelCount:";
-        private static readonly Selector sel_sampleCount = "sampleCount";
-        private static readonly Selector sel_setSampleCount = "setSampleCount:";
-        private static readonly Selector sel_arrayLength = "arrayLength";
-        private static readonly Selector sel_setArrayLength = "setArrayLength:";
-        private static readonly Selector sel_resourceOptions = "resourceOptions";
-        private static readonly Selector sel_setResourceOptions = "setResourceOptions:";
-        private static readonly Selector sel_cpuCacheMode = "cpuCacheMode";
-        private static readonly Selector sel_setCpuCacheMode = "setCpuCacheMode:";
-        private static readonly Selector sel_storageMode = "storageMode";
-        private static readonly Selector sel_setStorageMode = "setStorageMode:";
-        private static readonly Selector sel_hazardTrackingMode = "hazardTrackingMode";
-        private static readonly Selector sel_setHazardTrackingMode = "setHazardTrackingMode:";
-        private static readonly Selector sel_usage = "usage";
-        private static readonly Selector sel_setUsage = "setUsage:";
+        public static MTLTextureDescriptor TextureCubeDescriptor(MTLPixelFormat pixelFormat, ulong size, bool mipmapped)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(new ObjectiveCClass("MTLTextureDescriptor"), sel_textureCubeDescriptorWithPixelFormatsizemipmapped, (ulong)pixelFormat, size, mipmapped));
+        }
+
         private static readonly Selector sel_allowGPUOptimizedContents = "allowGPUOptimizedContents";
+        private static readonly Selector sel_arrayLength = "arrayLength";
+        private static readonly Selector sel_compressionType = "compressionType";
+        private static readonly Selector sel_cpuCacheMode = "cpuCacheMode";
+        private static readonly Selector sel_depth = "depth";
+        private static readonly Selector sel_hazardTrackingMode = "hazardTrackingMode";
+        private static readonly Selector sel_height = "height";
+        private static readonly Selector sel_mipmapLevelCount = "mipmapLevelCount";
+        private static readonly Selector sel_pixelFormat = "pixelFormat";
+        private static readonly Selector sel_resourceOptions = "resourceOptions";
+        private static readonly Selector sel_sampleCount = "sampleCount";
         private static readonly Selector sel_setAllowGPUOptimizedContents = "setAllowGPUOptimizedContents:";
-        private static readonly Selector sel_compressionType = "compressionType";
+        private static readonly Selector sel_setArrayLength = "setArrayLength:";
         private static readonly Selector sel_setCompressionType = "setCompressionType:";
-        private static readonly Selector sel_swizzle = "swizzle";
+        private static readonly Selector sel_setCpuCacheMode = "setCpuCacheMode:";
+        private static readonly Selector sel_setDepth = "setDepth:";
+        private static readonly Selector sel_setHazardTrackingMode = "setHazardTrackingMode:";
+        private static readonly Selector sel_setHeight = "setHeight:";
+        private static readonly Selector sel_setMipmapLevelCount = "setMipmapLevelCount:";
+        private static readonly Selector sel_setPixelFormat = "setPixelFormat:";
+        private static readonly Selector sel_setResourceOptions = "setResourceOptions:";
+        private static readonly Selector sel_setSampleCount = "setSampleCount:";
+        private static readonly Selector sel_setStorageMode = "setStorageMode:";
         private static readonly Selector sel_setSwizzle = "setSwizzle:";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLTexture : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLTexture obj) => obj.NativePtr;
-        public static implicit operator MTLResource(MTLTexture obj) => new(obj.NativePtr);
-        public MTLTexture(IntPtr ptr) => NativePtr = ptr;
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public MTLResource RootResource => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_rootResource));
-
-        public MTLTexture ParentTexture => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_parentTexture));
-
-        public ulong ParentRelativeLevel => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_parentRelativeLevel);
-
-        public ulong ParentRelativeSlice => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_parentRelativeSlice);
-
-        public MTLBuffer Buffer => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_buffer));
-
-        public ulong BufferOffset => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_bufferOffset);
-
-        public ulong BufferBytesPerRow => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_bufferBytesPerRow);
-
-        public IntPtr Iosurface => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_iosurface));
-
-        public ulong IosurfacePlane => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_iosurfacePlane);
-
-        public MTLTextureType TextureType => (MTLTextureType)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_textureType);
-
-        public MTLPixelFormat PixelFormat => (MTLPixelFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_pixelFormat);
-
-        public ulong Width => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_width);
-
-        public ulong Height => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_height);
-
-        public ulong Depth => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_depth);
-
-        public ulong MipmapLevelCount => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_mipmapLevelCount);
-
-        public ulong SampleCount => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_sampleCount);
-
-        public ulong ArrayLength => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_arrayLength);
-
-        public MTLTextureUsage Usage => (MTLTextureUsage)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_usage);
-
-        public bool Shareable => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isShareable);
-
-        public bool FramebufferOnly => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isFramebufferOnly);
-
-        public ulong FirstMipmapInTail => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_firstMipmapInTail);
-
-        public ulong TailSizeInBytes => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_tailSizeInBytes);
-
-        public bool IsSparse => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isSparse);
-
-        public bool AllowGPUOptimizedContents => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_allowGPUOptimizedContents);
-
-        public MTLTextureCompressionType CompressionType => (MTLTextureCompressionType)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_compressionType);
-
-        public MTLResourceID GpuResourceID => ObjectiveCRuntime.MTLResourceID_objc_msgSend(NativePtr, sel_gpuResourceID);
-
-        public MTLSharedTextureHandle NewSharedTextureHandle => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newSharedTextureHandle));
-
-        public MTLTexture RemoteStorageTexture => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_remoteStorageTexture));
-
-        public MTLTextureSwizzleChannels Swizzle => ObjectiveCRuntime.MTLTextureSwizzleChannels_objc_msgSend(NativePtr, sel_swizzle);
-
-        public NSString Label
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
-        }
-
-        public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
-
-        public MTLCPUCacheMode CpuCacheMode => (MTLCPUCacheMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_cpuCacheMode);
-
-        public MTLStorageMode StorageMode => (MTLStorageMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_storageMode);
-
-        public MTLHazardTrackingMode HazardTrackingMode => (MTLHazardTrackingMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_hazardTrackingMode);
-
-        public MTLResourceOptions ResourceOptions => (MTLResourceOptions)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_resourceOptions);
-
-        public MTLHeap Heap => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_heap));
-
-        public ulong HeapOffset => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_heapOffset);
-
-        public ulong AllocatedSize => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_allocatedSize);
-
-        public bool IsAliasable => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isAliasable);
-
-        public void GetBytes(IntPtr pixelBytes, ulong bytesPerRow, ulong bytesPerImage, MTLRegion region, ulong level, ulong slice)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_getBytesbytesPerRowbytesPerImagefromRegionmipmapLevelslice, pixelBytes, bytesPerRow, bytesPerImage, region, level, slice);
-        }
-
-        public void ReplaceRegion(MTLRegion region, ulong level, ulong slice, IntPtr pixelBytes, ulong bytesPerRow, ulong bytesPerImage)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_replaceRegionmipmapLevelslicewithBytesbytesPerRowbytesPerImage, region, level, slice, pixelBytes, bytesPerRow, bytesPerImage);
-        }
-
-        public void GetBytes(IntPtr pixelBytes, ulong bytesPerRow, MTLRegion region, ulong level)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_getBytesbytesPerRowfromRegionmipmapLevel, pixelBytes, bytesPerRow, region, level);
-        }
-
-        public void ReplaceRegion(MTLRegion region, ulong level, IntPtr pixelBytes, ulong bytesPerRow)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_replaceRegionmipmapLevelwithBytesbytesPerRow, region, level, pixelBytes, bytesPerRow);
-        }
-
-        public MTLTexture NewTextureView(MTLPixelFormat pixelFormat)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newTextureViewWithPixelFormat, (ulong)pixelFormat));
-        }
-
-        public MTLTexture NewTextureView(MTLPixelFormat pixelFormat, MTLTextureType textureType, NSRange levelRange, NSRange sliceRange)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newTextureViewWithPixelFormattextureTypelevelsslices, (ulong)pixelFormat, (ulong)textureType, levelRange, sliceRange));
-        }
-
-        public MTLTexture NewRemoteTextureViewForDevice(MTLDevice device)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newRemoteTextureViewForDevice, device));
-        }
-
-        public MTLTexture NewTextureView(MTLPixelFormat pixelFormat, MTLTextureType textureType, NSRange levelRange, NSRange sliceRange, MTLTextureSwizzleChannels swizzle)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newTextureViewWithPixelFormattextureTypelevelsslicesswizzle, (ulong)pixelFormat, (ulong)textureType, levelRange, sliceRange, swizzle));
-        }
-
-        public MTLPurgeableState SetPurgeableState(MTLPurgeableState state)
-        {
-            return (MTLPurgeableState)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_setPurgeableState, (ulong)state);
-        }
-
-        public void MakeAliasable()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_makeAliasable);
-        }
-
-        private static readonly Selector sel_rootResource = "rootResource";
-        private static readonly Selector sel_parentTexture = "parentTexture";
-        private static readonly Selector sel_parentRelativeLevel = "parentRelativeLevel";
-        private static readonly Selector sel_parentRelativeSlice = "parentRelativeSlice";
-        private static readonly Selector sel_buffer = "buffer";
-        private static readonly Selector sel_bufferOffset = "bufferOffset";
-        private static readonly Selector sel_bufferBytesPerRow = "bufferBytesPerRow";
-        private static readonly Selector sel_iosurface = "iosurface";
-        private static readonly Selector sel_iosurfacePlane = "iosurfacePlane";
-        private static readonly Selector sel_textureType = "textureType";
-        private static readonly Selector sel_pixelFormat = "pixelFormat";
-        private static readonly Selector sel_width = "width";
-        private static readonly Selector sel_height = "height";
-        private static readonly Selector sel_depth = "depth";
-        private static readonly Selector sel_mipmapLevelCount = "mipmapLevelCount";
-        private static readonly Selector sel_sampleCount = "sampleCount";
-        private static readonly Selector sel_arrayLength = "arrayLength";
-        private static readonly Selector sel_usage = "usage";
-        private static readonly Selector sel_isShareable = "isShareable";
-        private static readonly Selector sel_isFramebufferOnly = "isFramebufferOnly";
-        private static readonly Selector sel_firstMipmapInTail = "firstMipmapInTail";
-        private static readonly Selector sel_tailSizeInBytes = "tailSizeInBytes";
-        private static readonly Selector sel_isSparse = "isSparse";
-        private static readonly Selector sel_allowGPUOptimizedContents = "allowGPUOptimizedContents";
-        private static readonly Selector sel_compressionType = "compressionType";
-        private static readonly Selector sel_gpuResourceID = "gpuResourceID";
-        private static readonly Selector sel_getBytesbytesPerRowbytesPerImagefromRegionmipmapLevelslice = "getBytes:bytesPerRow:bytesPerImage:fromRegion:mipmapLevel:slice:";
-        private static readonly Selector sel_replaceRegionmipmapLevelslicewithBytesbytesPerRowbytesPerImage = "replaceRegion:mipmapLevel:slice:withBytes:bytesPerRow:bytesPerImage:";
-        private static readonly Selector sel_getBytesbytesPerRowfromRegionmipmapLevel = "getBytes:bytesPerRow:fromRegion:mipmapLevel:";
-        private static readonly Selector sel_replaceRegionmipmapLevelwithBytesbytesPerRow = "replaceRegion:mipmapLevel:withBytes:bytesPerRow:";
-        private static readonly Selector sel_newTextureViewWithPixelFormat = "newTextureViewWithPixelFormat:";
-        private static readonly Selector sel_newTextureViewWithPixelFormattextureTypelevelsslices = "newTextureViewWithPixelFormat:textureType:levels:slices:";
-        private static readonly Selector sel_newSharedTextureHandle = "newSharedTextureHandle";
-        private static readonly Selector sel_remoteStorageTexture = "remoteStorageTexture";
-        private static readonly Selector sel_newRemoteTextureViewForDevice = "newRemoteTextureViewForDevice:";
-        private static readonly Selector sel_swizzle = "swizzle";
-        private static readonly Selector sel_newTextureViewWithPixelFormattextureTypelevelsslicesswizzle = "newTextureViewWithPixelFormat:textureType:levels:slices:swizzle:";
-        private static readonly Selector sel_label = "label";
-        private static readonly Selector sel_setLabel = "setLabel:";
-        private static readonly Selector sel_device = "device";
-        private static readonly Selector sel_cpuCacheMode = "cpuCacheMode";
+        private static readonly Selector sel_setTextureType = "setTextureType:";
+        private static readonly Selector sel_setUsage = "setUsage:";
+        private static readonly Selector sel_setWidth = "setWidth:";
         private static readonly Selector sel_storageMode = "storageMode";
-        private static readonly Selector sel_hazardTrackingMode = "hazardTrackingMode";
-        private static readonly Selector sel_resourceOptions = "resourceOptions";
-        private static readonly Selector sel_setPurgeableState = "setPurgeableState:";
-        private static readonly Selector sel_heap = "heap";
-        private static readonly Selector sel_heapOffset = "heapOffset";
-        private static readonly Selector sel_allocatedSize = "allocatedSize";
-        private static readonly Selector sel_makeAliasable = "makeAliasable";
-        private static readonly Selector sel_isAliasable = "isAliasable";
+        private static readonly Selector sel_swizzle = "swizzle";
+        private static readonly Selector sel_texture2DDescriptorWithPixelFormatwidthheightmipmapped = "texture2DDescriptorWithPixelFormat:width:height:mipmapped:";
+        private static readonly Selector sel_textureBufferDescriptorWithPixelFormatwidthresourceOptionsusage = "textureBufferDescriptorWithPixelFormat:width:resourceOptions:usage:";
+        private static readonly Selector sel_textureCubeDescriptorWithPixelFormatsizemipmapped = "textureCubeDescriptorWithPixelFormat:size:mipmapped:";
+        private static readonly Selector sel_textureType = "textureType";
+        private static readonly Selector sel_usage = "usage";
+        private static readonly Selector sel_width = "width";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLTypes.cs
+++ b/src/SharpMetal/Metal/MTLTypes.cs
@@ -15,19 +15,17 @@ namespace SharpMetal.Metal
 
     [SupportedOSPlatform("macos")]
     [StructLayout(LayoutKind.Sequential)]
-    public struct MTLSize
-    {
-        public ulong width;
-        public ulong height;
-        public ulong depth;
-    }
-
-    [SupportedOSPlatform("macos")]
-    [StructLayout(LayoutKind.Sequential)]
     public struct MTLRegion
     {
         public MTLOrigin origin;
         public MTLSize size;
+    }
+
+    [SupportedOSPlatform("macos")]
+    [StructLayout(LayoutKind.Sequential)]
+    public struct MTLResourceID
+    {
+        public ulong _impl;
     }
 
     [SupportedOSPlatform("macos")]
@@ -40,8 +38,10 @@ namespace SharpMetal.Metal
 
     [SupportedOSPlatform("macos")]
     [StructLayout(LayoutKind.Sequential)]
-    public struct MTLResourceID
+    public struct MTLSize
     {
-        public ulong _impl;
+        public ulong width;
+        public ulong height;
+        public ulong depth;
     }
 }

--- a/src/SharpMetal/Metal/MTLVertexDescriptor.cs
+++ b/src/SharpMetal/Metal/MTLVertexDescriptor.cs
@@ -74,84 +74,6 @@ namespace SharpMetal.Metal
     }
 
     [SupportedOSPlatform("macos")]
-    public struct MTLVertexBufferLayoutDescriptor : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLVertexBufferLayoutDescriptor obj) => obj.NativePtr;
-        public MTLVertexBufferLayoutDescriptor(IntPtr ptr) => NativePtr = ptr;
-
-        public MTLVertexBufferLayoutDescriptor()
-        {
-            var cls = new ObjectiveCClass("MTLVertexBufferLayoutDescriptor");
-            NativePtr = cls.AllocInit();
-        }
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public ulong Stride
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_stride);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStride, value);
-        }
-
-        public MTLVertexStepFunction StepFunction
-        {
-            get => (MTLVertexStepFunction)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_stepFunction);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStepFunction, (ulong)value);
-        }
-
-        public ulong StepRate
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_stepRate);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStepRate, value);
-        }
-
-        private static readonly Selector sel_stride = "stride";
-        private static readonly Selector sel_setStride = "setStride:";
-        private static readonly Selector sel_stepFunction = "stepFunction";
-        private static readonly Selector sel_setStepFunction = "setStepFunction:";
-        private static readonly Selector sel_stepRate = "stepRate";
-        private static readonly Selector sel_setStepRate = "setStepRate:";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLVertexBufferLayoutDescriptorArray : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLVertexBufferLayoutDescriptorArray obj) => obj.NativePtr;
-        public MTLVertexBufferLayoutDescriptorArray(IntPtr ptr) => NativePtr = ptr;
-
-        public MTLVertexBufferLayoutDescriptorArray()
-        {
-            var cls = new ObjectiveCClass("MTLVertexBufferLayoutDescriptorArray");
-            NativePtr = cls.AllocInit();
-        }
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public MTLVertexBufferLayoutDescriptor Object(ulong index)
-        {
-            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_objectAtIndexedSubscript, index));
-        }
-
-        public void SetObject(MTLVertexBufferLayoutDescriptor bufferDesc, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setObjectatIndexedSubscript, bufferDesc, index);
-        }
-
-        private static readonly Selector sel_objectAtIndexedSubscript = "objectAtIndexedSubscript:";
-        private static readonly Selector sel_setObjectatIndexedSubscript = "setObject:atIndexedSubscript:";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
     public struct MTLVertexAttributeDescriptor : IDisposable
     {
         public IntPtr NativePtr;
@@ -169,6 +91,12 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
+        public ulong BufferIndex
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_bufferIndex);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBufferIndex, value);
+        }
+
         public MTLVertexFormat Format
         {
             get => (MTLVertexFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_format);
@@ -181,18 +109,12 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setOffset, value);
         }
 
-        public ulong BufferIndex
-        {
-            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_bufferIndex);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setBufferIndex, value);
-        }
-
-        private static readonly Selector sel_format = "format";
-        private static readonly Selector sel_setFormat = "setFormat:";
-        private static readonly Selector sel_offset = "offset";
-        private static readonly Selector sel_setOffset = "setOffset:";
         private static readonly Selector sel_bufferIndex = "bufferIndex";
+        private static readonly Selector sel_format = "format";
+        private static readonly Selector sel_offset = "offset";
         private static readonly Selector sel_setBufferIndex = "setBufferIndex:";
+        private static readonly Selector sel_setFormat = "setFormat:";
+        private static readonly Selector sel_setOffset = "setOffset:";
         private static readonly Selector sel_release = "release";
     }
 
@@ -230,6 +152,84 @@ namespace SharpMetal.Metal
     }
 
     [SupportedOSPlatform("macos")]
+    public struct MTLVertexBufferLayoutDescriptor : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLVertexBufferLayoutDescriptor obj) => obj.NativePtr;
+        public MTLVertexBufferLayoutDescriptor(IntPtr ptr) => NativePtr = ptr;
+
+        public MTLVertexBufferLayoutDescriptor()
+        {
+            var cls = new ObjectiveCClass("MTLVertexBufferLayoutDescriptor");
+            NativePtr = cls.AllocInit();
+        }
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public MTLVertexStepFunction StepFunction
+        {
+            get => (MTLVertexStepFunction)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_stepFunction);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStepFunction, (ulong)value);
+        }
+
+        public ulong StepRate
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_stepRate);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStepRate, value);
+        }
+
+        public ulong Stride
+        {
+            get => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_stride);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setStride, value);
+        }
+
+        private static readonly Selector sel_setStepFunction = "setStepFunction:";
+        private static readonly Selector sel_setStepRate = "setStepRate:";
+        private static readonly Selector sel_setStride = "setStride:";
+        private static readonly Selector sel_stepFunction = "stepFunction";
+        private static readonly Selector sel_stepRate = "stepRate";
+        private static readonly Selector sel_stride = "stride";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
+    public struct MTLVertexBufferLayoutDescriptorArray : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLVertexBufferLayoutDescriptorArray obj) => obj.NativePtr;
+        public MTLVertexBufferLayoutDescriptorArray(IntPtr ptr) => NativePtr = ptr;
+
+        public MTLVertexBufferLayoutDescriptorArray()
+        {
+            var cls = new ObjectiveCClass("MTLVertexBufferLayoutDescriptorArray");
+            NativePtr = cls.AllocInit();
+        }
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public MTLVertexBufferLayoutDescriptor Object(ulong index)
+        {
+            return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_objectAtIndexedSubscript, index));
+        }
+
+        public void SetObject(MTLVertexBufferLayoutDescriptor bufferDesc, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setObjectatIndexedSubscript, bufferDesc, index);
+        }
+
+        private static readonly Selector sel_objectAtIndexedSubscript = "objectAtIndexedSubscript:";
+        private static readonly Selector sel_setObjectatIndexedSubscript = "setObject:atIndexedSubscript:";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
     public struct MTLVertexDescriptor : IDisposable
     {
         public IntPtr NativePtr;
@@ -247,19 +247,19 @@ namespace SharpMetal.Metal
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public MTLVertexBufferLayoutDescriptorArray Layouts => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_layouts));
-
         public MTLVertexAttributeDescriptorArray Attributes => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_attributes));
+
+        public MTLVertexBufferLayoutDescriptorArray Layouts => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_layouts));
 
         public void Reset()
         {
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_reset);
         }
 
-        private static readonly Selector sel_vertexDescriptor = "vertexDescriptor";
-        private static readonly Selector sel_layouts = "layouts";
         private static readonly Selector sel_attributes = "attributes";
+        private static readonly Selector sel_layouts = "layouts";
         private static readonly Selector sel_reset = "reset";
+        private static readonly Selector sel_vertexDescriptor = "vertexDescriptor";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/Metal/MTLVisibleFunctionTable.cs
+++ b/src/SharpMetal/Metal/MTLVisibleFunctionTable.cs
@@ -5,6 +5,84 @@ using SharpMetal.Foundation;
 namespace SharpMetal.Metal
 {
     [SupportedOSPlatform("macos")]
+    public struct MTLVisibleFunctionTable : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLVisibleFunctionTable obj) => obj.NativePtr;
+        public static implicit operator MTLResource(MTLVisibleFunctionTable obj) => new(obj.NativePtr);
+        public MTLVisibleFunctionTable(IntPtr ptr) => NativePtr = ptr;
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public ulong AllocatedSize => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_allocatedSize);
+
+        public MTLCPUCacheMode CpuCacheMode => (MTLCPUCacheMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_cpuCacheMode);
+
+        public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
+
+        public MTLResourceID GpuResourceID => ObjectiveCRuntime.MTLResourceID_objc_msgSend(NativePtr, sel_gpuResourceID);
+
+        public MTLHazardTrackingMode HazardTrackingMode => (MTLHazardTrackingMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_hazardTrackingMode);
+
+        public MTLHeap Heap => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_heap));
+
+        public ulong HeapOffset => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_heapOffset);
+
+        public bool IsAliasable => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isAliasable);
+
+        public NSString Label
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
+        }
+
+        public MTLResourceOptions ResourceOptions => (MTLResourceOptions)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_resourceOptions);
+
+        public MTLStorageMode StorageMode => (MTLStorageMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_storageMode);
+
+        public void MakeAliasable()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_makeAliasable);
+        }
+
+        public void SetFunction(MTLFunctionHandle function, ulong index)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFunctionatIndex, function, index);
+        }
+
+        public void SetFunctions(MTLFunctionHandle[] functions, NSRange range)
+        {
+            throw new NotImplementedException();
+        }
+
+        public MTLPurgeableState SetPurgeableState(MTLPurgeableState state)
+        {
+            return (MTLPurgeableState)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_setPurgeableState, (ulong)state);
+        }
+
+        private static readonly Selector sel_allocatedSize = "allocatedSize";
+        private static readonly Selector sel_cpuCacheMode = "cpuCacheMode";
+        private static readonly Selector sel_device = "device";
+        private static readonly Selector sel_gpuResourceID = "gpuResourceID";
+        private static readonly Selector sel_hazardTrackingMode = "hazardTrackingMode";
+        private static readonly Selector sel_heap = "heap";
+        private static readonly Selector sel_heapOffset = "heapOffset";
+        private static readonly Selector sel_isAliasable = "isAliasable";
+        private static readonly Selector sel_label = "label";
+        private static readonly Selector sel_makeAliasable = "makeAliasable";
+        private static readonly Selector sel_resourceOptions = "resourceOptions";
+        private static readonly Selector sel_setFunctionatIndex = "setFunction:atIndex:";
+        private static readonly Selector sel_setFunctionswithRange = "setFunctions:withRange:";
+        private static readonly Selector sel_setLabel = "setLabel:";
+        private static readonly Selector sel_setPurgeableState = "setPurgeableState:";
+        private static readonly Selector sel_storageMode = "storageMode";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
     public struct MTLVisibleFunctionTableDescriptor : IDisposable
     {
         public IntPtr NativePtr;
@@ -28,87 +106,9 @@ namespace SharpMetal.Metal
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFunctionCount, value);
         }
 
-        private static readonly Selector sel_visibleFunctionTableDescriptor = "visibleFunctionTableDescriptor";
         private static readonly Selector sel_functionCount = "functionCount";
         private static readonly Selector sel_setFunctionCount = "setFunctionCount:";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLVisibleFunctionTable : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLVisibleFunctionTable obj) => obj.NativePtr;
-        public static implicit operator MTLResource(MTLVisibleFunctionTable obj) => new(obj.NativePtr);
-        public MTLVisibleFunctionTable(IntPtr ptr) => NativePtr = ptr;
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public MTLResourceID GpuResourceID => ObjectiveCRuntime.MTLResourceID_objc_msgSend(NativePtr, sel_gpuResourceID);
-
-        public NSString Label
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_label));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setLabel, value);
-        }
-
-        public MTLDevice Device => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_device));
-
-        public MTLCPUCacheMode CpuCacheMode => (MTLCPUCacheMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_cpuCacheMode);
-
-        public MTLStorageMode StorageMode => (MTLStorageMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_storageMode);
-
-        public MTLHazardTrackingMode HazardTrackingMode => (MTLHazardTrackingMode)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_hazardTrackingMode);
-
-        public MTLResourceOptions ResourceOptions => (MTLResourceOptions)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_resourceOptions);
-
-        public MTLHeap Heap => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_heap));
-
-        public ulong HeapOffset => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_heapOffset);
-
-        public ulong AllocatedSize => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_allocatedSize);
-
-        public bool IsAliasable => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isAliasable);
-
-        public void SetFunction(MTLFunctionHandle function, ulong index)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFunctionatIndex, function, index);
-        }
-
-        public void SetFunctions(MTLFunctionHandle[] functions, NSRange range)
-        {
-            throw new NotImplementedException();
-        }
-
-        public MTLPurgeableState SetPurgeableState(MTLPurgeableState state)
-        {
-            return (MTLPurgeableState)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_setPurgeableState, (ulong)state);
-        }
-
-        public void MakeAliasable()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_makeAliasable);
-        }
-
-        private static readonly Selector sel_gpuResourceID = "gpuResourceID";
-        private static readonly Selector sel_setFunctionatIndex = "setFunction:atIndex:";
-        private static readonly Selector sel_setFunctionswithRange = "setFunctions:withRange:";
-        private static readonly Selector sel_label = "label";
-        private static readonly Selector sel_setLabel = "setLabel:";
-        private static readonly Selector sel_device = "device";
-        private static readonly Selector sel_cpuCacheMode = "cpuCacheMode";
-        private static readonly Selector sel_storageMode = "storageMode";
-        private static readonly Selector sel_hazardTrackingMode = "hazardTrackingMode";
-        private static readonly Selector sel_resourceOptions = "resourceOptions";
-        private static readonly Selector sel_setPurgeableState = "setPurgeableState:";
-        private static readonly Selector sel_heap = "heap";
-        private static readonly Selector sel_heapOffset = "heapOffset";
-        private static readonly Selector sel_allocatedSize = "allocatedSize";
-        private static readonly Selector sel_makeAliasable = "makeAliasable";
-        private static readonly Selector sel_isAliasable = "isAliasable";
+        private static readonly Selector sel_visibleFunctionTableDescriptor = "visibleFunctionTableDescriptor";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/MetalFX/MTLFXSpatialScaler.cs
+++ b/src/SharpMetal/MetalFX/MTLFXSpatialScaler.cs
@@ -13,6 +13,63 @@ namespace SharpMetal.MetalFX
     }
 
     [SupportedOSPlatform("macos")]
+    public struct MTLFXSpatialScaler : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLFXSpatialScaler obj) => obj.NativePtr;
+        public MTLFXSpatialScaler(IntPtr ptr) => NativePtr = ptr;
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public MTLFXSpatialScalerColorProcessingMode ColorProcessingMode => (MTLFXSpatialScalerColorProcessingMode)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_colorProcessingMode);
+
+        public MTLTexture ColorTexture => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_colorTexture));
+
+        public MTLPixelFormat ColorTextureFormat => (MTLPixelFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_colorTextureFormat);
+
+        public MTLTextureUsage ColorTextureUsage => (MTLTextureUsage)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_colorTextureUsage);
+
+        public MTLFence Fence => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_fence));
+
+        public ulong InputContentHeight => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_inputContentHeight);
+
+        public ulong InputContentWidth => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_inputContentWidth);
+
+        public ulong InputHeight => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_inputHeight);
+
+        public ulong InputWidth => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_inputWidth);
+
+        public ulong OutputHeight => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_outputHeight);
+
+        public MTLTexture OutputTexture => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_outputTexture));
+
+        public MTLPixelFormat OutputTextureFormat => (MTLPixelFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_outputTextureFormat);
+
+        public MTLTextureUsage OutputTextureUsage => (MTLTextureUsage)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_outputTextureUsage);
+
+        public ulong OutputWidth => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_outputWidth);
+
+        private static readonly Selector sel_colorProcessingMode = "colorProcessingMode";
+        private static readonly Selector sel_colorTexture = "colorTexture";
+        private static readonly Selector sel_colorTextureFormat = "colorTextureFormat";
+        private static readonly Selector sel_colorTextureUsage = "colorTextureUsage";
+        private static readonly Selector sel_fence = "fence";
+        private static readonly Selector sel_inputContentHeight = "inputContentHeight";
+        private static readonly Selector sel_inputContentWidth = "inputContentWidth";
+        private static readonly Selector sel_inputHeight = "inputHeight";
+        private static readonly Selector sel_inputWidth = "inputWidth";
+        private static readonly Selector sel_outputHeight = "outputHeight";
+        private static readonly Selector sel_outputTexture = "outputTexture";
+        private static readonly Selector sel_outputTextureFormat = "outputTextureFormat";
+        private static readonly Selector sel_outputTextureUsage = "outputTextureUsage";
+        private static readonly Selector sel_outputWidth = "outputWidth";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
     public struct MTLFXSpatialScalerDescriptor : IDisposable
     {
         public IntPtr NativePtr;
@@ -30,91 +87,34 @@ namespace SharpMetal.MetalFX
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
+        public MTLFXSpatialScalerColorProcessingMode ColorProcessingMode => (MTLFXSpatialScalerColorProcessingMode)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_colorProcessingMode);
+
         public MTLPixelFormat ColorTextureFormat => (MTLPixelFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_colorTextureFormat);
-
-        public MTLPixelFormat OutputTextureFormat => (MTLPixelFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_outputTextureFormat);
-
-        public ulong InputWidth => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_inputWidth);
 
         public ulong InputHeight => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_inputHeight);
 
-        public ulong OutputWidth => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_outputWidth);
+        public ulong InputWidth => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_inputWidth);
 
         public ulong OutputHeight => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_outputHeight);
 
-        public MTLFXSpatialScalerColorProcessingMode ColorProcessingMode => (MTLFXSpatialScalerColorProcessingMode)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_colorProcessingMode);
+        public MTLPixelFormat OutputTextureFormat => (MTLPixelFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_outputTextureFormat);
+
+        public ulong OutputWidth => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_outputWidth);
 
         public MTLFXSpatialScaler NewSpatialScaler(MTLDevice pDevice)
         {
             return new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_newSpatialScalerWithDevice, pDevice));
         }
 
-        private static readonly Selector sel_colorTextureFormat = "colorTextureFormat";
-        private static readonly Selector sel_outputTextureFormat = "outputTextureFormat";
-        private static readonly Selector sel_inputWidth = "inputWidth";
-        private static readonly Selector sel_inputHeight = "inputHeight";
-        private static readonly Selector sel_outputWidth = "outputWidth";
-        private static readonly Selector sel_outputHeight = "outputHeight";
         private static readonly Selector sel_colorProcessingMode = "colorProcessingMode";
+        private static readonly Selector sel_colorTextureFormat = "colorTextureFormat";
+        private static readonly Selector sel_inputHeight = "inputHeight";
+        private static readonly Selector sel_inputWidth = "inputWidth";
         private static readonly Selector sel_newSpatialScalerWithDevice = "newSpatialScalerWithDevice:";
-        private static readonly Selector sel_supportsDevice = "supportsDevice:";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLFXSpatialScaler : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLFXSpatialScaler obj) => obj.NativePtr;
-        public MTLFXSpatialScaler(IntPtr ptr) => NativePtr = ptr;
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public MTLTextureUsage ColorTextureUsage => (MTLTextureUsage)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_colorTextureUsage);
-
-        public MTLTextureUsage OutputTextureUsage => (MTLTextureUsage)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_outputTextureUsage);
-
-        public ulong InputContentWidth => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_inputContentWidth);
-
-        public ulong InputContentHeight => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_inputContentHeight);
-
-        public MTLTexture ColorTexture => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_colorTexture));
-
-        public MTLTexture OutputTexture => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_outputTexture));
-
-        public MTLPixelFormat ColorTextureFormat => (MTLPixelFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_colorTextureFormat);
-
-        public MTLPixelFormat OutputTextureFormat => (MTLPixelFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_outputTextureFormat);
-
-        public ulong InputWidth => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_inputWidth);
-
-        public ulong InputHeight => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_inputHeight);
-
-        public ulong OutputWidth => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_outputWidth);
-
-        public ulong OutputHeight => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_outputHeight);
-
-        public MTLFXSpatialScalerColorProcessingMode ColorProcessingMode => (MTLFXSpatialScalerColorProcessingMode)ObjectiveCRuntime.long_objc_msgSend(NativePtr, sel_colorProcessingMode);
-
-        public MTLFence Fence => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_fence));
-
-        private static readonly Selector sel_colorTextureUsage = "colorTextureUsage";
-        private static readonly Selector sel_outputTextureUsage = "outputTextureUsage";
-        private static readonly Selector sel_inputContentWidth = "inputContentWidth";
-        private static readonly Selector sel_inputContentHeight = "inputContentHeight";
-        private static readonly Selector sel_colorTexture = "colorTexture";
-        private static readonly Selector sel_outputTexture = "outputTexture";
-        private static readonly Selector sel_colorTextureFormat = "colorTextureFormat";
-        private static readonly Selector sel_outputTextureFormat = "outputTextureFormat";
-        private static readonly Selector sel_inputWidth = "inputWidth";
-        private static readonly Selector sel_inputHeight = "inputHeight";
-        private static readonly Selector sel_outputWidth = "outputWidth";
         private static readonly Selector sel_outputHeight = "outputHeight";
-        private static readonly Selector sel_colorProcessingMode = "colorProcessingMode";
-        private static readonly Selector sel_fence = "fence";
+        private static readonly Selector sel_outputTextureFormat = "outputTextureFormat";
+        private static readonly Selector sel_outputWidth = "outputWidth";
+        private static readonly Selector sel_supportsDevice = "supportsDevice:";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/MetalFX/MTLFXTemporalScaler.cs
+++ b/src/SharpMetal/MetalFX/MTLFXTemporalScaler.cs
@@ -5,6 +5,108 @@ using SharpMetal.Metal;
 namespace SharpMetal.MetalFX
 {
     [SupportedOSPlatform("macos")]
+    public struct MTLFXTemporalScaler : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(MTLFXTemporalScaler obj) => obj.NativePtr;
+        public MTLFXTemporalScaler(IntPtr ptr) => NativePtr = ptr;
+
+        public void Dispose()
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
+        }
+
+        public MTLTexture ColorTexture => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_colorTexture));
+
+        public MTLPixelFormat ColorTextureFormat => (MTLPixelFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_colorTextureFormat);
+
+        public MTLTextureUsage ColorTextureUsage => (MTLTextureUsage)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_colorTextureUsage);
+
+        public MTLTexture DepthTexture => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_depthTexture));
+
+        public MTLPixelFormat DepthTextureFormat => (MTLPixelFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_depthTextureFormat);
+
+        public MTLTextureUsage DepthTextureUsage => (MTLTextureUsage)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_depthTextureUsage);
+
+        public MTLTexture ExposureTexture => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_exposureTexture));
+
+        public MTLFence Fence => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_fence));
+
+        public ulong InputContentHeight => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_inputContentHeight);
+
+        public float InputContentMaxScale => ObjectiveCRuntime.float_objc_msgSend(NativePtr, sel_inputContentMaxScale);
+
+        public float InputContentMinScale => ObjectiveCRuntime.float_objc_msgSend(NativePtr, sel_inputContentMinScale);
+
+        public ulong InputContentWidth => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_inputContentWidth);
+
+        public ulong InputHeight => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_inputHeight);
+
+        public ulong InputWidth => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_inputWidth);
+
+        public bool IsDepthReversed => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isDepthReversed);
+
+        public float JitterOffsetX => ObjectiveCRuntime.float_objc_msgSend(NativePtr, sel_jitterOffsetX);
+
+        public float JitterOffsetY => ObjectiveCRuntime.float_objc_msgSend(NativePtr, sel_jitterOffsetY);
+
+        public MTLTexture MotionTexture => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_motionTexture));
+
+        public MTLPixelFormat MotionTextureFormat => (MTLPixelFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_motionTextureFormat);
+
+        public MTLTextureUsage MotionTextureUsage => (MTLTextureUsage)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_motionTextureUsage);
+
+        public float MotionVectorScaleX => ObjectiveCRuntime.float_objc_msgSend(NativePtr, sel_motionVectorScaleX);
+
+        public float MotionVectorScaleY => ObjectiveCRuntime.float_objc_msgSend(NativePtr, sel_motionVectorScaleY);
+
+        public ulong OutputHeight => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_outputHeight);
+
+        public MTLTexture OutputTexture => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_outputTexture));
+
+        public MTLPixelFormat OutputTextureFormat => (MTLPixelFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_outputTextureFormat);
+
+        public MTLTextureUsage OutputTextureUsage => (MTLTextureUsage)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_outputTextureUsage);
+
+        public ulong OutputWidth => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_outputWidth);
+
+        public float PreExposure => ObjectiveCRuntime.float_objc_msgSend(NativePtr, sel_preExposure);
+
+        public bool Reset => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_reset);
+
+        private static readonly Selector sel_colorTexture = "colorTexture";
+        private static readonly Selector sel_colorTextureFormat = "colorTextureFormat";
+        private static readonly Selector sel_colorTextureUsage = "colorTextureUsage";
+        private static readonly Selector sel_depthTexture = "depthTexture";
+        private static readonly Selector sel_depthTextureFormat = "depthTextureFormat";
+        private static readonly Selector sel_depthTextureUsage = "depthTextureUsage";
+        private static readonly Selector sel_exposureTexture = "exposureTexture";
+        private static readonly Selector sel_fence = "fence";
+        private static readonly Selector sel_inputContentHeight = "inputContentHeight";
+        private static readonly Selector sel_inputContentMaxScale = "inputContentMaxScale";
+        private static readonly Selector sel_inputContentMinScale = "inputContentMinScale";
+        private static readonly Selector sel_inputContentWidth = "inputContentWidth";
+        private static readonly Selector sel_inputHeight = "inputHeight";
+        private static readonly Selector sel_inputWidth = "inputWidth";
+        private static readonly Selector sel_isDepthReversed = "isDepthReversed";
+        private static readonly Selector sel_jitterOffsetX = "jitterOffsetX";
+        private static readonly Selector sel_jitterOffsetY = "jitterOffsetY";
+        private static readonly Selector sel_motionTexture = "motionTexture";
+        private static readonly Selector sel_motionTextureFormat = "motionTextureFormat";
+        private static readonly Selector sel_motionTextureUsage = "motionTextureUsage";
+        private static readonly Selector sel_motionVectorScaleX = "motionVectorScaleX";
+        private static readonly Selector sel_motionVectorScaleY = "motionVectorScaleY";
+        private static readonly Selector sel_outputHeight = "outputHeight";
+        private static readonly Selector sel_outputTexture = "outputTexture";
+        private static readonly Selector sel_outputTextureFormat = "outputTextureFormat";
+        private static readonly Selector sel_outputTextureUsage = "outputTextureUsage";
+        private static readonly Selector sel_outputWidth = "outputWidth";
+        private static readonly Selector sel_preExposure = "preExposure";
+        private static readonly Selector sel_reset = "reset";
+        private static readonly Selector sel_release = "release";
+    }
+
+    [SupportedOSPlatform("macos")]
     public struct MTLFXTemporalScalerDescriptor : IDisposable
     {
         public IntPtr NativePtr;
@@ -26,25 +128,25 @@ namespace SharpMetal.MetalFX
 
         public MTLPixelFormat DepthTextureFormat => (MTLPixelFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_depthTextureFormat);
 
-        public MTLPixelFormat MotionTextureFormat => (MTLPixelFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_motionTextureFormat);
+        public float InputContentMaxScale => ObjectiveCRuntime.float_objc_msgSend(NativePtr, sel_inputContentMaxScale);
 
-        public MTLPixelFormat OutputTextureFormat => (MTLPixelFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_outputTextureFormat);
-
-        public ulong InputWidth => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_inputWidth);
+        public float InputContentMinScale => ObjectiveCRuntime.float_objc_msgSend(NativePtr, sel_inputContentMinScale);
 
         public ulong InputHeight => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_inputHeight);
 
-        public ulong OutputWidth => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_outputWidth);
-
-        public ulong OutputHeight => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_outputHeight);
+        public ulong InputWidth => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_inputWidth);
 
         public bool IsAutoExposureEnabled => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isAutoExposureEnabled);
 
         public bool IsInputContentPropertiesEnabled => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isInputContentPropertiesEnabled);
 
-        public float InputContentMinScale => ObjectiveCRuntime.float_objc_msgSend(NativePtr, sel_inputContentMinScale);
+        public MTLPixelFormat MotionTextureFormat => (MTLPixelFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_motionTextureFormat);
 
-        public float InputContentMaxScale => ObjectiveCRuntime.float_objc_msgSend(NativePtr, sel_inputContentMaxScale);
+        public ulong OutputHeight => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_outputHeight);
+
+        public MTLPixelFormat OutputTextureFormat => (MTLPixelFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_outputTextureFormat);
+
+        public ulong OutputWidth => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_outputWidth);
 
         public MTLFXTemporalScaler NewTemporalScaler(MTLDevice pDevice)
         {
@@ -58,120 +160,18 @@ namespace SharpMetal.MetalFX
 
         private static readonly Selector sel_colorTextureFormat = "colorTextureFormat";
         private static readonly Selector sel_depthTextureFormat = "depthTextureFormat";
-        private static readonly Selector sel_motionTextureFormat = "motionTextureFormat";
-        private static readonly Selector sel_outputTextureFormat = "outputTextureFormat";
-        private static readonly Selector sel_inputWidth = "inputWidth";
+        private static readonly Selector sel_inputContentMaxScale = "inputContentMaxScale";
+        private static readonly Selector sel_inputContentMinScale = "inputContentMinScale";
         private static readonly Selector sel_inputHeight = "inputHeight";
-        private static readonly Selector sel_outputWidth = "outputWidth";
-        private static readonly Selector sel_outputHeight = "outputHeight";
+        private static readonly Selector sel_inputWidth = "inputWidth";
         private static readonly Selector sel_isAutoExposureEnabled = "isAutoExposureEnabled";
         private static readonly Selector sel_isInputContentPropertiesEnabled = "isInputContentPropertiesEnabled";
-        private static readonly Selector sel_inputContentMinScale = "inputContentMinScale";
-        private static readonly Selector sel_inputContentMaxScale = "inputContentMaxScale";
-        private static readonly Selector sel_newTemporalScalerWithDevice = "newTemporalScalerWithDevice:";
-        private static readonly Selector sel_supportsDevice = "supportsDevice:";
-        private static readonly Selector sel_release = "release";
-    }
-
-    [SupportedOSPlatform("macos")]
-    public struct MTLFXTemporalScaler : IDisposable
-    {
-        public IntPtr NativePtr;
-        public static implicit operator IntPtr(MTLFXTemporalScaler obj) => obj.NativePtr;
-        public MTLFXTemporalScaler(IntPtr ptr) => NativePtr = ptr;
-
-        public void Dispose()
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
-        }
-
-        public MTLTextureUsage ColorTextureUsage => (MTLTextureUsage)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_colorTextureUsage);
-
-        public MTLTextureUsage DepthTextureUsage => (MTLTextureUsage)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_depthTextureUsage);
-
-        public MTLTextureUsage MotionTextureUsage => (MTLTextureUsage)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_motionTextureUsage);
-
-        public MTLTextureUsage OutputTextureUsage => (MTLTextureUsage)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_outputTextureUsage);
-
-        public ulong InputContentWidth => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_inputContentWidth);
-
-        public ulong InputContentHeight => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_inputContentHeight);
-
-        public MTLTexture ColorTexture => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_colorTexture));
-
-        public MTLTexture DepthTexture => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_depthTexture));
-
-        public MTLTexture MotionTexture => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_motionTexture));
-
-        public MTLTexture OutputTexture => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_outputTexture));
-
-        public MTLTexture ExposureTexture => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_exposureTexture));
-
-        public float PreExposure => ObjectiveCRuntime.float_objc_msgSend(NativePtr, sel_preExposure);
-
-        public float JitterOffsetX => ObjectiveCRuntime.float_objc_msgSend(NativePtr, sel_jitterOffsetX);
-
-        public float JitterOffsetY => ObjectiveCRuntime.float_objc_msgSend(NativePtr, sel_jitterOffsetY);
-
-        public float MotionVectorScaleX => ObjectiveCRuntime.float_objc_msgSend(NativePtr, sel_motionVectorScaleX);
-
-        public float MotionVectorScaleY => ObjectiveCRuntime.float_objc_msgSend(NativePtr, sel_motionVectorScaleY);
-
-        public bool Reset => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_reset);
-
-        public bool IsDepthReversed => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_isDepthReversed);
-
-        public MTLPixelFormat ColorTextureFormat => (MTLPixelFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_colorTextureFormat);
-
-        public MTLPixelFormat DepthTextureFormat => (MTLPixelFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_depthTextureFormat);
-
-        public MTLPixelFormat MotionTextureFormat => (MTLPixelFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_motionTextureFormat);
-
-        public MTLPixelFormat OutputTextureFormat => (MTLPixelFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_outputTextureFormat);
-
-        public ulong InputWidth => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_inputWidth);
-
-        public ulong InputHeight => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_inputHeight);
-
-        public ulong OutputWidth => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_outputWidth);
-
-        public ulong OutputHeight => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_outputHeight);
-
-        public float InputContentMinScale => ObjectiveCRuntime.float_objc_msgSend(NativePtr, sel_inputContentMinScale);
-
-        public float InputContentMaxScale => ObjectiveCRuntime.float_objc_msgSend(NativePtr, sel_inputContentMaxScale);
-
-        public MTLFence Fence => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_fence));
-
-        private static readonly Selector sel_colorTextureUsage = "colorTextureUsage";
-        private static readonly Selector sel_depthTextureUsage = "depthTextureUsage";
-        private static readonly Selector sel_motionTextureUsage = "motionTextureUsage";
-        private static readonly Selector sel_outputTextureUsage = "outputTextureUsage";
-        private static readonly Selector sel_inputContentWidth = "inputContentWidth";
-        private static readonly Selector sel_inputContentHeight = "inputContentHeight";
-        private static readonly Selector sel_colorTexture = "colorTexture";
-        private static readonly Selector sel_depthTexture = "depthTexture";
-        private static readonly Selector sel_motionTexture = "motionTexture";
-        private static readonly Selector sel_outputTexture = "outputTexture";
-        private static readonly Selector sel_exposureTexture = "exposureTexture";
-        private static readonly Selector sel_preExposure = "preExposure";
-        private static readonly Selector sel_jitterOffsetX = "jitterOffsetX";
-        private static readonly Selector sel_jitterOffsetY = "jitterOffsetY";
-        private static readonly Selector sel_motionVectorScaleX = "motionVectorScaleX";
-        private static readonly Selector sel_motionVectorScaleY = "motionVectorScaleY";
-        private static readonly Selector sel_reset = "reset";
-        private static readonly Selector sel_isDepthReversed = "isDepthReversed";
-        private static readonly Selector sel_colorTextureFormat = "colorTextureFormat";
-        private static readonly Selector sel_depthTextureFormat = "depthTextureFormat";
         private static readonly Selector sel_motionTextureFormat = "motionTextureFormat";
-        private static readonly Selector sel_outputTextureFormat = "outputTextureFormat";
-        private static readonly Selector sel_inputWidth = "inputWidth";
-        private static readonly Selector sel_inputHeight = "inputHeight";
-        private static readonly Selector sel_outputWidth = "outputWidth";
+        private static readonly Selector sel_newTemporalScalerWithDevice = "newTemporalScalerWithDevice:";
         private static readonly Selector sel_outputHeight = "outputHeight";
-        private static readonly Selector sel_inputContentMinScale = "inputContentMinScale";
-        private static readonly Selector sel_inputContentMaxScale = "inputContentMaxScale";
-        private static readonly Selector sel_fence = "fence";
+        private static readonly Selector sel_outputTextureFormat = "outputTextureFormat";
+        private static readonly Selector sel_outputWidth = "outputWidth";
+        private static readonly Selector sel_supportsDevice = "supportsDevice:";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/ObjectiveCRuntime.cs
+++ b/src/SharpMetal/ObjectiveCRuntime.cs
@@ -10,175 +10,8 @@ namespace SharpMetal
     public static partial class ObjectiveCRuntime
     {
         [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b, ulong c);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, long b, ref IntPtr c);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, IntPtr c, ref IntPtr d);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, IntPtr b, ref IntPtr c);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, IntPtr b, ulong c);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, ulong c);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, IntPtr b, IntPtr c);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b, NSRange c, NSRange d);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b, ulong c, ulong d);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b, [MarshalAs(UnmanagedType.Bool)] bool c);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b, ulong c, [MarshalAs(UnmanagedType.Bool)] bool d);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, MTLSize a, IntPtr b);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b, NSRange c, NSRange d, MTLTextureSwizzleChannels e);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, MTLSize a, float b, float c);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, IntPtr b, IntPtr c, IntPtr d);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, NSRange a);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, [MarshalAs(UnmanagedType.Bool)] bool a);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, double a);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, float a);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, long a);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, uint a);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, int a);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, IntPtr b);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, short a);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, ushort a);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ushort b);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, long b, IntPtr c);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, IntPtr b);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, ulong c, [MarshalAs(UnmanagedType.Bool)] bool d);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, ushort a, ulong b);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, byte a);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, MTLSize a);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, MTLSize a, ulong b, IntPtr c);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, ulong a);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ref IntPtr b);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial MTLAccelerationStructureSizes MTLAccelerationStructureSizes_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial MTLClearColor MTLClearColor_objc_msgSend(IntPtr receiver, IntPtr selector);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial MTLResourceID MTLResourceID_objc_msgSend(IntPtr receiver, IntPtr selector);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial MTLSize MTLSize_objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b, ulong c);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial MTLSize MTLSize_objc_msgSend(IntPtr receiver, IntPtr selector, ulong a);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial MTLSize MTLSize_objc_msgSend(IntPtr receiver, IntPtr selector);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial MTLSize MTLSize_objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b, ulong c, long d);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial MTLSizeAndAlign MTLSizeAndAlign_objc_msgSend(IntPtr receiver, IntPtr selector);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial MTLSizeAndAlign MTLSizeAndAlign_objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial MTLSizeAndAlign MTLSizeAndAlign_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial MTLSizeAndAlign MTLSizeAndAlign_objc_msgSend(IntPtr receiver, IntPtr selector, ulong a);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial MTLTextureSwizzleChannels MTLTextureSwizzleChannels_objc_msgSend(IntPtr receiver, IntPtr selector);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial NSOperatingSystemVersion NSOperatingSystemVersion_objc_msgSend(IntPtr receiver, IntPtr selector);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial NSRange NSRange_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        public static partial bool bool_objc_msgSend(IntPtr receiver, IntPtr selector, ulong a);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool bool_objc_msgSend(IntPtr receiver, IntPtr selector);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        public static partial bool bool_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, IntPtr b, ref IntPtr c);
 
         [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
         [return: MarshalAs(UnmanagedType.Bool)]
@@ -186,7 +19,7 @@ namespace SharpMetal
 
         [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        public static partial bool bool_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ref IntPtr b);
+        public static partial bool bool_objc_msgSend(IntPtr receiver, IntPtr selector, long a);
 
         [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
         [return: MarshalAs(UnmanagedType.Bool)]
@@ -198,7 +31,15 @@ namespace SharpMetal
 
         [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        public static partial bool bool_objc_msgSend(IntPtr receiver, IntPtr selector, long a);
+        public static partial bool bool_objc_msgSend(IntPtr receiver, IntPtr selector, ulong a);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static partial bool bool_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ref IntPtr b);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static partial bool bool_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, IntPtr b, ref IntPtr c);
 
         [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
         public static partial byte byte_objc_msgSend(IntPtr receiver, IntPtr selector);
@@ -216,10 +57,169 @@ namespace SharpMetal
         public static partial int int_objc_msgSend(IntPtr receiver, IntPtr selector);
 
         [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial long long_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a);
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, [MarshalAs(UnmanagedType.Bool)] bool a);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, byte a);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, double a);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, float a);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, int a);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, long a);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, MTLSize a);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, NSRange a);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, short a);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, uint a);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, ulong a);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, ushort a);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, IntPtr b);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ref IntPtr b);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ushort b);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, MTLSize a, IntPtr b);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, IntPtr b);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, ushort a, ulong b);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, IntPtr b, IntPtr c);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, IntPtr b, ref IntPtr c);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, IntPtr b, ulong c);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, long b, IntPtr c);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, long b, ref IntPtr c);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, ulong c);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, MTLSize a, float b, float c);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, MTLSize a, ulong b, IntPtr c);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b, [MarshalAs(UnmanagedType.Bool)] bool c);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b, ulong c);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, IntPtr b, IntPtr c, IntPtr d);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, IntPtr c, ref IntPtr d);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, ulong c, [MarshalAs(UnmanagedType.Bool)] bool d);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b, NSRange c, NSRange d);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b, ulong c, [MarshalAs(UnmanagedType.Bool)] bool d);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b, ulong c, ulong d);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b, NSRange c, NSRange d, MTLTextureSwizzleChannels e);
 
         [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
         public static partial long long_objc_msgSend(IntPtr receiver, IntPtr selector);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial long long_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial MTLAccelerationStructureSizes MTLAccelerationStructureSizes_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial MTLClearColor MTLClearColor_objc_msgSend(IntPtr receiver, IntPtr selector);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial MTLResourceID MTLResourceID_objc_msgSend(IntPtr receiver, IntPtr selector);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial MTLSize MTLSize_objc_msgSend(IntPtr receiver, IntPtr selector);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial MTLSize MTLSize_objc_msgSend(IntPtr receiver, IntPtr selector, ulong a);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial MTLSize MTLSize_objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b, ulong c);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial MTLSize MTLSize_objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b, ulong c, long d);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial MTLSizeAndAlign MTLSizeAndAlign_objc_msgSend(IntPtr receiver, IntPtr selector);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial MTLSizeAndAlign MTLSizeAndAlign_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial MTLSizeAndAlign MTLSizeAndAlign_objc_msgSend(IntPtr receiver, IntPtr selector, ulong a);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial MTLSizeAndAlign MTLSizeAndAlign_objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial MTLTextureSwizzleChannels MTLTextureSwizzleChannels_objc_msgSend(IntPtr receiver, IntPtr selector);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial NSOperatingSystemVersion NSOperatingSystemVersion_objc_msgSend(IntPtr receiver, IntPtr selector);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial NSRange NSRange_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b);
 
         [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
         public static partial short short_objc_msgSend(IntPtr receiver, IntPtr selector);
@@ -228,22 +228,22 @@ namespace SharpMetal
         public static partial uint uint_objc_msgSend(IntPtr receiver, IntPtr selector);
 
         [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial ulong ulong_objc_msgSend(IntPtr receiver, IntPtr selector, NSFastEnumerationState a, IntPtr b, ulong c);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial ulong ulong_objc_msgSend(IntPtr receiver, IntPtr selector, ulong a);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
         public static partial ulong ulong_objc_msgSend(IntPtr receiver, IntPtr selector);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial ulong ulong_objc_msgSend(IntPtr receiver, IntPtr selector, long a);
 
         [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
         public static partial ulong ulong_objc_msgSend(IntPtr receiver, IntPtr selector, MTLSize a);
 
         [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial ulong ulong_objc_msgSend(IntPtr receiver, IntPtr selector, ulong a);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
         public static partial ulong ulong_objc_msgSend(IntPtr receiver, IntPtr selector, MTLSamplePosition a, ulong b);
 
         [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial ulong ulong_objc_msgSend(IntPtr receiver, IntPtr selector, long a);
+        public static partial ulong ulong_objc_msgSend(IntPtr receiver, IntPtr selector, NSFastEnumerationState a, IntPtr b, ulong c);
 
         [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
         public static partial ushort ushort_objc_msgSend(IntPtr receiver, IntPtr selector);
@@ -252,252 +252,252 @@ namespace SharpMetal
         public static partial ushort ushort_objc_msgSend(IntPtr receiver, IntPtr selector, ulong a);
 
         [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, ulong c, IntPtr d, ulong e);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, float b, float c, NSRange d);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, MTLClearColor a);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, IntPtr b, ulong c, ulong d);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, IntPtr b, IntPtr c, IntPtr d, ulong e, ulong f);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, uint a, uint b);
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector);
 
         [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
         public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, [MarshalAs(UnmanagedType.Bool)] bool a);
 
         [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, IntPtr b, IntPtr c, ulong d);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, MTLRegion a);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, uint a);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
         public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, double a);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, ulong c, MTLSize d, ulong e, ulong f, MTLOrigin g, IntPtr h, ulong i);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, IntPtr b, IntPtr c, IntPtr d, ulong e);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, float a, float b, float c, float d);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, MTLSize a, MTLSize b, MTLSize c);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, MTLSize a, MTLSize b);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, MTLRegion c, ulong d, ulong e, ulong f);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, MTLRegion c, ulong d, ulong e);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, IntPtr c, ulong d);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, ulong c, MTLOrigin d, MTLSize e, IntPtr f, ulong g, ulong h, MTLOrigin i);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, ulong c);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, ulong c, ulong d);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b, ulong c, IntPtr d, ulong e, ulong f, ulong g, IntPtr h, ulong i, ulong j);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, MTLViewport a, ulong b);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b, ulong c, IntPtr d, ulong e, IntPtr f, ulong g, ulong h, ulong i, IntPtr j, ulong k, ulong l);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b, ulong c, ulong d, ulong e);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, MTLVertexAmplificationViewMapping b);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, IntPtr b, IntPtr c);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, float a, float b, float c);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b, ulong c, IntPtr d, ulong e, ulong f, long g, ulong h);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, MTLScissorRect a);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, MTLScissorRect a, ulong b);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, NSRange a);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, MTLSize c);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, ulong c, IntPtr d, ulong e, ulong f, ulong g, ulong h);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b, ulong c, ulong d);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, NSRange b, byte c);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, IntPtr b, NSRange c);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, MTLSize a);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, ulong c, NSRange d);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, IntPtr b, ulong c);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, [MarshalAs(UnmanagedType.Bool)] bool c);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, ulong c, ulong d, MTLSize e, IntPtr f, ulong g, ulong h, MTLOrigin i);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b, ulong c);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, NSRange b);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, IntPtr c);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, float b, float c, ulong d);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, ulong c, MTLOrigin d, MTLSize e, IntPtr f, ulong g, ulong h, ulong i);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, ulong c, MTLOrigin d, MTLSize e, IntPtr f, ulong g, ulong h, ulong i, ulong j);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, long a);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, NSRange b, IntPtr c, ulong d);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, MTLRegion b, ulong c, ulong d);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, MTLRegion b, ulong c, ulong d, [MarshalAs(UnmanagedType.Bool)] bool e, IntPtr f, ulong g);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, IntPtr c, ulong d, ulong e);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, IntPtr b);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, ulong c, ulong d, MTLSize e, IntPtr f, ulong g, ulong h, MTLOrigin i, ulong j);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, NSRange c);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, MTLTextureSwizzleChannels a);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, ulong c, MTLRegion d, ulong e, ulong f);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b, ulong c, IntPtr d, ulong e, ulong f);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, MTLRegion a, MTLRegion b, MTLSize c, ulong d);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, MTLRegion a, MTLRegion b, MTLSize c, ulong d, ulong e);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b, ulong c, IntPtr d, ulong e);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, ulong a);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, MTLSamplePosition a, ulong b);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, IntPtr b, ulong c);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b, IntPtr c, ulong d, IntPtr e, ulong f);
 
         [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
         public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, float a);
 
         [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b, ulong c, IntPtr d, ulong e, ulong f, ulong g);
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a);
 
         [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, IntPtr b, ulong c, IntPtr d, ulong e);
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, long a);
 
         [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b, ulong c, IntPtr d, ulong e, IntPtr f, ulong g, ulong h, ulong i);
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, MTLClearColor a);
 
         [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, IntPtr b, IntPtr c, NSRange d);
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, MTLRegion a);
 
         [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, NSRange b);
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, MTLScissorRect a);
 
         [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, IntPtr b, ulong c, IntPtr d, ulong e, IntPtr f, ulong g);
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, MTLSize a);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, MTLTextureSwizzleChannels a);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, MTLViewport a);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, NSRange a);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, uint a);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, ulong a);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, IntPtr b);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, NSRange b);
 
         [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
         public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b);
 
         [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, MTLRegion a, ulong b, IntPtr c, ulong d);
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, MTLSamplePosition a, ulong b);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, MTLScissorRect a, ulong b);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, MTLSize a, MTLSize b);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, MTLViewport a, ulong b);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, uint a, uint b);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, MTLVertexAmplificationViewMapping b);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, NSRange b);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, float a, float b, float c);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, IntPtr b, NSRange c);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, IntPtr b, ulong c);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, NSRange b, byte c);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, [MarshalAs(UnmanagedType.Bool)] bool c);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, IntPtr c);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, MTLSize c);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, NSRange c);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, ulong c);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, MTLSize a, MTLSize b, MTLSize c);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, IntPtr b, IntPtr c);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, IntPtr b, ulong c);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b, ulong c);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, float a, float b, float c, float d);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, float b, float c, NSRange d);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, float b, float c, ulong d);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, IntPtr b, IntPtr c, NSRange d);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, IntPtr b, IntPtr c, ulong d);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, IntPtr b, ulong c, ulong d);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, MTLRegion b, ulong c, ulong d);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, NSRange b, IntPtr c, ulong d);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, IntPtr c, ulong d);
 
         [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
         public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, MTLRegion c, ulong d);
 
         [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, MTLRegion a, ulong b, ulong c, IntPtr d, ulong e, ulong f);
-
-        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
         public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, MTLSize c, MTLSize d);
 
         [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
-        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, MTLViewport a);
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, ulong c, NSRange d);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, ulong c, ulong d);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, MTLRegion a, MTLRegion b, MTLSize c, ulong d);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, MTLRegion a, ulong b, IntPtr c, ulong d);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b, ulong c, ulong d);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, IntPtr b, IntPtr c, IntPtr d, ulong e);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, IntPtr c, ulong d, ulong e);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, MTLRegion c, ulong d, ulong e);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, ulong c, IntPtr d, ulong e);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, MTLRegion a, MTLRegion b, MTLSize c, ulong d, ulong e);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, IntPtr b, ulong c, IntPtr d, ulong e);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b, ulong c, IntPtr d, ulong e);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b, ulong c, ulong d, ulong e);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, IntPtr b, IntPtr c, IntPtr d, ulong e, ulong f);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, MTLRegion c, ulong d, ulong e, ulong f);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, ulong c, MTLRegion d, ulong e, ulong f);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, MTLRegion a, ulong b, ulong c, IntPtr d, ulong e, ulong f);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b, IntPtr c, ulong d, IntPtr e, ulong f);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b, ulong c, IntPtr d, ulong e, ulong f);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, MTLRegion b, ulong c, ulong d, [MarshalAs(UnmanagedType.Bool)] bool e, IntPtr f, ulong g);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, IntPtr b, ulong c, IntPtr d, ulong e, IntPtr f, ulong g);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b, ulong c, IntPtr d, ulong e, ulong f, ulong g);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, ulong c, IntPtr d, ulong e, ulong f, ulong g, ulong h);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b, ulong c, IntPtr d, ulong e, ulong f, long g, ulong h);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, ulong c, MTLOrigin d, MTLSize e, IntPtr f, ulong g, ulong h, MTLOrigin i);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, ulong c, MTLOrigin d, MTLSize e, IntPtr f, ulong g, ulong h, ulong i);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, ulong c, MTLSize d, ulong e, ulong f, MTLOrigin g, IntPtr h, ulong i);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, ulong c, ulong d, MTLSize e, IntPtr f, ulong g, ulong h, MTLOrigin i);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b, ulong c, IntPtr d, ulong e, IntPtr f, ulong g, ulong h, ulong i);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, ulong c, MTLOrigin d, MTLSize e, IntPtr f, ulong g, ulong h, ulong i, ulong j);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr a, ulong b, ulong c, ulong d, MTLSize e, IntPtr f, ulong g, ulong h, MTLOrigin i, ulong j);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b, ulong c, IntPtr d, ulong e, ulong f, ulong g, IntPtr h, ulong i, ulong j);
+
+        [LibraryImport(ObjectiveC.ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, IntPtr selector, ulong a, ulong b, ulong c, IntPtr d, ulong e, IntPtr f, ulong g, ulong h, ulong i, IntPtr j, ulong k, ulong l);
     }
 }

--- a/src/SharpMetal/QuartzCore/CAMetalDrawable.cs
+++ b/src/SharpMetal/QuartzCore/CAMetalDrawable.cs
@@ -17,22 +17,17 @@ namespace SharpMetal.QuartzCore
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_release);
         }
 
-        public CAMetalLayer Layer => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_layer));
+        public ulong DrawableID => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_drawableID);
 
-        public MTLTexture Texture => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_texture));
+        public CAMetalLayer Layer => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_layer));
 
         public IntPtr PresentedTime => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_presentedTime));
 
-        public ulong DrawableID => ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_drawableID);
+        public MTLTexture Texture => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_texture));
 
         public void Present()
         {
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_present);
-        }
-
-        public void PresentAtTime(IntPtr presentationTime)
-        {
-            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_presentAtTime, presentationTime);
         }
 
         public void PresentAfterMinimumDuration(IntPtr duration)
@@ -40,13 +35,18 @@ namespace SharpMetal.QuartzCore
             ObjectiveCRuntime.objc_msgSend(NativePtr, sel_presentAfterMinimumDuration, duration);
         }
 
-        private static readonly Selector sel_layer = "layer";
-        private static readonly Selector sel_texture = "texture";
-        private static readonly Selector sel_present = "present";
-        private static readonly Selector sel_presentAtTime = "presentAtTime:";
-        private static readonly Selector sel_presentAfterMinimumDuration = "presentAfterMinimumDuration:";
-        private static readonly Selector sel_presentedTime = "presentedTime";
+        public void PresentAtTime(IntPtr presentationTime)
+        {
+            ObjectiveCRuntime.objc_msgSend(NativePtr, sel_presentAtTime, presentationTime);
+        }
+
         private static readonly Selector sel_drawableID = "drawableID";
+        private static readonly Selector sel_layer = "layer";
+        private static readonly Selector sel_present = "present";
+        private static readonly Selector sel_presentAfterMinimumDuration = "presentAfterMinimumDuration:";
+        private static readonly Selector sel_presentAtTime = "presentAtTime:";
+        private static readonly Selector sel_presentedTime = "presentedTime";
+        private static readonly Selector sel_texture = "texture";
         private static readonly Selector sel_release = "release";
     }
 }

--- a/src/SharpMetal/QuartzCore/CAMetalLayer.cs
+++ b/src/SharpMetal/QuartzCore/CAMetalLayer.cs
@@ -22,28 +22,10 @@ namespace SharpMetal.QuartzCore
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDevice, value);
         }
 
-        public MTLPixelFormat PixelFormat
-        {
-            get => (MTLPixelFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_pixelFormat);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPixelFormat, (ulong)value);
-        }
-
         public IntPtr Colorspace
         {
             get => ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_colorspace);
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setColorspace, value);
-        }
-
-        public bool FramebufferOnly
-        {
-            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_framebufferOnly);
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFramebufferOnly, value);
-        }
-
-        public IntPtr DrawableSize
-        {
-            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_drawableSize));
-            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDrawableSize, value);
         }
 
         public bool DisplaySyncEnabled
@@ -52,19 +34,37 @@ namespace SharpMetal.QuartzCore
             set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDisplaySyncEnabled, value);
         }
 
-        private static readonly Selector sel_layer = "layer";
-        private static readonly Selector sel_device = "device";
-        private static readonly Selector sel_setDevice = "setDevice:";
-        private static readonly Selector sel_pixelFormat = "pixelFormat";
-        private static readonly Selector sel_setPixelFormat = "setPixelFormat:";
+        public IntPtr DrawableSize
+        {
+            get => new(ObjectiveCRuntime.IntPtr_objc_msgSend(NativePtr, sel_drawableSize));
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setDrawableSize, value);
+        }
+
+        public bool FramebufferOnly
+        {
+            get => ObjectiveCRuntime.bool_objc_msgSend(NativePtr, sel_framebufferOnly);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setFramebufferOnly, value);
+        }
+
+        public MTLPixelFormat PixelFormat
+        {
+            get => (MTLPixelFormat)ObjectiveCRuntime.ulong_objc_msgSend(NativePtr, sel_pixelFormat);
+            set => ObjectiveCRuntime.objc_msgSend(NativePtr, sel_setPixelFormat, (ulong)value);
+        }
+
         private static readonly Selector sel_colorspace = "colorspace";
-        private static readonly Selector sel_setColorspace = "setColorspace:";
-        private static readonly Selector sel_framebufferOnly = "framebufferOnly";
-        private static readonly Selector sel_setFramebufferOnly = "setFramebufferOnly:";
-        private static readonly Selector sel_drawableSize = "drawableSize";
-        private static readonly Selector sel_setDrawableSize = "setDrawableSize:";
+        private static readonly Selector sel_device = "device";
         private static readonly Selector sel_displaySyncEnabled = "displaySyncEnabled";
+        private static readonly Selector sel_drawableSize = "drawableSize";
+        private static readonly Selector sel_framebufferOnly = "framebufferOnly";
+        private static readonly Selector sel_layer = "layer";
+        private static readonly Selector sel_pixelFormat = "pixelFormat";
+        private static readonly Selector sel_setColorspace = "setColorspace:";
+        private static readonly Selector sel_setDevice = "setDevice:";
         private static readonly Selector sel_setDisplaySyncEnabled = "setDisplaySyncEnabled:";
+        private static readonly Selector sel_setDrawableSize = "setDrawableSize:";
+        private static readonly Selector sel_setFramebufferOnly = "setFramebufferOnly:";
+        private static readonly Selector sel_setPixelFormat = "setPixelFormat:";
         private static readonly Selector sel_release = "release";
     }
 }


### PR DESCRIPTION
Hello,

this is a small change (but large commit as a result) that basically adds stable ordering for the generated code, no matter if the order in the reference .cpp changes.

You can take it as commit 1 out of 3 to get to the bindings for Metal 4. Without this, updating to the newer API is basically impossible, since the diffs get messy really quickly.

Before PRing the Metal 4, the second step is moving the manual additions to partial files, to reduce the needed amount of manual touch ups of the generated code. Currently working on that one, will send it if this one gets merged.

Tested all three examples and they seem to work fine.

The general process was:
1/ Generate bindings on the current version of generator, create a patch to see the manual touch-ups that had to be done
2/ Change the generator
3/ Manually apply the touch-ups
4/ Test the examples