### PR TITLE
Added more primitive types calls to ObjectiveC class

### DIFF
--- a/src/SharpMetal/ObjectiveCCore/ObjectiveC.cs
+++ b/src/SharpMetal/ObjectiveCCore/ObjectiveC.cs
@@ -96,7 +96,34 @@ namespace SharpMetal.ObjectiveCCore
         public static partial bool bool_objc_msgSend(IntPtr receiver, Selector selector);
 
         [LibraryImport(ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial byte byte_objc_msgSend(IntPtr receiver, Selector selector);
+
+        [LibraryImport(ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial sbyte sbyte_objc_msgSend(IntPtr receiver, Selector selector);
+
+        [LibraryImport(ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial short short_objc_msgSend(IntPtr receiver, Selector selector);
+
+        [LibraryImport(ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial ushort ushort_objc_msgSend(IntPtr receiver, Selector selector);
+
+        [LibraryImport(ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial int int_objc_msgSend(IntPtr receiver, Selector selector);
+
+        [LibraryImport(ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial uint uint_objc_msgSend(IntPtr receiver, Selector selector);
+
+        [LibraryImport(ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial long long_objc_msgSend(IntPtr receiver, Selector selector);
+
+        [LibraryImport(ObjCRuntime, EntryPoint = "objc_msgSend")]
         public static partial ulong ulong_objc_msgSend(IntPtr receiver, Selector selector);
+
+        [LibraryImport(ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial float float_objc_msgSend(IntPtr receiver, Selector selector);
+
+        [LibraryImport(ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial double double_objc_msgSend(IntPtr receiver, Selector selector);
 
         public static IntPtr LinkMetal()
         {


### PR DESCRIPTION
Basically ever since the `ObjectiveCRuntime` became internal, a lot of the calls are now inacessible to the apps using `SharpMetal`.

Especially true for stuff like trying to get a `NSEvent.KeyCode`, or `MTKView.ClearColor`.

I guess at least exposing these primitives to be implement simple getters could be a part of the SharpMetal library.

If there is a better way to do this, even on the app's side, I am all ears.